### PR TITLE
Sync the host and exam-desktop clipboards in both directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,14 @@ for the full command and configuration reference.
 
 Anything you copy reaches the exam desktop automatically — highlight text
 in a question and press ⌘C, or copy from any other app and come back to
-the tab. Paste in the exam terminal with Ctrl+V, ⌘V, the terminal's own
-Ctrl+Shift+V, or right-click → Paste. Copying in the terminal works the
-same way in reverse, but only in Chrome: Firefox requires a user gesture
-for clipboard access in both directions, so it can neither read what you
-copied elsewhere nor write what the terminal sent without one — the
-Clipboard panel is a real click and covers both cases. Press `?` for the
-full shortcut list.
+the tab. The in-page copy needs no clipboard permission anywhere,
+Firefox included, since it reads the live selection rather than the
+clipboard API. Paste in the exam terminal with Ctrl+V, ⌘V, the
+terminal's own Ctrl+Shift+V, or right-click → Paste. Copying in the
+terminal works the same way in reverse, but only in Chrome: reading the
+host clipboard automatically and writing the terminal's copy back to it
+both need a gesture Firefox won't grant — the Clipboard panel is a real
+click and covers both. Press `?` for the full shortcut list.
 
 What reaches the desktop is reduced to ASCII, so an em dash arrives as a
 hyphen and curly quotes arrive straight. The clipboard channel drops any

--- a/README.md
+++ b/README.md
@@ -58,11 +58,17 @@ for the full command and configuration reference.
 4. **Score** — percent, pass/fail, expandable per-question checks, full
    solutions, and a New attempt button.
 
-Click any value in a question to copy it, then paste in the exam
-terminal with Ctrl+Shift+V — or ⌘V on a Mac, which the page translates
-along with ⌘C, ⌘K and the line-motion chords. Press `?` for the full
-list. Anything else in your clipboard reaches the desktop through the
-Clipboard panel.
+Anything you copy reaches the exam desktop automatically — highlight text
+in a question and press ⌘C, or copy from any other app and come back to
+the tab. Paste in the exam terminal with Ctrl+V, ⌘V, the terminal's own
+Ctrl+Shift+V, or right-click → Paste. Copying in the terminal works the
+same way in reverse. Press `?` for the full shortcut list. Firefox mirrors
+in-page copies the same way; it just can't read what you copied in
+another app, so the Clipboard panel covers that case.
+
+What reaches the desktop is reduced to ASCII, so an em dash arrives as a
+hyphen and curly quotes arrive straight. The clipboard channel drops any
+non-ASCII character outright, and a hyphen beats losing the paste.
 
 `down` then `up` resumes your exam state, including an in-progress
 session. Light and dark themes follow your system. The exam needs a

--- a/README.md
+++ b/README.md
@@ -62,9 +62,11 @@ Anything you copy reaches the exam desktop automatically — highlight text
 in a question and press ⌘C, or copy from any other app and come back to
 the tab. Paste in the exam terminal with Ctrl+V, ⌘V, the terminal's own
 Ctrl+Shift+V, or right-click → Paste. Copying in the terminal works the
-same way in reverse. Press `?` for the full shortcut list. Firefox mirrors
-in-page copies the same way; it just can't read what you copied in
-another app, so the Clipboard panel covers that case.
+same way in reverse, but only in Chrome: Firefox requires a user gesture
+for clipboard access in both directions, so it can neither read what you
+copied elsewhere nor write what the terminal sent without one — the
+Clipboard panel is a real click and covers both cases. Press `?` for the
+full shortcut list.
 
 What reaches the desktop is reduced to ASCII, so an em dash arrives as a
 hyphen and curly quotes arrive straight. The clipboard channel drops any

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -16,6 +16,11 @@ The series is incomplete: plans exist for milestones A, B, C and F, and
 specs for A, B, C, D, F and G. The rest were never written down in this
 form.
 
+Not everything here is a milestone. `specs/2026-07-28-clipboard-sync-design.md`
+records a single piece of work — host↔desktop clipboard sync — and is
+kept here because it is the same kind of artifact, frozen the moment it
+shipped.
+
 For anything current, use:
 
 | You want | Read |

--- a/docs/history/plans/2026-07-28-clipboard-sync.md
+++ b/docs/history/plans/2026-07-28-clipboard-sync.md
@@ -1,0 +1,809 @@
+# Clipboard Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Mirror the host clipboard and the exam desktop's clipboard in both directions automatically, so anything highlighted and copied can be pasted in the remote desktop with ⌘V/Ctrl+V, Ctrl+Shift+V, or right-click → Paste.
+
+**Architecture:** One new module singleton, `ui/src/lib/clipboardSync.ts`, owns the window-level `copy`/`cut`/`focus`/`visibilitychange` listeners and delegates transport to the existing `desktopClipboard`. A single `lastSynced` string prevents the two directions from ping-ponging. Separately, `desktopKeymap`'s shifted chords are corrected to send uppercase X11 keysyms.
+
+**Tech Stack:** TypeScript, React 18, Vitest 2, jsdom, @novnc/novnc 1.7.
+
+Spec: [`../specs/2026-07-28-clipboard-sync-design.md`](../specs/2026-07-28-clipboard-sync-design.md)
+
+## Global Constraints
+
+- Work in `ui/`. All commands below run from `ui/` unless stated otherwise.
+- Full gate before pushing: `npx tsc --noEmit && npm run lint && npm test`.
+- **vitest is pinned to v2** for compatibility with vite 5. Do not bump it.
+- `npm run lint` has one pre-existing warning (a deliberate mount-only effect). One warning is the expected baseline; do not "fix" it.
+- Do not deep-import `@novnc/novnc` subpaths. Its `exports` field is the single string `./core/rfb.js`, so every subpath is unresolvable and fails at build time. X11 keysyms stay in the local `XK` table.
+- Follow the existing module-singleton shape (`desktopClipboard`, `desktopKeymap`, `desktopResize`): a class with a `reset()` for tests, exported as a lowercase const instance.
+- Every commit message ends with these two trailers, separated from the subject by a blank line:
+
+```
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01P6kgExw1VAyDeovNuvb1KL
+```
+
+---
+
+### Task 1: Correct the shifted chord keysyms
+
+The bug that started this: `sendPasteChord()` sends keysym `0x0076` (lowercase `v`) while holding `Shift_L`. Holding Shift while naming an unshifted keysym is an inconsistent pair; xfce4-terminal's Ctrl+Shift+V accelerator does not match it and the terminal forwards a plain Ctrl+V to the application, which renders as `^` in vim. Every chord with `shift: true` shares the defect.
+
+**Files:**
+- Modify: `ui/src/lib/desktopKeymap.ts:35-49` (the `XK` table), `:74-75`, `:98-99`, `:275`
+- Test: `ui/src/lib/desktopKeymap.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: no signature changes. `desktopKeymap.sendPasteChord(): void` and `desktopKeymap.attach(target: KeyTarget): void` keep their current shapes.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside the existing top-level `describe("desktopKeymap", ...)` block in `ui/src/lib/desktopKeymap.test.ts`:
+
+```ts
+  test("a shifted chord sends the uppercase keysym", () => {
+    // X11 derives the character from keycode + modifier state. Naming the
+    // lowercase keysym while holding Shift is inconsistent, and GTK's
+    // Ctrl+Shift+V accelerator does not match it — the terminal then
+    // forwards a bare Ctrl+V, which is readline's verbatim-insert prefix.
+    const { target, sent } = fakeTarget();
+    desktopKeymap.attach(target);
+
+    desktopKeymap.sendPasteChord();
+
+    expect(sent).toContainEqual([0x0056, "KeyV", true]);
+    expect(sent).not.toContainEqual([0x0076, "KeyV", true]);
+  });
+
+  test("every shifted chord in the map uses an uppercase keysym", () => {
+    const { target, sent } = fakeTarget();
+    desktopKeymap.setReservedEnabled(true);
+    desktopKeymap.attach(target);
+
+    // ⌘C -> Ctrl+Shift+C, ⌘T -> Ctrl+Shift+T, ⌘W -> Ctrl+Shift+W.
+    for (const key of ["c", "t", "w"]) {
+      desktopKeymap.handleKeyDown(keydown(key, { metaKey: true }));
+    }
+
+    // Down-only: send() taps each key down then up, so every keysym
+    // appears twice.
+    const letters = sent.filter(([ks, , down]) => down && ks >= 0x0041 && ks <= 0x007a);
+    expect(letters.map(([ks]) => ks)).toEqual([0x0043, 0x0054, 0x0057]);
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/desktopKeymap.test.ts -t "uppercase keysym"`
+
+Expected: FAIL. The first test reports the array contains `[118, "KeyV", true]` (`0x0076`) and not `[86, ...]`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `ui/src/lib/desktopKeymap.ts`, add the four uppercase entries to the `XK` table. Keep the existing lowercase entries — `meta+k` maps to Ctrl+L and `alt+arrow*` to Alt+B/Alt+F, none of which hold Shift:
+
+```ts
+const XK = {
+  Control_L: 0xffe3,
+  Shift_L: 0xffe1,
+  Alt_L: 0xffe9,
+  Home: 0xff50,
+  End: 0xff57,
+  b: 0x0062,
+  c: 0x0063,
+  f: 0x0066,
+  l: 0x006c,
+  t: 0x0074,
+  u: 0x0075,
+  v: 0x0076,
+  w: 0x0077,
+  // Shifted forms. A chord that holds Shift must name the shifted keysym:
+  // X11 derives the character from keycode + modifier state, so Shift plus
+  // a lowercase keysym is an inconsistent pair that GTK accelerators
+  // (Ctrl+Shift+V and friends) will not match.
+  C: 0x0043,
+  T: 0x0054,
+  V: 0x0056,
+  W: 0x0057,
+} as const;
+```
+
+Then point every `shift: true` chord at the shifted keysym. Line 74-75:
+
+```ts
+  "meta+c": { keysym: XK.C, code: "KeyC", ctrl: true, shift: true, describes: "Copy" },
+  "meta+v": { keysym: XK.V, code: "KeyV", ctrl: true, shift: true, describes: "Paste" },
+```
+
+Line 98-99:
+
+```ts
+  "meta+t": { keysym: XK.T, code: "KeyT", ctrl: true, shift: true, describes: "New terminal tab" },
+  "meta+w": { keysym: XK.W, code: "KeyW", ctrl: true, shift: true, describes: "Close terminal tab" },
+```
+
+And `sendPasteChord` at line 275:
+
+```ts
+  sendPasteChord(): void {
+    this.send({ keysym: XK.V, code: "KeyV", ctrl: true, shift: true, describes: "Paste" });
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/lib/desktopKeymap.test.ts`
+
+Expected: PASS, including the pre-existing tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/desktopKeymap.ts src/lib/desktopKeymap.test.ts
+git commit -m "fix: shifted chords must name the shifted keysym"
+```
+
+---
+
+### Task 2: clipboardSync module — push the page selection to the desktop
+
+The permission-free half. A `copy` or `cut` raised inside the page carries a live DOM selection, so the text can be read directly with no clipboard API and no prompt. This is what makes highlighting question 1 and pressing ⌘C work in every browser.
+
+**Files:**
+- Create: `ui/src/lib/clipboardSync.ts`
+- Test: `ui/src/lib/clipboardSync.test.ts`
+
+**Interfaces:**
+- Consumes: `desktopClipboard.sendToDesktop(text: string): boolean` and `desktopClipboard.connect(target: ClipboardTarget): void` from `./desktopClipboard`.
+- Produces: `clipboardSync`, a singleton with `start(): void`, `stop(): void`, `reset(): void`, and `syncFromSelection(): boolean`. Later tasks add `syncFromHost()` and `syncToHost()` to the same class.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ui/src/lib/clipboardSync.test.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { clipboardSync } from "./clipboardSync";
+import { desktopClipboard, type ClipboardTarget } from "./desktopClipboard";
+
+function fakeTarget(): ClipboardTarget & { pasted: string[] } {
+  const pasted: string[] = [];
+  return { pasted, clipboardPasteFrom: (text: string) => void pasted.push(text) };
+}
+
+function stubSelection(text: string) {
+  Object.defineProperty(window, "getSelection", {
+    value: () => ({ toString: () => text }),
+    configurable: true,
+  });
+}
+
+beforeEach(() => {
+  clipboardSync.reset();
+  stubSelection("");
+});
+
+afterEach(() => {
+  clipboardSync.stop();
+  clipboardSync.reset();
+  desktopClipboard.reset();
+});
+
+describe("clipboardSync selection push", () => {
+  test("a copy inside the page reaches the desktop", () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    clipboardSync.start();
+    stubSelection("Team Aurora owns every Namespace");
+
+    window.dispatchEvent(new Event("copy"));
+
+    expect(target.pasted).toEqual(["Team Aurora owns every Namespace"]);
+  });
+
+  test("a cut is treated the same as a copy", () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    clipboardSync.start();
+    stubSelection("staging-quota");
+
+    window.dispatchEvent(new Event("cut"));
+
+    expect(target.pasted).toEqual(["staging-quota"]);
+  });
+
+  test("an empty selection pushes nothing", () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    clipboardSync.start();
+
+    window.dispatchEvent(new Event("copy"));
+
+    expect(target.pasted).toEqual([]);
+  });
+
+  test("the same value is not pushed twice", () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    clipboardSync.start();
+    stubSelection("aurora-staging");
+
+    window.dispatchEvent(new Event("copy"));
+    window.dispatchEvent(new Event("copy"));
+
+    expect(target.pasted).toEqual(["aurora-staging"]);
+  });
+
+  test("stop removes the listeners", () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    clipboardSync.start();
+    clipboardSync.stop();
+    stubSelection("team=aurora");
+
+    window.dispatchEvent(new Event("copy"));
+
+    expect(target.pasted).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/clipboardSync.test.ts`
+
+Expected: FAIL — `Failed to resolve import "./clipboardSync"`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `ui/src/lib/clipboardSync.ts`:
+
+```ts
+// Keeps the host clipboard and the exam desktop's clipboard in step.
+//
+// Before this existed, the desktop's clipboard was written only by an
+// explicit click on a copy control in the question panel. A candidate who
+// highlighted prose and pressed ⌘C — or copied a manifest out of an
+// editor — had no way to get it across: the value reached the host
+// clipboard and stopped there.
+//
+// Two triggers, deliberately different in what they cost. A copy raised
+// inside the page carries a live DOM selection, so it needs no clipboard
+// permission in any browser. Reading what another application put on the
+// host clipboard needs navigator.clipboard.readText, which Firefox does
+// not expose to web content at all — that half degrades to the Clipboard
+// panel rather than failing loudly.
+//
+// Module-singleton shape, following desktopClipboard and desktopKeymap:
+// the Exam screen starts it, and nothing else needs to know it exists.
+
+import { desktopClipboard } from "./desktopClipboard";
+
+/**
+ * Longest value worth mirroring.
+ *
+ * Xvnc is started with -MaxCutText 2097152, so this is far below what the
+ * transport accepts. The limit exists to stop a candidate who selected an
+ * entire scrollback from pushing megabytes across the socket on every
+ * keystroke of a chord.
+ */
+const MAX_SYNC_CHARS = 100_000;
+
+class ClipboardSync {
+  /**
+   * The last value moved in either direction.
+   *
+   * The whole reason both directions can be automatic. Without it the two
+   * ping-pong: the page writes X to the host, the next focus reads X back,
+   * and pushes it to the desktop again. A value that arrived from one side
+   * is never sent back to it.
+   */
+  private lastSynced = "";
+  private stopFns: Array<() => void> = [];
+
+  start(): void {
+    if (this.stopFns.length) return; // idempotent: effects can run twice
+    const onCopy = () => void this.syncFromSelection();
+    window.addEventListener("copy", onCopy);
+    window.addEventListener("cut", onCopy);
+    this.stopFns.push(() => {
+      window.removeEventListener("copy", onCopy);
+      window.removeEventListener("cut", onCopy);
+    });
+  }
+
+  stop(): void {
+    for (const fn of this.stopFns) fn();
+    this.stopFns = [];
+  }
+
+  /**
+   * Pushes the current DOM selection to the desktop.
+   *
+   * Returns whether anything was sent, which is what the tests assert on.
+   */
+  syncFromSelection(): boolean {
+    return this.pushToDesktop(window.getSelection()?.toString() ?? "");
+  }
+
+  /** Sends to the desktop unless it is empty, oversized, or already there. */
+  private pushToDesktop(text: string): boolean {
+    if (!text || text === this.lastSynced) return false;
+    if (text.length > MAX_SYNC_CHARS) return false;
+    if (!desktopClipboard.sendToDesktop(text)) return false;
+    this.lastSynced = text;
+    return true;
+  }
+
+  /** Test-only, mirroring desktopKeymap.reset. */
+  reset(): void {
+    this.stop();
+    this.lastSynced = "";
+  }
+}
+
+export const clipboardSync = new ClipboardSync();
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/clipboardSync.test.ts`
+
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/clipboardSync.ts src/lib/clipboardSync.test.ts
+git commit -m "feat: mirror the page selection into the desktop clipboard"
+```
+
+---
+
+### Task 3: Read the host clipboard on focus
+
+Covers text copied in another application. `readText()` needs the `clipboard-read` permission and a focused document; when it is refused this is a silent no-op, because it runs on every tab focus and a toast there would be noise rather than information.
+
+**Files:**
+- Modify: `ui/src/lib/clipboardSync.ts`
+- Test: `ui/src/lib/clipboardSync.test.ts`
+
+**Interfaces:**
+- Consumes: `clipboardSync.start()`, `clipboardSync.reset()` and the private `pushToDesktop` from Task 2.
+- Produces: `clipboardSync.syncFromHost(): Promise<boolean>` — resolves true when a value was pushed to the desktop.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `ui/src/lib/clipboardSync.test.ts`. Also add `vi` to the existing vitest import at the top of the file:
+
+```ts
+function stubClipboard(clipboard: Partial<Clipboard>) {
+  Object.defineProperty(navigator, "clipboard", {
+    value: clipboard,
+    configurable: true,
+  });
+}
+
+describe("clipboardSync host read", () => {
+  test("focus pushes what another app put on the host clipboard", async () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    stubClipboard({ readText: vi.fn(async () => "kubectl get pods -A") });
+
+    expect(await clipboardSync.syncFromHost()).toBe(true);
+    expect(target.pasted).toEqual(["kubectl get pods -A"]);
+  });
+
+  test("an unchanged host clipboard is not pushed again", async () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    stubClipboard({ readText: vi.fn(async () => "aurora-staging") });
+
+    await clipboardSync.syncFromHost();
+    await clipboardSync.syncFromHost();
+
+    expect(target.pasted).toEqual(["aurora-staging"]);
+  });
+
+  test("a refused read is silent", async () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    stubClipboard({ readText: vi.fn(async () => Promise.reject(new Error("denied"))) });
+
+    expect(await clipboardSync.syncFromHost()).toBe(false);
+    expect(target.pasted).toEqual([]);
+  });
+
+  test("a browser with no readText at all is silent", async () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    stubClipboard({}); // Firefox: no readText for web content
+
+    expect(await clipboardSync.syncFromHost()).toBe(false);
+    expect(target.pasted).toEqual([]);
+  });
+
+  test("start wires focus to a host read", async () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    stubClipboard({ readText: vi.fn(async () => "5 Pods") });
+    clipboardSync.start();
+
+    window.dispatchEvent(new Event("focus"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(target.pasted).toEqual(["5 Pods"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/clipboardSync.test.ts -t "host read"`
+
+Expected: FAIL — `clipboardSync.syncFromHost is not a function`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `ui/src/lib/clipboardSync.ts`, add the method to the class:
+
+```ts
+  /**
+   * Reads the host clipboard and pushes it to the desktop.
+   *
+   * Silent on refusal by design: Firefox has no readText for web content,
+   * and Chrome needs a granted permission. This runs on every tab focus,
+   * so a warning here would fire constantly for a large share of users.
+   * The Clipboard panel is the path that always works, and its copy
+   * already says so.
+   */
+  async syncFromHost(): Promise<boolean> {
+    let text: string;
+    try {
+      text = await navigator.clipboard.readText();
+    } catch {
+      return false;
+    }
+    return this.pushToDesktop(text);
+  }
+```
+
+Then extend `start()` to wire focus. Replace the body with:
+
+```ts
+  start(): void {
+    if (this.stopFns.length) return; // idempotent: effects can run twice
+    const onCopy = () => void this.syncFromSelection();
+    window.addEventListener("copy", onCopy);
+    window.addEventListener("cut", onCopy);
+    this.stopFns.push(() => {
+      window.removeEventListener("copy", onCopy);
+      window.removeEventListener("cut", onCopy);
+    });
+
+    // Returning to the tab is the moment a candidate has just copied
+    // something elsewhere. visibilitychange covers tab switches;
+    // focus covers switching between windows of the same tab.
+    const onFocus = () => {
+      if (document.visibilityState === "hidden") return;
+      void this.syncFromHost();
+    };
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onFocus);
+    this.stopFns.push(() => {
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onFocus);
+    });
+
+    void this.syncFromHost();
+  }
+```
+
+Note `navigator.clipboard` may be `undefined` in an insecure context; the property access throws a `TypeError`, which the same `catch` absorbs.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/clipboardSync.test.ts`
+
+Expected: PASS, 10 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/clipboardSync.ts src/lib/clipboardSync.test.ts
+git commit -m "feat: mirror the host clipboard to the desktop on focus"
+```
+
+---
+
+### Task 4: Write the desktop's clipboard back to the host
+
+The reverse direction. `desktopClipboard.receive()` already fires on every remote clipboard change and currently only parks the text for the panel. Chrome grants `clipboard-write` to the focused tab, so this needs no gesture; Firefox refuses and the panel's button remains.
+
+**Files:**
+- Modify: `ui/src/lib/clipboardSync.ts`
+- Test: `ui/src/lib/clipboardSync.test.ts`
+
+**Interfaces:**
+- Consumes: `desktopClipboard.subscribe(listener: () => void): () => void`, `desktopClipboard.getRemote(): string`, `desktopClipboard.receive(text: string): void`.
+- Produces: `clipboardSync.syncToHost(): Promise<boolean>` — resolves true when the host clipboard was written.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `ui/src/lib/clipboardSync.test.ts`:
+
+```ts
+describe("clipboardSync host write", () => {
+  test("what the desktop copied reaches the host clipboard", async () => {
+    const writeText = vi.fn(async () => {});
+    stubClipboard({ writeText });
+    desktopClipboard.receive("candidate@instance-1");
+
+    expect(await clipboardSync.syncToHost()).toBe(true);
+    expect(writeText).toHaveBeenCalledWith("candidate@instance-1");
+  });
+
+  test("a refused write is silent", async () => {
+    stubClipboard({ writeText: vi.fn(async () => Promise.reject(new Error("denied"))) });
+    desktopClipboard.receive("nope");
+
+    expect(await clipboardSync.syncToHost()).toBe(false);
+  });
+
+  test("a value taken from the desktop is never pushed back to it", async () => {
+    // The loop this guards against: write X to the host, the next focus
+    // reads X back, and pushes it to the desktop again, forever.
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    const writeText = vi.fn(async () => {});
+    stubClipboard({ writeText, readText: vi.fn(async () => "orbit-frontend") });
+
+    desktopClipboard.receive("orbit-frontend");
+    await clipboardSync.syncToHost();
+    const pushed = await clipboardSync.syncFromHost();
+
+    expect(pushed).toBe(false);
+    expect(target.pasted).toEqual([]);
+  });
+
+  test("a value pushed to the desktop is not written back to the host", async () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    const writeText = vi.fn(async () => {});
+    stubClipboard({ writeText, readText: vi.fn(async () => "lyra") });
+
+    await clipboardSync.syncFromHost();
+    desktopClipboard.receive("lyra"); // the server echoes it back
+
+    expect(await clipboardSync.syncToHost()).toBe(false);
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/clipboardSync.test.ts -t "host write"`
+
+Expected: FAIL — `clipboardSync.syncToHost is not a function`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the method to the class in `ui/src/lib/clipboardSync.ts`:
+
+```ts
+  /**
+   * Writes the desktop's clipboard to the host.
+   *
+   * Chrome grants clipboard-write to the focused tab, so no gesture is
+   * needed. Firefox refuses without one — the Clipboard panel's button is
+   * a real gesture and stays for exactly that case.
+   */
+  async syncToHost(): Promise<boolean> {
+    const text = desktopClipboard.getRemote();
+    if (!text || text === this.lastSynced) return false;
+    if (text.length > MAX_SYNC_CHARS) return false;
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      return false;
+    }
+    this.lastSynced = text;
+    return true;
+  }
+```
+
+Then subscribe to remote changes inside `start()`, immediately before the trailing `void this.syncFromHost();`:
+
+```ts
+    // The desktop pushes its clipboard on every explicit copy there.
+    // Writing needs a focused document, so a change that arrives while the
+    // candidate is looking elsewhere is picked up by the focus handler.
+    const unsubscribe = desktopClipboard.subscribe(() => {
+      if (!document.hasFocus()) return;
+      void this.syncToHost();
+    });
+    this.stopFns.push(unsubscribe);
+```
+
+And extend `onFocus` so returning to the tab settles both directions. Replace it with:
+
+```ts
+    const onFocus = () => {
+      if (document.visibilityState === "hidden") return;
+      void this.syncToHost().then((written) => {
+        if (!written) void this.syncFromHost();
+      });
+    };
+```
+
+The desktop wins a genuine tie: if both sides changed while the tab was hidden there is no way to know which is newer, and the remote value is the one the candidate produced by hand.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/clipboardSync.test.ts`
+
+Expected: PASS, 14 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/clipboardSync.ts src/lib/clipboardSync.test.ts
+git commit -m "feat: write the desktop clipboard back to the host"
+```
+
+---
+
+### Task 5: Start the sync from the Exam screen
+
+**Files:**
+- Modify: `ui/src/screens/Exam.tsx` (add an effect beside the existing `?`-key effect at `:169-182`)
+- Test: `ui/src/lib/clipboardSync.test.ts`
+
+**Interfaces:**
+- Consumes: `clipboardSync.start()` / `clipboardSync.stop()` from Tasks 2-4.
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing test**
+
+React StrictMode double-invokes effects in development, so a second `start()` must not register a second set of listeners. Add to `ui/src/lib/clipboardSync.test.ts`:
+
+```ts
+describe("clipboardSync lifecycle", () => {
+  test("start is idempotent, so a double-invoked effect pushes once", () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    stubClipboard({});
+    clipboardSync.start();
+    clipboardSync.start();
+    stubSelection("cygnus");
+
+    window.dispatchEvent(new Event("copy"));
+
+    expect(target.pasted).toEqual(["cygnus"]);
+  });
+
+  test("stop then start re-arms the listeners", () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    stubClipboard({});
+    clipboardSync.start();
+    clipboardSync.stop();
+    clipboardSync.start();
+    stubSelection("helios");
+
+    window.dispatchEvent(new Event("copy"));
+
+    expect(target.pasted).toEqual(["helios"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/clipboardSync.test.ts -t "lifecycle"`
+
+Expected: The first test FAILS with `["cygnus", "cygnus"]` if `start()` is not guarded. If Task 2's guard is already in place both PASS — that is fine, they are the regression tests for it. Proceed to Step 3 either way.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `ui/src/screens/Exam.tsx`, add the import beside the existing `desktopKeymap` import at line 13:
+
+```ts
+import { clipboardSync } from "../lib/clipboardSync";
+```
+
+Then add this effect immediately after the `?`-key effect that ends at line 182:
+
+```tsx
+  // Clipboard mirroring runs for as long as the exam view is mounted, not
+  // for as long as a viewport is connected: a candidate copies things
+  // before the desktop finishes connecting, and the sync is a no-op until
+  // there is somewhere to send them.
+  useEffect(() => {
+    clipboardSync.start();
+    return () => clipboardSync.stop();
+  }, []);
+```
+
+- [ ] **Step 4: Run the full gate**
+
+Run: `npx tsc --noEmit && npm run lint && npm test`
+
+Expected: types clean, lint reports exactly one pre-existing warning, all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/screens/Exam.tsx src/lib/clipboardSync.test.ts
+git commit -m "feat: run clipboard sync for the life of the exam view"
+```
+
+---
+
+### Task 6: Correct the README and verify in a real browser
+
+The README still documents the pre-`pasteChordLabel()` behaviour and contradicts the code. And the whole reason this bug shipped is that `navigator.clipboard` is stubbed in every test — the suite cannot catch a malformed keysym.
+
+**Files:**
+- Modify: `README.md:61-65`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-5.
+- Produces: nothing.
+
+- [ ] **Step 1: Rewrite the README paragraph**
+
+Replace lines 61-65 of `README.md`:
+
+```markdown
+Anything you copy reaches the exam desktop automatically — highlight text
+in a question and press ⌘C, or copy from any other app and come back to
+the tab. Paste in the exam terminal with Ctrl+V, ⌘V, the terminal's own
+Ctrl+Shift+V, or right-click → Paste. Copying in the terminal works the
+same way in reverse. Press `?` for the full shortcut list. Firefox cannot
+hand this page your clipboard, so there the Clipboard panel is the way
+across.
+```
+
+- [ ] **Step 2: Run the full gate**
+
+From `ui/`: `npx tsc --noEmit && npm run lint && npm test`
+
+From the repo root: `tests/check-lint.sh`
+
+Expected: all pass. `check-lint.sh` grades spelling and prose in Markdown, so a typo here fails the build.
+
+- [ ] **Step 3: Verify in Chrome against a running stack**
+
+Bring the stack up (`./sim up`) and start an exam. Confirm each of these by hand — no test in this repo can:
+
+1. Highlight the body text of question 1 with the mouse, press ⌘C. In the terminal, right-click → **Paste**. The full multi-line text appears.
+2. With the same text copied, press **⌘V** over the desktop. It pastes. It must **not** print `^` — that is the verbatim-insert prefix and means the chord regressed.
+3. Press **Ctrl+V**. Same result as ⌘V.
+4. Copy something in a different application, switch back to the tab, paste in the terminal. It arrives.
+5. In the terminal, select text and press Ctrl+Shift+C, then paste into a host application. It arrives.
+6. Paste a multi-line block into `vim`. Expect autoindent to staircase it unless bracketed paste handles it — if it staircases, that is a vim/terminal concern, not a clipboard one. Note the result, do not fix it here.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: the clipboard is synced now, so say that"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Dedicated `clipboardSync` module — Task 2. Copy/cut trigger — Task 2. Focus/visibilitychange trigger plus one read on start — Task 3. Desktop→host on focus — Task 4. `lastSynced` loop guard — Tasks 2-4, asserted directly in Task 4. Shifted keysyms and the ⌘C/⌘T/⌘W repair — Task 1. ⌘V keeping its fresh read-push-chord sequence — no change needed; `DesktopViewport.tsx:170-183` already does exactly that and Task 1 fixes the chord it sends. Browser check as part of done — Task 6. "Deliberately not done" items — no tasks, correctly.
+
+**Placeholder scan.** No TBDs. Every code step carries the literal code. Task 6's step 3 is a manual checklist with concrete pass/fail criteria rather than "verify it works".
+
+**Type consistency.** `sendToDesktop`, `getRemote`, `subscribe`, `receive`, `connect` and `reset` all match `desktopClipboard`'s existing signatures. `syncFromSelection(): boolean` is sync; `syncFromHost()` and `syncToHost()` both return `Promise<boolean>` and are used as such in Task 4's `onFocus`. `MAX_SYNC_CHARS` is defined once in Task 2 and reused in Task 4.
+
+One note carried forward for the executor: Task 5's first test may pass immediately, because Task 2's implementation already includes the idempotence guard. That is intentional — the test is the regression lock, not a discovery.

--- a/docs/history/specs/2026-07-28-clipboard-sync-design.md
+++ b/docs/history/specs/2026-07-28-clipboard-sync-design.md
@@ -157,3 +157,45 @@ remain the fastest way to move a single resource name.
 **No polling.** Reading the clipboard on an interval would keep the
 desktop current within a second or two, but it burns a permission-gated
 API in a loop for a case that `focus` already covers.
+
+## Found during verification: non-ASCII never crossed at all
+
+The browser check earned its place. With everything above working, text
+containing any non-ASCII character silently failed to reach the desktop —
+nothing pasted, and the UI still reported success. Measured with controlled
+strings through the same path, each followed by a right-click paste:
+
+| Probe | Result |
+|---|---|
+| `AAA-BBB`, 7 chars, ASCII | pastes |
+| `AAA—BBB`, 7 chars, one em dash (U+2014) | nothing |
+| `XXXéYYY`, 7 chars, e-acute (U+00E9) | nothing |
+| 182 chars, 3 lines, ASCII | pastes |
+| 205 chars, 1 line, two em dashes | nothing |
+
+Length, newlines and the latin-1 boundary are all ruled out: `é` sits
+inside latin-1 and fails exactly like `—`, which does not.
+
+noVNC 1.7's encoder reads as correct. `clipboardPasteFrom`
+(`core/rfb.js:500`) takes the extended-clipboard path, and
+`extendedClipboardProvide` (`:3170`) encodes UTF-8, writes a correct
+big-endian byte length, packs bytes with `charCodeAt` and deflates. The
+latin-1 fallback at `:509-530` substitutes `?` for anything above `0xff` —
+and nothing arrives rather than `?`, which proves that fallback is not in
+play. The fault is therefore most likely TigerVNC 1.12 on the server side.
+That was not confirmed at the byte level, and patching a vendored
+dependency or the VNC server was out of scope.
+
+**The fix is a transliteration at the only layer we control.**
+`toAsciiForDesktop` in `desktopClipboard` maps the typography the banks
+actually contain — em and en dashes, curly quotes, ellipsis, non-breaking
+space — and replaces anything else non-ASCII with `?`, matching what
+noVNC's own fallback does with what it cannot send. It is applied in one
+private `pushToTarget`, the single place text crosses to the desktop, so
+`copy()`, `sendToDesktop()` and `pasteFromHost()` all inherit it and a
+fourth caller cannot bypass it.
+
+Lossy on purpose, and only in one direction: `copy()` still writes the
+original Unicode to the host clipboard, which has no such limitation.
+Question 1's own prose contains em dashes, so before this the headline
+case — copy the whole question — was exactly the one that broke.

--- a/docs/history/specs/2026-07-28-clipboard-sync-design.md
+++ b/docs/history/specs/2026-07-28-clipboard-sync-design.md
@@ -105,10 +105,13 @@ the desktop again.
 One `lastSynced` string, held in `clipboardSync` and consulted by both
 directions, is the guard. A value that arrived from one side is never
 sent back to it. Both directions compare before sending and update it
-after. The ⌘V/Ctrl+V path below is itself a host → desktop push and obeys
-the same rule, so a keystroke paste cannot desynchronise the guard. This
-is the single piece of state in the module and the one most worth
-testing.
+after. The ⌘V/Ctrl+V path below bypasses the guard entirely: it calls
+`desktopClipboard.pasteFromHost` directly, reading and pushing without
+ever touching `lastSynced`. That is harmless rather than a second loop
+risk — the push lands in the desktop's clipboard buffer only, no
+keystrokes are replayed, so the worst case is one redundant re-push of
+the same value the next time the tab regains focus. This is the single
+piece of state in the module and the one most worth testing.
 
 ### The chord fix
 

--- a/docs/history/specs/2026-07-28-clipboard-sync-design.md
+++ b/docs/history/specs/2026-07-28-clipboard-sync-design.md
@@ -108,9 +108,9 @@ sent back to it. Both directions compare before sending and update it
 after. The ⌘V/Ctrl+V path below bypasses the guard entirely: it calls
 `desktopClipboard.pasteFromHost` directly, reading and pushing without
 ever touching `lastSynced`. That is harmless rather than a second loop
-risk — the push lands in the desktop's clipboard buffer only, no
-keystrokes are replayed, so the worst case is one redundant re-push of
-the same value the next time the tab regains focus. This is the single
+risk: the worst case is one redundant re-push on the next focus, and
+unlike pasteFromHost's own chord, that re-push only updates the
+desktop's clipboard buffer — no keystrokes replayed. This is the single
 piece of state in the module and the one most worth testing.
 
 ### The chord fix

--- a/docs/history/specs/2026-07-28-clipboard-sync-design.md
+++ b/docs/history/specs/2026-07-28-clipboard-sync-design.md
@@ -1,0 +1,159 @@
+# Clipboard sync — the host clipboard and the exam desktop, in both directions
+
+Date: 2026-07-28
+
+## The problem
+
+A candidate highlights the text of question 1, presses ⌘C, clicks into
+the exam terminal, and pastes. Nothing arrives. The same thing happens
+with anything copied from outside the browser — a manifest from an
+editor, a command from a notes app.
+
+Two separate defects sit behind that one symptom, and one widely-held
+assumption about a third turned out to be wrong.
+
+## What was measured
+
+Against a live exam in Chrome on macOS, `localhost:8080`:
+
+| Check | Result |
+|---|---|
+| `window.isSecureContext` | `true` |
+| `navigator.clipboard.readText` | present, permission `granted` |
+| `readText()` with the document focused | returns the host clipboard |
+| Real Ctrl+V over the canvas | interception fires, no warning toast, one cut-text sent |
+| Copy button outcome | `copiedToDesktop` — the RFB push reports success |
+| Right-click → Paste in the remote terminal | **pastes correctly** |
+
+The last row is the important one. The RFB extended-clipboard handshake
+completes, and the remote X CLIPBOARD really is populated. An earlier
+reading of "zero `ServerCutText` messages" suggested the transfer was
+broken; it was inconclusive, because the synthetic keystrokes used to
+trigger the paste never reached the terminal as a paste at all. The
+transport is sound and needs no change.
+
+## Root causes
+
+**Nothing pushes arbitrary host clipboard content.** `desktopClipboard`
+only ever writes to the desktop from an explicit click on a copy control
+— `CopyableCode` for inline values, `CodeBlock` for fenced listings.
+Question 1 renders eight inline copy buttons and zero code blocks, so
+there is no control that copies prose at all. A mouse selection plus ⌘C
+reaches the host clipboard and stops there. The only bridges from host to
+desktop are ⌘V/Ctrl+V and the Clipboard panel's Send button.
+
+**The synthesized paste chord is malformed.** `sendPasteChord()` sends
+`keysym: XK.v` — `0x0076`, lowercase `v` — while holding `Shift_L`. The
+`XK` table carries lowercase letters only. Holding Shift while naming an
+unshifted keysym is an inconsistent pair, and xfce4-terminal's
+Ctrl+Shift+V accelerator does not match it; the terminal forwards a plain
+Ctrl+V to the application instead. In vim that renders as `^`, readline's
+verbatim-insert prefix — precisely the failure the comment at
+`DesktopViewport.tsx:166` claims to have removed. Every chord with
+`shift: true` shares the defect: `meta+c`, `meta+v`, `meta+t`, `meta+w`.
+⌘C on a Mac is broken for the same reason.
+
+## Decisions
+
+### A dedicated sync module
+
+`ui/src/lib/clipboardSync.ts`, a module singleton in the established
+shape of `desktopClipboard`, `desktopKeymap` and `desktopResize`. It owns
+the window-level listeners and depends on `desktopClipboard` for
+transport. The Exam screen starts and stops it.
+
+It does **not** live in `DesktopViewport`'s effect. That effect is scoped
+to the canvas mount because it intercepts keys aimed at the remote
+desktop. `copy`, `cut` and `focus` are application-wide events with no
+relationship to the canvas, and putting them there would tie their
+lifetime to a viewport that remounts on reconnect.
+
+### Host → desktop, two triggers
+
+**A `copy`/`cut` listener on the window.** Read
+`document.getSelection().toString()`; if it is non-empty and a desktop is
+connected, push it with `sendToDesktop`. This needs no clipboard
+permission in any browser, and it is the path that makes highlighting a
+question and pressing ⌘C work.
+
+The existing copy buttons use `navigator.clipboard.writeText`, which is a
+programmatic write and does not raise a `copy` event, so they keep their
+current explicit push and nothing is sent twice.
+
+**A `focus` / `visibilitychange` listener, plus one read on start.** Call
+`readText()` and push when the value differs from the last synced value.
+This is the half that covers other applications, and the half Firefox
+cannot do — it has no `readText` for web content. A refusal is a silent
+no-op: this runs on every tab focus, so a toast would be noise rather
+than information. The Clipboard panel remains the documented fallback and
+its copy already says so.
+
+### Desktop → host
+
+`desktopClipboard.receive()` already fires on every remote clipboard
+change and currently only parks the text for the panel. When the document
+is focused, write it to the host with `writeText`. Chrome grants
+`clipboard-write` to the focused tab, so this needs no gesture. Firefox
+will refuse; the panel's existing button stays for that case.
+
+### Loop prevention
+
+With both directions automatic the naive implementation ping-pongs: the
+page writes X to the host, the next focus reads X back, and pushes it to
+the desktop again.
+
+One `lastSynced` string, held in `clipboardSync` and consulted by both
+directions, is the guard. A value that arrived from one side is never
+sent back to it. Both directions compare before sending and update it
+after. The ⌘V/Ctrl+V path below is itself a host → desktop push and obeys
+the same rule, so a keystroke paste cannot desynchronise the guard. This
+is the single piece of state in the module and the one most worth
+testing.
+
+### The chord fix
+
+Add the shifted keysyms to the `XK` table — `V` `0x0056`, `C` `0x0043`,
+`T` `0x0054`, `W` `0x0057` — and send the shifted keysym whenever a chord
+sets `shift: true`. This repairs `sendPasteChord()` and, with it, ⌘C, ⌘T
+and ⌘W.
+
+⌘V/Ctrl+V keeps its fresh `readText` → push → send-chord sequence rather
+than relying on the ambient sync, so a paste is current even when a focus
+event was missed. When the read is refused it falls back to sending the
+chord alone, which now pastes whatever the ambient sync last delivered.
+
+The chord stays Ctrl+Shift+V unconditionally. Detecting which remote
+window has focus would need a helper inside the desktop container
+reporting the active X window over a side channel — real complexity for
+the rare case of pasting into the desktop's Firefox, where right-click
+paste already works.
+
+## Testing
+
+Unit tests for `clipboardSync` with a mocked `navigator.clipboard` and a
+fake RFB target, matching the style of `desktopClipboard.test.ts`:
+selection copy pushes, focus read pushes only on change, a value received
+from the desktop is not pushed back, and a refused `readText` is silent.
+
+A keysym assertion that every chord with `shift: true` sends the
+uppercase keysym. That is the exact regression that shipped.
+
+**A browser check is part of done, not optional.** The existing suite
+stubs `navigator.clipboard` and asserts the blocked path correctly, which
+is why a bug in the real chord survived it. Verify in Chrome: highlight
+question prose, ⌘C, then both right-click → Paste and ⌘V in the terminal.
+
+## Deliberately not done
+
+**No "copy whole question" button.** The requirement is that anything
+highlighted and copied reaches the desktop, whatever its source. A button
+would solve one case and leave every other one broken.
+
+**No change to the copy buttons.** They are precise, they work, and they
+remain the fastest way to move a single resource name.
+
+**No focused-remote-window detection.** See the chord decision above.
+
+**No polling.** Reading the clipboard on an interval would keep the
+desktop current within a second or two, but it burns a permission-gated
+API in a loop for a case that `focus` already covers.

--- a/ui/src/lib/clipboardSync.test.ts
+++ b/ui/src/lib/clipboardSync.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { clipboardSync } from "./clipboardSync";
+import { desktopClipboard, type ClipboardTarget } from "./desktopClipboard";
+
+function fakeTarget(): ClipboardTarget & { pasted: string[] } {
+  const pasted: string[] = [];
+  return { pasted, clipboardPasteFrom: (text: string) => void pasted.push(text) };
+}
+
+function stubSelection(text: string) {
+  Object.defineProperty(window, "getSelection", {
+    value: () => ({ toString: () => text }),
+    configurable: true,
+  });
+}
+
+beforeEach(() => {
+  clipboardSync.reset();
+  stubSelection("");
+});
+
+afterEach(() => {
+  clipboardSync.stop();
+  clipboardSync.reset();
+  desktopClipboard.reset();
+});
+
+describe("clipboardSync selection push", () => {
+  test("a copy inside the page reaches the desktop", () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    clipboardSync.start();
+    stubSelection("Team Aurora owns every Namespace");
+
+    window.dispatchEvent(new Event("copy"));
+
+    expect(target.pasted).toEqual(["Team Aurora owns every Namespace"]);
+  });
+
+  test("a cut is treated the same as a copy", () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    clipboardSync.start();
+    stubSelection("staging-quota");
+
+    window.dispatchEvent(new Event("cut"));
+
+    expect(target.pasted).toEqual(["staging-quota"]);
+  });
+
+  test("an empty selection pushes nothing", () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    clipboardSync.start();
+
+    window.dispatchEvent(new Event("copy"));
+
+    expect(target.pasted).toEqual([]);
+  });
+
+  test("the same value is not pushed twice", () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    clipboardSync.start();
+    stubSelection("aurora-staging");
+
+    window.dispatchEvent(new Event("copy"));
+    window.dispatchEvent(new Event("copy"));
+
+    expect(target.pasted).toEqual(["aurora-staging"]);
+  });
+
+  test("stop removes the listeners", () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    clipboardSync.start();
+    clipboardSync.stop();
+    stubSelection("team=aurora");
+
+    window.dispatchEvent(new Event("copy"));
+
+    expect(target.pasted).toEqual([]);
+  });
+});

--- a/ui/src/lib/clipboardSync.test.ts
+++ b/ui/src/lib/clipboardSync.test.ts
@@ -190,3 +190,50 @@ describe("clipboardSync host read", () => {
     expect(target.pasted).toEqual(["5 Pods"]);
   });
 });
+
+describe("clipboardSync host write", () => {
+  test("what the desktop copied reaches the host clipboard", async () => {
+    const writeText = vi.fn(async () => {});
+    stubClipboard({ writeText });
+    desktopClipboard.receive("candidate@instance-1");
+
+    expect(await clipboardSync.syncToHost()).toBe(true);
+    expect(writeText).toHaveBeenCalledWith("candidate@instance-1");
+  });
+
+  test("a refused write is silent", async () => {
+    stubClipboard({ writeText: vi.fn(async () => Promise.reject(new Error("denied"))) });
+    desktopClipboard.receive("nope");
+
+    expect(await clipboardSync.syncToHost()).toBe(false);
+  });
+
+  test("a value taken from the desktop is never pushed back to it", async () => {
+    // The loop this guards against: write X to the host, the next focus
+    // reads X back, and pushes it to the desktop again, forever.
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    const writeText = vi.fn(async () => {});
+    stubClipboard({ writeText, readText: vi.fn(async () => "orbit-frontend") });
+
+    desktopClipboard.receive("orbit-frontend");
+    await clipboardSync.syncToHost();
+    const pushed = await clipboardSync.syncFromHost();
+
+    expect(pushed).toBe(false);
+    expect(target.pasted).toEqual([]);
+  });
+
+  test("a value pushed to the desktop is not written back to the host", async () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    const writeText = vi.fn(async () => {});
+    stubClipboard({ writeText, readText: vi.fn(async () => "lyra") });
+
+    await clipboardSync.syncFromHost();
+    desktopClipboard.receive("lyra"); // the server echoes it back
+
+    expect(await clipboardSync.syncToHost()).toBe(false);
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/lib/clipboardSync.test.ts
+++ b/ui/src/lib/clipboardSync.test.ts
@@ -310,6 +310,96 @@ describe("clipboardSync desktop-change wiring", () => {
   });
 });
 
+describe("clipboardSync loop-guard edge cases", () => {
+  test("a page copy between a desktop push and the next focus does not re-send stale desktop text and blocks the real host change", async () => {
+    // Reproduces the MERGE BLOCKER: syncToHost used to compare
+    // desktopClipboard.getRemote() (a level) against lastSynced alone (a
+    // watermark also moved by pushToDesktop). Step 2 below moves the
+    // watermark away from the desktop's still-current value, which made
+    // step 3 treat that stale value as "new" again — overwriting whatever
+    // the user actually just copied outside the tab, and returning true so
+    // syncFromHost (the only path that would have picked up the real host
+    // change) never ran.
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    const hasFocusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(true);
+
+    let hostClipboard = "";
+    const writeText = vi.fn(async (text: string) => {
+      hostClipboard = text;
+    });
+    const readText = vi.fn(async () => hostClipboard);
+    stubClipboard({ writeText, readText });
+
+    try {
+      clipboardSync.start();
+
+      // Step 1: terminal copy "pod-A" reaches the desktop, and because the
+      // tab is focused the subscribe wiring writes it straight to the host.
+      desktopClipboard.receive("pod-A");
+      await vi.waitFor(() => expect(hostClipboard).toBe("pod-A"));
+
+      // Step 2: a page copy of "value-C" moves the watermark. The desktop's
+      // remote value is still "pod-A" — nothing told desktopClipboard
+      // otherwise.
+      stubSelection("value-C");
+      window.dispatchEvent(new Event("copy"));
+      expect(target.pasted).toContain("value-C");
+
+      // Step 3: the user copies "manifest-D" in another app (simulated by
+      // the host clipboard changing outside of writeText) and returns to
+      // the tab.
+      hostClipboard = "manifest-D";
+      window.dispatchEvent(new Event("focus"));
+
+      await vi.waitFor(() => expect(target.pasted).toContain("manifest-D"));
+      expect(hostClipboard).toBe("manifest-D");
+    } finally {
+      hasFocusSpy.mockRestore();
+    }
+  });
+});
+
+describe("clipboardSync stop/start lifecycle clears sync state", () => {
+  test("stop then start pushes an unchanged host clipboard again, as a fresh desktop container needs", async () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    stubClipboard({ readText: vi.fn(async () => "aurora-staging") });
+
+    clipboardSync.start();
+    await vi.waitFor(() => expect(target.pasted).toEqual(["aurora-staging"]));
+
+    clipboardSync.stop();
+
+    // A new attempt reconnects a fresh, empty desktop container. The host
+    // clipboard has not changed, so only a cleared watermark makes start()
+    // push it again.
+    const target2 = fakeTarget();
+    desktopClipboard.connect(target2);
+    clipboardSync.start();
+
+    await vi.waitFor(() => expect(target2.pasted).toEqual(["aurora-staging"]));
+  });
+});
+
+describe("clipboardSync pushToDesktop failure path", () => {
+  test("a push with no desktop connected leaves the guard unset, so the same text retries successfully once connected", () => {
+    stubClipboard({});
+    clipboardSync.start();
+    stubSelection("kube-system");
+
+    // No desktopClipboard.connect() yet: sendToDesktop returns false, and
+    // pushToDesktop must not record the text as synced anyway.
+    window.dispatchEvent(new Event("copy"));
+
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    window.dispatchEvent(new Event("copy"));
+
+    expect(target.pasted).toEqual(["kube-system"]);
+  });
+});
+
 describe("clipboardSync lifecycle", () => {
   test("start is idempotent, so a double-invoked effect pushes once", () => {
     const target = fakeTarget();

--- a/ui/src/lib/clipboardSync.test.ts
+++ b/ui/src/lib/clipboardSync.test.ts
@@ -132,10 +132,58 @@ describe("clipboardSync host read", () => {
   test("start wires focus to a host read", async () => {
     const target = fakeTarget();
     desktopClipboard.connect(target);
-    stubClipboard({ readText: vi.fn(async () => "5 Pods") });
+    // Different values for the mount-time read and the focus-triggered read:
+    // if the two reads returned the same text, the dedup guard in
+    // pushToDesktop would make the second read a no-op even with the focus
+    // listener deleted, and the test would pass either way.
+    let hostText = "5 Pods";
+    stubClipboard({ readText: vi.fn(async () => hostText) });
     clipboardSync.start();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(target.pasted).toEqual(["5 Pods"]); // the mount-time read
 
+    hostText = "3 Deployments";
     window.dispatchEvent(new Event("focus"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(target.pasted).toEqual(["5 Pods", "3 Deployments"]);
+  });
+
+  test("start wires visibilitychange to a host read", async () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    let hostText = "5 Pods";
+    stubClipboard({ readText: vi.fn(async () => hostText) });
+    clipboardSync.start();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(target.pasted).toEqual(["5 Pods"]); // the mount-time read
+
+    hostText = "3 Deployments";
+    document.dispatchEvent(new Event("visibilitychange"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(target.pasted).toEqual(["5 Pods", "3 Deployments"]);
+  });
+
+  test("stop removes the focus and visibilitychange listeners", async () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    let hostText = "5 Pods";
+    stubClipboard({ readText: vi.fn(async () => hostText) });
+    clipboardSync.start();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(target.pasted).toEqual(["5 Pods"]); // the mount-time read
+
+    clipboardSync.stop();
+    hostText = "3 Deployments"; // a value distinct from lastSynced, so a
+    // stray read would not be caught by the dedup guard
+    window.dispatchEvent(new Event("focus"));
+    document.dispatchEvent(new Event("visibilitychange"));
     await Promise.resolve();
     await Promise.resolve();
 

--- a/ui/src/lib/clipboardSync.test.ts
+++ b/ui/src/lib/clipboardSync.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { clipboardSync } from "./clipboardSync";
 import { desktopClipboard, type ClipboardTarget } from "./desktopClipboard";
 
@@ -10,6 +10,13 @@ function fakeTarget(): ClipboardTarget & { pasted: string[] } {
 function stubSelection(text: string) {
   Object.defineProperty(window, "getSelection", {
     value: () => ({ toString: () => text }),
+    configurable: true,
+  });
+}
+
+function stubClipboard(clipboard: Partial<Clipboard>) {
+  Object.defineProperty(navigator, "clipboard", {
+    value: clipboard,
     configurable: true,
   });
 }
@@ -80,5 +87,58 @@ describe("clipboardSync selection push", () => {
     window.dispatchEvent(new Event("copy"));
 
     expect(target.pasted).toEqual([]);
+  });
+});
+
+describe("clipboardSync host read", () => {
+  test("focus pushes what another app put on the host clipboard", async () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    stubClipboard({ readText: vi.fn(async () => "kubectl get pods -A") });
+
+    expect(await clipboardSync.syncFromHost()).toBe(true);
+    expect(target.pasted).toEqual(["kubectl get pods -A"]);
+  });
+
+  test("an unchanged host clipboard is not pushed again", async () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    stubClipboard({ readText: vi.fn(async () => "aurora-staging") });
+
+    await clipboardSync.syncFromHost();
+    await clipboardSync.syncFromHost();
+
+    expect(target.pasted).toEqual(["aurora-staging"]);
+  });
+
+  test("a refused read is silent", async () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    stubClipboard({ readText: vi.fn(async () => Promise.reject(new Error("denied"))) });
+
+    expect(await clipboardSync.syncFromHost()).toBe(false);
+    expect(target.pasted).toEqual([]);
+  });
+
+  test("a browser with no readText at all is silent", async () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    stubClipboard({}); // Firefox: no readText for web content
+
+    expect(await clipboardSync.syncFromHost()).toBe(false);
+    expect(target.pasted).toEqual([]);
+  });
+
+  test("start wires focus to a host read", async () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    stubClipboard({ readText: vi.fn(async () => "5 Pods") });
+    clipboardSync.start();
+
+    window.dispatchEvent(new Event("focus"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(target.pasted).toEqual(["5 Pods"]);
   });
 });

--- a/ui/src/lib/clipboardSync.test.ts
+++ b/ui/src/lib/clipboardSync.test.ts
@@ -21,6 +21,18 @@ function stubClipboard(clipboard: Partial<Clipboard>) {
   });
 }
 
+/**
+ * Drains every microtask already queued, however many `.then` hops deep,
+ * without hardcoding a tick count: a macrotask boundary (a real timer)
+ * always runs after all microtasks queued ahead of it have settled. Used
+ * where a fixed number of `await Promise.resolve()` would work today but
+ * silently stop covering the code the moment another `await` is inserted
+ * anywhere in the chain under test.
+ */
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 beforeEach(() => {
   clipboardSync.reset();
   stubSelection("");
@@ -139,16 +151,14 @@ describe("clipboardSync host read", () => {
     let hostText = "5 Pods";
     stubClipboard({ readText: vi.fn(async () => hostText) });
     clipboardSync.start();
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(target.pasted).toEqual(["5 Pods"]); // the mount-time read
+    // Condition-based, not tick-counted: onFocus now runs syncToHost()
+    // ahead of syncFromHost(), so the number of microtask hops before this
+    // settles is an implementation detail, not a contract.
+    await vi.waitFor(() => expect(target.pasted).toEqual(["5 Pods"])); // the mount-time read
 
     hostText = "3 Deployments";
     window.dispatchEvent(new Event("focus"));
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(target.pasted).toEqual(["5 Pods", "3 Deployments"]);
+    await vi.waitFor(() => expect(target.pasted).toEqual(["5 Pods", "3 Deployments"]));
   });
 
   test("start wires visibilitychange to a host read", async () => {
@@ -157,16 +167,11 @@ describe("clipboardSync host read", () => {
     let hostText = "5 Pods";
     stubClipboard({ readText: vi.fn(async () => hostText) });
     clipboardSync.start();
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(target.pasted).toEqual(["5 Pods"]); // the mount-time read
+    await vi.waitFor(() => expect(target.pasted).toEqual(["5 Pods"])); // the mount-time read
 
     hostText = "3 Deployments";
     document.dispatchEvent(new Event("visibilitychange"));
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(target.pasted).toEqual(["5 Pods", "3 Deployments"]);
+    await vi.waitFor(() => expect(target.pasted).toEqual(["5 Pods", "3 Deployments"]));
   });
 
   test("stop removes the focus and visibilitychange listeners", async () => {
@@ -175,17 +180,20 @@ describe("clipboardSync host read", () => {
     let hostText = "5 Pods";
     stubClipboard({ readText: vi.fn(async () => hostText) });
     clipboardSync.start();
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(target.pasted).toEqual(["5 Pods"]); // the mount-time read
+    await vi.waitFor(() => expect(target.pasted).toEqual(["5 Pods"])); // the mount-time read
 
     clipboardSync.stop();
     hostText = "3 Deployments"; // a value distinct from lastSynced, so a
     // stray read would not be caught by the dedup guard
     window.dispatchEvent(new Event("focus"));
     document.dispatchEvent(new Event("visibilitychange"));
-    await Promise.resolve();
-    await Promise.resolve();
+    // Proving absence can't use vi.waitFor (it resolves the instant the
+    // assertion is true, which is immediately if nothing is wired — that
+    // would pass just as happily if the listener removal were broken and
+    // the push simply hadn't landed yet). A macrotask flush instead drains
+    // every microtask any surviving handler could have queued before this
+    // assertion runs, whatever the chain length.
+    await flushMicrotasks();
 
     expect(target.pasted).toEqual(["5 Pods"]);
   });
@@ -235,5 +243,69 @@ describe("clipboardSync host write", () => {
 
     expect(await clipboardSync.syncToHost()).toBe(false);
     expect(writeText).not.toHaveBeenCalled();
+  });
+});
+
+describe("clipboardSync desktop-change wiring", () => {
+  test("a desktop change while focused is written to the host", async () => {
+    const hasFocusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    try {
+      const writeText = vi.fn(async () => {});
+      stubClipboard({ writeText });
+      clipboardSync.start();
+
+      desktopClipboard.receive("candidate@instance-2");
+
+      await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith("candidate@instance-2"));
+    } finally {
+      hasFocusSpy.mockRestore();
+    }
+  });
+
+  test("a desktop change while unfocused waits for the next focus", async () => {
+    const hasFocusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    try {
+      const writeText = vi.fn(async () => {});
+      stubClipboard({ writeText });
+      clipboardSync.start();
+
+      desktopClipboard.receive("candidate@instance-3");
+      // The subscribe callback's hasFocus() guard runs synchronously inside
+      // receive(); if it had passed, the write it triggers would already
+      // be underway. No tick to wait out for this half of the claim.
+      expect(writeText).not.toHaveBeenCalled();
+
+      hasFocusSpy.mockReturnValue(true);
+      window.dispatchEvent(new Event("focus"));
+
+      // ...but nothing is lost: the focus handler tries syncToHost() on
+      // return, independently of the subscription, and picks up the value
+      // that arrived while the tab was elsewhere.
+      await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith("candidate@instance-3"));
+    } finally {
+      hasFocusSpy.mockRestore();
+    }
+  });
+
+  test("stop unsubscribes from desktop clipboard changes", async () => {
+    const hasFocusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    try {
+      const writeText = vi.fn(async () => {});
+      stubClipboard({ writeText });
+      clipboardSync.start();
+      clipboardSync.stop();
+
+      desktopClipboard.receive("candidate@instance-4");
+      // Were the subscription still live, hasFocus() would pass and
+      // syncToHost() would call writeText synchronously as part of
+      // handling receive() — so, as above, no tick to wait out. A
+      // trailing flush still guards against a future implementation that
+      // defers the call.
+      await flushMicrotasks();
+
+      expect(writeText).not.toHaveBeenCalled();
+    } finally {
+      hasFocusSpy.mockRestore();
+    }
   });
 });

--- a/ui/src/lib/clipboardSync.test.ts
+++ b/ui/src/lib/clipboardSync.test.ts
@@ -309,3 +309,32 @@ describe("clipboardSync desktop-change wiring", () => {
     }
   });
 });
+
+describe("clipboardSync lifecycle", () => {
+  test("start is idempotent, so a double-invoked effect pushes once", () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    stubClipboard({});
+    clipboardSync.start();
+    clipboardSync.start();
+    stubSelection("cygnus");
+
+    window.dispatchEvent(new Event("copy"));
+
+    expect(target.pasted).toEqual(["cygnus"]);
+  });
+
+  test("stop then start re-arms the listeners", () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    stubClipboard({});
+    clipboardSync.start();
+    clipboardSync.stop();
+    clipboardSync.start();
+    stubSelection("helios");
+
+    window.dispatchEvent(new Event("copy"));
+
+    expect(target.pasted).toEqual(["helios"]);
+  });
+});

--- a/ui/src/lib/clipboardSync.ts
+++ b/ui/src/lib/clipboardSync.ts
@@ -36,8 +36,30 @@ class ClipboardSync {
    * ping-pong: the page writes X to the host, the next focus reads X back,
    * and pushes it to the desktop again. A value that arrived from one side
    * is never sent back to it.
+   *
+   * This is a watermark, not a level: pushToDesktop moves it on every
+   * host → desktop send, so after a page copy it no longer describes what
+   * the desktop's clipboard currently holds. desktopClipboard.getRemote()
+   * is the level — the last value the desktop actually sent, moved only
+   * by receive(). syncToHost must not treat "differs from lastSynced" as
+   * "the desktop has something new": a page copy moves the watermark away
+   * from a remote value that never changed, which would make that stale
+   * value look new again on every later focus and overwrite whatever the
+   * user just put on the real host clipboard. lastRemote below is what
+   * keeps that comparison edge-triggered on the level instead.
    */
   private lastSynced = "";
+
+  /**
+   * The last desktop value actually written to the host clipboard.
+   *
+   * Set only after a successful write, so a refused write still retries on
+   * the next focus. Exists purely to edge-trigger syncToHost against
+   * desktopClipboard's level (see lastSynced above) instead of comparing
+   * against the shared watermark.
+   */
+  private lastRemote = "";
+
   private stopFns: Array<() => void> = [];
 
   start(): void {
@@ -81,6 +103,12 @@ class ClipboardSync {
   stop(): void {
     for (const fn of this.stopFns) fn();
     this.stopFns = [];
+    // A fresh desktop container (a new exam attempt) starts with an empty
+    // clipboard. Leaving these set would make start()'s mount-time read see
+    // an unchanged host value and push nothing, so the new desktop would
+    // stay empty until the candidate copied again.
+    this.lastSynced = "";
+    this.lastRemote = "";
   }
 
   /**
@@ -120,13 +148,14 @@ class ClipboardSync {
    */
   async syncToHost(): Promise<boolean> {
     const text = desktopClipboard.getRemote();
-    if (!text || text === this.lastSynced) return false;
+    if (!text || text === this.lastSynced || text === this.lastRemote) return false;
     if (text.length > MAX_SYNC_CHARS) return false;
     try {
       await navigator.clipboard.writeText(text);
     } catch {
       return false;
     }
+    this.lastRemote = text;
     this.lastSynced = text;
     return true;
   }
@@ -144,6 +173,7 @@ class ClipboardSync {
   reset(): void {
     this.stop();
     this.lastSynced = "";
+    this.lastRemote = "";
   }
 }
 

--- a/ui/src/lib/clipboardSync.ts
+++ b/ui/src/lib/clipboardSync.ts
@@ -1,0 +1,84 @@
+// Keeps the host clipboard and the exam desktop's clipboard in step.
+//
+// Before this existed, the desktop's clipboard was written only by an
+// explicit click on a copy control in the question panel. A candidate who
+// highlighted prose and pressed ⌘C — or copied a manifest out of an
+// editor — had no way to get it across: the value reached the host
+// clipboard and stopped there.
+//
+// Two triggers, deliberately different in what they cost. A copy raised
+// inside the page carries a live DOM selection, so it needs no clipboard
+// permission in any browser. Reading what another application put on the
+// host clipboard needs navigator.clipboard.readText, which Firefox does
+// not expose to web content at all — that half degrades to the Clipboard
+// panel rather than failing loudly.
+//
+// Module-singleton shape, following desktopClipboard and desktopKeymap:
+// the Exam screen starts it, and nothing else needs to know it exists.
+
+import { desktopClipboard } from "./desktopClipboard";
+
+/**
+ * Longest value worth mirroring.
+ *
+ * Xvnc is started with -MaxCutText 2097152, so this is far below what the
+ * transport accepts. The limit exists to stop a candidate who selected an
+ * entire scrollback from pushing megabytes across the socket on every
+ * keystroke of a chord.
+ */
+const MAX_SYNC_CHARS = 100_000;
+
+class ClipboardSync {
+  /**
+   * The last value moved in either direction.
+   *
+   * The whole reason both directions can be automatic. Without it the two
+   * ping-pong: the page writes X to the host, the next focus reads X back,
+   * and pushes it to the desktop again. A value that arrived from one side
+   * is never sent back to it.
+   */
+  private lastSynced = "";
+  private stopFns: Array<() => void> = [];
+
+  start(): void {
+    if (this.stopFns.length) return; // idempotent: effects can run twice
+    const onCopy = () => void this.syncFromSelection();
+    window.addEventListener("copy", onCopy);
+    window.addEventListener("cut", onCopy);
+    this.stopFns.push(() => {
+      window.removeEventListener("copy", onCopy);
+      window.removeEventListener("cut", onCopy);
+    });
+  }
+
+  stop(): void {
+    for (const fn of this.stopFns) fn();
+    this.stopFns = [];
+  }
+
+  /**
+   * Pushes the current DOM selection to the desktop.
+   *
+   * Returns whether anything was sent, which is what the tests assert on.
+   */
+  syncFromSelection(): boolean {
+    return this.pushToDesktop(window.getSelection()?.toString() ?? "");
+  }
+
+  /** Sends to the desktop unless it is empty, oversized, or already there. */
+  private pushToDesktop(text: string): boolean {
+    if (!text || text === this.lastSynced) return false;
+    if (text.length > MAX_SYNC_CHARS) return false;
+    if (!desktopClipboard.sendToDesktop(text)) return false;
+    this.lastSynced = text;
+    return true;
+  }
+
+  /** Test-only, mirroring desktopKeymap.reset. */
+  reset(): void {
+    this.stop();
+    this.lastSynced = "";
+  }
+}
+
+export const clipboardSync = new ClipboardSync();

--- a/ui/src/lib/clipboardSync.ts
+++ b/ui/src/lib/clipboardSync.ts
@@ -55,7 +55,9 @@ class ClipboardSync {
     // focus covers switching between windows of the same tab.
     const onFocus = () => {
       if (document.visibilityState === "hidden") return;
-      void this.syncFromHost();
+      void this.syncToHost().then((written) => {
+        if (!written) void this.syncFromHost();
+      });
     };
     window.addEventListener("focus", onFocus);
     document.addEventListener("visibilitychange", onFocus);
@@ -63,6 +65,15 @@ class ClipboardSync {
       window.removeEventListener("focus", onFocus);
       document.removeEventListener("visibilitychange", onFocus);
     });
+
+    // The desktop pushes its clipboard on every explicit copy there.
+    // Writing needs a focused document, so a change that arrives while the
+    // candidate is looking elsewhere is picked up by the focus handler.
+    const unsubscribe = desktopClipboard.subscribe(() => {
+      if (!document.hasFocus()) return;
+      void this.syncToHost();
+    });
+    this.stopFns.push(unsubscribe);
 
     void this.syncFromHost();
   }
@@ -98,6 +109,26 @@ class ClipboardSync {
       return false;
     }
     return this.pushToDesktop(text);
+  }
+
+  /**
+   * Writes the desktop's clipboard to the host.
+   *
+   * Chrome grants clipboard-write to the focused tab, so no gesture is
+   * needed. Firefox refuses without one — the Clipboard panel's button is
+   * a real gesture and stays for exactly that case.
+   */
+  async syncToHost(): Promise<boolean> {
+    const text = desktopClipboard.getRemote();
+    if (!text || text === this.lastSynced) return false;
+    if (text.length > MAX_SYNC_CHARS) return false;
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      return false;
+    }
+    this.lastSynced = text;
+    return true;
   }
 
   /** Sends to the desktop unless it is empty, oversized, or already there. */

--- a/ui/src/lib/clipboardSync.ts
+++ b/ui/src/lib/clipboardSync.ts
@@ -49,6 +49,22 @@ class ClipboardSync {
       window.removeEventListener("copy", onCopy);
       window.removeEventListener("cut", onCopy);
     });
+
+    // Returning to the tab is the moment a candidate has just copied
+    // something elsewhere. visibilitychange covers tab switches;
+    // focus covers switching between windows of the same tab.
+    const onFocus = () => {
+      if (document.visibilityState === "hidden") return;
+      void this.syncFromHost();
+    };
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onFocus);
+    this.stopFns.push(() => {
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onFocus);
+    });
+
+    void this.syncFromHost();
   }
 
   stop(): void {
@@ -63,6 +79,25 @@ class ClipboardSync {
    */
   syncFromSelection(): boolean {
     return this.pushToDesktop(window.getSelection()?.toString() ?? "");
+  }
+
+  /**
+   * Reads the host clipboard and pushes it to the desktop.
+   *
+   * Silent on refusal by design: Firefox has no readText for web content,
+   * and Chrome needs a granted permission. This runs on every tab focus,
+   * so a warning here would fire constantly for a large share of users.
+   * The Clipboard panel is the path that always works, and its copy
+   * already says so.
+   */
+  async syncFromHost(): Promise<boolean> {
+    let text: string;
+    try {
+      text = await navigator.clipboard.readText();
+    } catch {
+      return false;
+    }
+    return this.pushToDesktop(text);
   }
 
   /** Sends to the desktop unless it is empty, oversized, or already there. */

--- a/ui/src/lib/desktopClipboard.test.ts
+++ b/ui/src/lib/desktopClipboard.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { desktopClipboard, type ClipboardTarget } from "./desktopClipboard";
+import { desktopClipboard, toAsciiForDesktop, type ClipboardTarget } from "./desktopClipboard";
 
 function fakeTarget(): ClipboardTarget & { pasted: string[] } {
   const pasted: string[] = [];
@@ -166,5 +166,69 @@ describe("inbound clipboard", () => {
     expect(notified).toBe(1);
 
     unsubscribe();
+  });
+});
+
+describe("toAsciiForDesktop", () => {
+  test("leaves ASCII untouched", () => {
+    expect(toAsciiForDesktop("kubectl get pods -A")).toBe("kubectl get pods -A");
+  });
+
+  test("transliterates the typography the banks actually use", () => {
+    expect(toAsciiForDesktop("a—b")).toBe("a-b");
+    expect(toAsciiForDesktop("a–b")).toBe("a-b");
+    expect(toAsciiForDesktop("‘x’")).toBe("'x'");
+    expect(toAsciiForDesktop("“x”")).toBe('"x"');
+    expect(toAsciiForDesktop("a…")).toBe("a...");
+    expect(toAsciiForDesktop("a b")).toBe("a b");
+  });
+
+  test("replaces anything else non-ASCII rather than dropping it", () => {
+    // Whatever we cannot represent must still be visible as a gap.
+    expect(toAsciiForDesktop("a中b")).toBe("a?b");
+    expect(toAsciiForDesktop("aéb")).toBe("a?b");
+  });
+
+  test("preserves newlines and tabs", () => {
+    expect(toAsciiForDesktop("one\ntwo\tthree")).toBe("one\ntwo\tthree");
+  });
+
+  test("handles astral characters as a single replacement", () => {
+    // Iterating by code point, not code unit, so a surrogate pair is one "?".
+    expect(toAsciiForDesktop("a\u{1F600}b")).toBe("a?b");
+  });
+});
+
+describe("desktopClipboard sanitises every push", () => {
+  test("copy() sends ASCII to the desktop but the original to the browser", async () => {
+    const writeText = stubBrowserClipboard();
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+
+    expect(await desktopClipboard.copy("aurora — staging")).toBe("desktop");
+    expect(target.pasted).toEqual(["aurora - staging"]);
+    expect(writeText).toHaveBeenCalledWith("aurora — staging");
+  });
+
+  test("sendToDesktop() sanitises", () => {
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+
+    expect(desktopClipboard.sendToDesktop("a — b")).toBe(true);
+    expect(target.pasted).toEqual(["a - b"]);
+  });
+
+  test("pasteFromHost() sanitises before sending the chord", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { readText: async () => "quota — 5 Pods", writeText: async () => {} },
+      configurable: true,
+    });
+    const target = fakeTarget();
+    desktopClipboard.connect(target);
+    let chords = 0;
+
+    expect(await desktopClipboard.pasteFromHost(() => chords++)).toBe("sent");
+    expect(target.pasted).toEqual(["quota - 5 Pods"]);
+    expect(chords).toBe(1);
   });
 });

--- a/ui/src/lib/desktopClipboard.test.ts
+++ b/ui/src/lib/desktopClipboard.test.ts
@@ -180,6 +180,11 @@ describe("toAsciiForDesktop", () => {
     expect(toAsciiForDesktop("‘x’")).toBe("'x'");
     expect(toAsciiForDesktop("“x”")).toBe('"x"');
     expect(toAsciiForDesktop("a…")).toBe("a...");
+    // Explicit escape, not a literal nbsp glyph: the two are visually
+    // identical in source, which is exactly how the table bug shipped.
+    expect(toAsciiForDesktop("a\u00a0b")).toBe("a b");
+    // A plain ASCII space stays untouched, kept alongside the nbsp
+    // case above so the two are visibly distinct in the source.
     expect(toAsciiForDesktop("a b")).toBe("a b");
   });
 

--- a/ui/src/lib/desktopClipboard.ts
+++ b/ui/src/lib/desktopClipboard.ts
@@ -19,6 +19,49 @@ export interface ClipboardTarget {
   clipboardPasteFrom(text: string): void;
 }
 
+/**
+ * Characters the exam's own content actually contains, mapped to the ASCII a
+ * terminal can take. Typographic only — nothing here changes a resource name.
+ */
+const TRANSLITERATIONS: Record<string, string> = {
+  "—": "-", // em dash
+  "–": "-", // en dash
+  "‘": "'", // left single quote
+  "’": "'", // right single quote
+  "“": '"', // left double quote
+  "”": '"', // right double quote
+  "…": "...", // ellipsis
+  " ": " ", // non-breaking space
+};
+
+/**
+ * Reduces text to ASCII before it crosses the RFB socket.
+ *
+ * Any non-ASCII byte silently kills the transfer — measured against TigerVNC
+ * 1.12 with noVNC 1.7, for characters both inside latin-1 (U+00E9) and outside
+ * it (U+2014), at 7 characters as readily as at 205. noVNC's own encoder reads
+ * as correct, so the fault is most likely server-side; this is a workaround at
+ * the only layer we control.
+ *
+ * Lossy on purpose. Losing an em dash beats losing the whole paste and being
+ * told it worked.
+ */
+export function toAsciiForDesktop(text: string): string {
+  let out = "";
+  for (const ch of text) {
+    const mapped = TRANSLITERATIONS[ch];
+    if (mapped !== undefined) {
+      out += mapped;
+    } else if (ch.codePointAt(0)! < 0x80) {
+      out += ch;
+    } else {
+      // Matches what noVNC's own latin-1 fallback does with what it cannot send.
+      out += "?";
+    }
+  }
+  return out;
+}
+
 export type CopyOutcome =
   /** Reached both the browser clipboard and the exam desktop. */
   | "desktop"
@@ -58,6 +101,20 @@ class DesktopClipboard {
   }
 
   /**
+   * The single point where text crosses to the desktop. Everything that pushes
+   * goes through here so the ASCII reduction cannot be bypassed.
+   */
+  private pushToTarget(text: string): boolean {
+    if (!this.target) return false;
+    try {
+      this.target.clipboardPasteFrom(toAsciiForDesktop(text));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Called on disconnect/unmount. Ignores a stale target so a viewport
    * torn down after a newer one connected cannot clear the live link.
    */
@@ -79,16 +136,9 @@ class DesktopClipboard {
    * two are independent, and the desktop is the one that matters here.
    */
   async copy(text: string): Promise<CopyOutcome> {
-    let reachedDesktop = false;
-    if (this.target) {
-      try {
-        this.target.clipboardPasteFrom(text);
-        reachedDesktop = true;
-      } catch {
-        // A viewport that dropped between the click and this call; the
-        // browser clipboard below is still worth having.
-      }
-    }
+    // A viewport that dropped between the click and this call, or a target
+    // that threw, still leaves the browser clipboard below worth having.
+    const reachedDesktop = this.pushToTarget(text);
 
     let reachedBrowser = false;
     try {
@@ -107,13 +157,7 @@ class DesktopClipboard {
    * the browser's. Backs the clipboard panel's Send button.
    */
   sendToDesktop(text: string): boolean {
-    if (!this.target) return false;
-    try {
-      this.target.clipboardPasteFrom(text);
-      return true;
-    } catch {
-      return false;
-    }
+    return this.pushToTarget(text);
   }
 
   /**

--- a/ui/src/lib/desktopClipboard.ts
+++ b/ui/src/lib/desktopClipboard.ts
@@ -22,16 +22,22 @@ export interface ClipboardTarget {
 /**
  * Characters the exam's own content actually contains, mapped to the ASCII a
  * terminal can take. Typographic only — nothing here changes a resource name.
+ *
+ * Keys are explicit \uXXXX escapes, not literal characters: U+00A0
+ * (non-breaking space) is visually indistinguishable from a plain U+0020 in
+ * an editor, and a literal nbsp here once shipped as a silent no-op that
+ * mapped a regular space to itself. Escaping every entry keeps the table
+ * honest about what it actually matches.
  */
 const TRANSLITERATIONS: Record<string, string> = {
-  "—": "-", // em dash
-  "–": "-", // en dash
-  "‘": "'", // left single quote
-  "’": "'", // right single quote
-  "“": '"', // left double quote
-  "”": '"', // right double quote
-  "…": "...", // ellipsis
-  " ": " ", // non-breaking space
+  "\u2014": "-", // em dash
+  "\u2013": "-", // en dash
+  "\u2018": "'", // left single quote
+  "\u2019": "'", // right single quote
+  "\u201c": '"', // left double quote
+  "\u201d": '"', // right double quote
+  "\u2026": "...", // ellipsis
+  "\u00a0": " ", // non-breaking space
 };
 
 /**

--- a/ui/src/lib/desktopKeymap.test.ts
+++ b/ui/src/lib/desktopKeymap.test.ts
@@ -59,11 +59,14 @@ describe("desktopKeymap", () => {
 
     expect(desktopKeymap.handleKeyDown(keydown("c", { metaKey: true }))).toBe(true);
 
+    // Shifted keysym, not the lowercase one: Shift plus a lowercase keysym
+    // is the same inconsistent pair that broke paste (see "a shifted
+    // chord sends the uppercase keysym" below).
     expect(sent).toEqual([
       [0xffe3, "ControlLeft", true],
       [0xffe1, "ShiftLeft", true],
-      [0x0063, "KeyC", true],
-      [0x0063, "KeyC", false],
+      [0x0043, "KeyC", true],
+      [0x0043, "KeyC", false],
       [0xffe1, "ShiftLeft", false],
       [0xffe3, "ControlLeft", false],
     ]);
@@ -154,6 +157,36 @@ describe("desktopKeymap", () => {
     const copy = rows.find((r) => r.press === "⌘C");
     expect(copy).toEqual({ press: "⌘C", sends: "Ctrl+Shift+C", describes: "Copy" });
     expect(rows.find((r) => r.press === "⌘←")?.sends).toBe("Home");
+  });
+
+  test("a shifted chord sends the uppercase keysym", () => {
+    // X11 derives the character from keycode + modifier state. Naming the
+    // lowercase keysym while holding Shift is inconsistent, and GTK's
+    // Ctrl+Shift+V accelerator does not match it — the terminal then
+    // forwards a bare Ctrl+V, which is readline's verbatim-insert prefix.
+    const { target, sent } = fakeTarget();
+    desktopKeymap.attach(target);
+
+    desktopKeymap.sendPasteChord();
+
+    expect(sent).toContainEqual([0x0056, "KeyV", true]);
+    expect(sent).not.toContainEqual([0x0076, "KeyV", true]);
+  });
+
+  test("every shifted chord in the map uses an uppercase keysym", () => {
+    const { target, sent } = fakeTarget();
+    desktopKeymap.setReservedEnabled(true);
+    desktopKeymap.attach(target);
+
+    // ⌘C -> Ctrl+Shift+C, ⌘T -> Ctrl+Shift+T, ⌘W -> Ctrl+Shift+W.
+    for (const key of ["c", "t", "w"]) {
+      desktopKeymap.handleKeyDown(keydown(key, { metaKey: true }));
+    }
+
+    // Down-only: send() taps each key down then up, so every keysym
+    // appears twice.
+    const letters = sent.filter(([ks, , down]) => down && ks >= 0x0041 && ks <= 0x007a);
+    expect(letters.map(([ks]) => ks)).toEqual([0x0043, 0x0054, 0x0057]);
   });
 });
 

--- a/ui/src/lib/desktopKeymap.ts
+++ b/ui/src/lib/desktopKeymap.ts
@@ -39,13 +39,9 @@ const XK = {
   Home: 0xff50,
   End: 0xff57,
   b: 0x0062,
-  c: 0x0063,
   f: 0x0066,
   l: 0x006c,
-  t: 0x0074,
   u: 0x0075,
-  v: 0x0076,
-  w: 0x0077,
   // Shifted forms. A chord that holds Shift must name the shifted keysym:
   // X11 derives the character from keycode + modifier state, so Shift plus
   // a lowercase keysym is an inconsistent pair that GTK accelerators

--- a/ui/src/lib/desktopKeymap.ts
+++ b/ui/src/lib/desktopKeymap.ts
@@ -46,6 +46,14 @@ const XK = {
   u: 0x0075,
   v: 0x0076,
   w: 0x0077,
+  // Shifted forms. A chord that holds Shift must name the shifted keysym:
+  // X11 derives the character from keycode + modifier state, so Shift plus
+  // a lowercase keysym is an inconsistent pair that GTK accelerators
+  // (Ctrl+Shift+V and friends) will not match.
+  C: 0x0043,
+  T: 0x0054,
+  V: 0x0056,
+  W: 0x0057,
 } as const;
 
 /** One key press, with the modifiers to hold around it. */
@@ -71,8 +79,8 @@ const MAC_CHORDS: Record<string, Chord> = {
   // The two that matter. xfce4-terminal's copy/paste are Ctrl+Shift+C/V,
   // and MiscShowUnsafePasteDialog is already off in the image, so a
   // multi-line paste lands without a confirmation dialog.
-  "meta+c": { keysym: XK.c, code: "KeyC", ctrl: true, shift: true, describes: "Copy" },
-  "meta+v": { keysym: XK.v, code: "KeyV", ctrl: true, shift: true, describes: "Paste" },
+  "meta+c": { keysym: XK.C, code: "KeyC", ctrl: true, shift: true, describes: "Copy" },
+  "meta+v": { keysym: XK.V, code: "KeyV", ctrl: true, shift: true, describes: "Paste" },
   // macOS Terminal clears with ⌘K; the Linux equivalent is Ctrl+L.
   "meta+k": { keysym: XK.l, code: "KeyL", ctrl: true, describes: "Clear the screen" },
   // Line movement. On macOS these are ⌘←/→; readline wants Home/End.
@@ -95,8 +103,8 @@ const MAC_CHORDS: Record<string, Chord> = {
  * offered explicitly, with that caveat, rather than enabled quietly.
  */
 export const BROWSER_RESERVED: Record<string, Chord> = {
-  "meta+t": { keysym: XK.t, code: "KeyT", ctrl: true, shift: true, describes: "New terminal tab" },
-  "meta+w": { keysym: XK.w, code: "KeyW", ctrl: true, shift: true, describes: "Close terminal tab" },
+  "meta+t": { keysym: XK.T, code: "KeyT", ctrl: true, shift: true, describes: "New terminal tab" },
+  "meta+w": { keysym: XK.W, code: "KeyW", ctrl: true, shift: true, describes: "Close terminal tab" },
 };
 
 const STORAGE_KEY = "sim.desktopKeymap.enabled";
@@ -272,7 +280,7 @@ class DesktopKeymap {
 
   /** Sends an arbitrary chord — used by the clipboard paste path. */
   sendPasteChord(): void {
-    this.send({ keysym: XK.v, code: "KeyV", ctrl: true, shift: true, describes: "Paste" });
+    this.send({ keysym: XK.V, code: "KeyV", ctrl: true, shift: true, describes: "Paste" });
   }
 
   /** Test-only, mirroring desktopResize.reset. */

--- a/ui/src/screens/Exam.test.tsx
+++ b/ui/src/screens/Exam.test.tsx
@@ -136,9 +136,8 @@ describe("ExamGateControls in an untimed training attempt", () => {
 // suite green while silently turning the clipboard feature off in the app.
 describe("Exam clipboard sync wiring", () => {
   // state: "idle" rather than "running" keeps DesktopViewport (the
-  // Suspense branch that lazy-imports @novnc/novnc) unmounted, the same
-  // route the a11y suite uses to scan QuestionPanel without pulling in
-  // noVNC — see the comment above "exam question panel" in a11y.test.tsx.
+  // Suspense branch that lazy-imports @novnc/novnc) unmounted, so this
+  // test can assert on the mount/unmount effect without noVNC in the mix.
   const idleSession: SessionSnapshot = {
     ...runningSession,
     state: "idle",

--- a/ui/src/screens/Exam.test.tsx
+++ b/ui/src/screens/Exam.test.tsx
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { ExamGateControls } from "./Exam";
+import { Exam, ExamGateControls } from "./Exam";
 import type { SessionSnapshot } from "../api";
+import { clipboardSync } from "../lib/clipboardSync";
 
 const runningSession: SessionSnapshot = {
   state: "running",
@@ -125,5 +126,59 @@ describe("ExamGateControls in an untimed training attempt", () => {
 
     expect(screen.queryByText(/The clock keeps going/)).not.toBeInTheDocument();
     expect(screen.getByText(/no time limit/i)).toBeInTheDocument();
+  });
+});
+
+// Nothing else proves Exam actually calls clipboardSync.start()/stop() on
+// its own mount/unmount — clipboardSync.test.ts locks in the singleton's
+// idempotence, which says nothing about whether Exam wires it up at all.
+// Deleting the effect in Exam.tsx would leave every other test in the
+// suite green while silently turning the clipboard feature off in the app.
+describe("Exam clipboard sync wiring", () => {
+  // state: "idle" rather than "running" keeps DesktopViewport (the
+  // Suspense branch that lazy-imports @novnc/novnc) unmounted, the same
+  // route the a11y suite uses to scan QuestionPanel without pulling in
+  // noVNC — see the comment above "exam question panel" in a11y.test.tsx.
+  const idleSession: SessionSnapshot = {
+    ...runningSession,
+    state: "idle",
+  };
+
+  function stubExamFetch() {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ title: "CKAD Mock Exam 01", questions: [] }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      ),
+    );
+  }
+
+  test("starts clipboard sync on mount and stops it on unmount", async () => {
+    stubExamFetch();
+    const startSpy = vi.spyOn(clipboardSync, "start").mockImplementation(() => {});
+    const stopSpy = vi.spyOn(clipboardSync, "stop").mockImplementation(() => {});
+
+    try {
+      const { unmount } = render(
+        <Exam session={idleSession} fetchedAt={Date.now()} onSessionChange={() => {}} />,
+      );
+
+      // The effect body calls start() synchronously, so render() (which
+      // testing-library wraps in act()) has already flushed it — but
+      // waitFor keeps the assertion honest if that ever stops being true.
+      await vi.waitFor(() => expect(startSpy).toHaveBeenCalledTimes(1));
+      expect(stopSpy).not.toHaveBeenCalled();
+
+      unmount();
+
+      expect(stopSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      startSpy.mockRestore();
+      stopSpy.mockRestore();
+    }
   });
 });

--- a/ui/src/screens/Exam.tsx
+++ b/ui/src/screens/Exam.tsx
@@ -11,6 +11,7 @@ import { ClipboardPanel } from "../components/ClipboardPanel";
 import { CheckList } from "../components/CheckList";
 import { Icon } from "../components/Icon";
 import { desktopKeymap } from "../lib/desktopKeymap";
+import { clipboardSync } from "../lib/clipboardSync";
 import { ExamIntro, introSeen, markIntroSeen } from "../components/ExamIntro";
 import { PanelResizer } from "../components/PanelResizer";
 import { PendingBar } from "../components/Pending";
@@ -179,6 +180,14 @@ export function Exam({ session, fetchedAt, onSessionChange }: ExamProps) {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+  // Clipboard mirroring runs for as long as the exam view is mounted, not
+  // for as long as a viewport is connected: a candidate copies things
+  // before the desktop finishes connecting, and the sync is a no-op until
+  // there is somewhere to send them.
+  useEffect(() => {
+    clipboardSync.start();
+    return () => clipboardSync.stop();
   }, []);
   // First run shows the intro once; after that it is on demand from the
   // About drawer. Marked seen when it opens, not when it closes, so a

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -14,6 +14,13 @@ export default defineConfig({
     // evergreen browsers only.
     target: "es2022",
   },
+  // The same floor, for dependency pre-bundling. esbuild does not inherit
+  // build.target here, and its default predates top-level await — so
+  // @novnc/novnc failed to optimise and `npm run dev` served a blank page
+  // while `npm run build` was fine. The two targets must move together.
+  optimizeDeps: {
+    esbuildOptions: { target: "es2022" },
+  },
   server: {
     proxy: {
       "/api": "http://localhost:8080",


### PR DESCRIPTION
## What this fixes

Copying anything and pasting it in the exam desktop did not work. Three separate defects sat behind that:

1. **Nothing pushed arbitrary clipboard content.** The desktop's clipboard was only ever written by clicking a copy control in the question panel. Question 1 renders eight inline copy buttons and zero code blocks, so there was no way at all to copy its prose — a mouse selection plus ⌘C reached the host clipboard and stopped there.

2. **The synthesized paste chord was malformed.** `sendPasteChord()` sent keysym `0x0076` (lowercase `v`) while holding `Shift_L`. Holding Shift while naming an unshifted keysym is an inconsistent pair, so xfce4-terminal's Ctrl+Shift+V accelerator never matched and the terminal forwarded a plain Ctrl+V instead — which in vim renders as `^`, readline's verbatim-insert prefix. Every `shift: true` chord shared the defect, so ⌘C, ⌘T and ⌘W were broken too.

3. **Any non-ASCII character silently killed the transfer** — found only by testing in a real browser. Nothing pasted, and the UI still reported success. Question 1's prose contains em dashes, so the headline case was exactly the one that broke.

## How it works now

A new `clipboardSync` module singleton owns the window-level listeners and delegates transport to the existing `desktopClipboard`.

**Host → desktop**, two triggers:
- A `copy`/`cut` listener reads the live DOM selection. This needs no clipboard permission in any browser, and it is what makes highlighting question text and pressing ⌘C work.
- A `focus`/`visibilitychange` listener reads `navigator.clipboard.readText()`, covering text copied in other applications. Silent on refusal, since it fires on every tab focus.

**Desktop → host**: the existing remote-clipboard subscription now writes to the host when the document is focused.

**Loop prevention** is the delicate part. `lastSynced` is a watermark moved by both directions; `lastRemote` is edge-triggered and moved only by successful host writes. Both are needed — an earlier version compared the remote *level* against the bidirectional watermark, which silently overwrote the host clipboard with a stale value on every window switch and disabled the other direction entirely.

**Non-ASCII** is transliterated at a single choke point in `desktopClipboard`, so all four push paths inherit it and a future caller cannot bypass it. Lossy by design and only in one direction: the host clipboard still receives the original Unicode.

## Verification

Unit tests cannot reach the RFB boundary, which is why two of the three defects survived a green suite. Verified by hand in Chrome against a running stack:

- Highlight the whole of question 1 (531 chars, 8 lines, em dashes) → ⌘C → right-click Paste in the remote terminal: arrives complete
- ⌘V and Ctrl+V over the desktop: paste, and no longer emit `^`
- Copy in another application, return to the tab, paste: arrives
- Copy in the remote terminal: reaches the host clipboard with no extra click

29 test files, 276 tests. `tsc --noEmit` clean, lint at its one pre-existing warning, `tests/check-lint.sh` 76 checks / 0 errors.

## Also included

- `npm run dev` served a blank page: `build.target` was raised to es2022 for noVNC's top-level await, but esbuild's dependency pre-bundling does not inherit it. Unrelated to the clipboard, found while verifying.
- Four dead keysym table entries removed.
- Three comments and doc sentences that made claims the code did not support.

## Known gap

If the host clipboard moves on and you then re-copy a value the desktop had already sent, `receive()`'s dedupe swallows it and there is no edge to trigger on, so it does not reach the host. Bounded and self-healing — the next distinct copy recovers it. The root cause is that dedupe, which predates this branch; fixing it properly needs a version counter in `desktopClipboard` and carries loop-churn risk, so it is left for a follow-up.

The non-ASCII transliteration is a workaround, not a cure. noVNC's encoder reads as correct, which points at the TigerVNC 1.12 server, but that was not confirmed at the byte level.