### PR TITLE
Docs/troubleshooting and agents

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,4 +12,4 @@ reference solutions score 100%.
 - [ ] I ran `tests/smoke.sh` locally
 - [ ] Not needed — this change cannot affect grading or the environment
 
-See [docs/testing.md](../blob/main/docs/testing.md).
+See [docs/testing.md](https://github.com/Camilool8/kubestronaut-sim/blob/main/docs/testing.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# kubestronaut-sim
+
+A killer.sh-style exam simulator for the Kubestronaut certifications,
+run locally as a Docker Compose stack.
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before changing anything. Its
+"Things that will bite you" and "Rules that are not negotiable"
+sections are the parts that cost an afternoon if skipped, and they are
+not repeated here.
+
+## Commands
+
+`./sim` is the runtime task runner, not a dev task runner. There is no
+Makefile; the commands below are what CI runs
+(`.github/workflows/ci.yml`).
+
+| Task | Command | From |
+|---|---|---|
+| Run the stack | `./sim up` | repo root |
+| Stop it | `./sim down` | repo root |
+| Bank gates | `tests/bank-weights.sh && tests/check-lint.sh && tests/check-lib.sh && tests/bank-hints.sh` | repo root |
+| Go tests | `for m in conductor facilitator proxy; do (cd $m && go test ./... && go vet ./...); done` | repo root |
+| UI tests | `npm ci && npx tsc --noEmit && npm run lint && npm test` | **`ui/`** |
+| Smoke suite | `tests/smoke.sh` | repo root |
+
+The bank gates, the Go tests and the UI tests need no Docker and take
+seconds. Run them before pushing.
+
+`tests/smoke.sh` is the only check that a fresh environment scores 0 and
+the reference solutions score 100%. **CI cannot run it.** Run it by hand
+for any change that could affect grading or the environment.
+
+## Layout
+
+| Path | Contains |
+|---|---|
+| `sim` | The only task runner. Runtime commands, not dev commands |
+| `conductor/` | Go service. Owns the Docker socket; rebuilds the cluster |
+| `facilitator/` | Go service. Sessions, grading, the HTTP API, serves the UI |
+| `proxy/` | Go service. The documentation allowlist, run as `docs-proxy` |
+| `ui/` | React + Vite front end |
+| `images/` | Dockerfiles for the desktop, the instances, and the cluster host |
+| `banks/` | Question banks, the shared validator library, and Helm charts |
+| `tests/` | The four offline gates, the smoke suite, and reference solutions |
+| `docs/` | Reference and explanation. Start at [docs/README.md](docs/README.md) |
+
+## Conventions
+
+- Commit subjects: `type: what changed`, lower case, no trailing period.
+  Types in use: `feat`, `fix`, `docs`, `chore`, `bank`.
+- All user-facing copy belongs in `ui/src/strings.ts`.
+- `docs/history/` is frozen. It is not maintained, and where it
+  disagrees with the code the code is right. Do not update it.
+- Question banks are data with a schema — see
+  [docs/bank-spec.md](docs/bank-spec.md), not doc conventions.
+
+## Gotchas
+
+Full list in [CONTRIBUTING.md](CONTRIBUTING.md#things-that-will-bite-you).
+The three that most often catch an agent:
+
+- **Run every npm command from `ui/`, never the repo root.** From the
+  root, every DOM test dies with `document is not defined`.
+- **Regenerate `ui/package-lock.json` inside `node:22-alpine`**, never
+  with host npm.
+- **Building Go in a container needs `GOFLAGS=-buildvcs=false`.**

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ networks and boot sequence.
 | Document | What it covers |
 |---|---|
 | [docs/cli.md](docs/cli.md) | `./sim` subcommands, environment variables, host ports |
+| [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) | Symptoms and fixes, from preflight to grading |
 | [docs/architecture.md](docs/architecture.md) | Containers, networks, boot sequence, data flow |
 | [docs/api.md](docs/api.md) | HTTP API for the facilitator and conductor |
 | [docs/bank-spec.md](docs/bank-spec.md) | Question bank format and the validator contract |

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,8 @@ pages are for changing the thing.
   non-obvious rules that will otherwise cost you an afternoon.
 - [testing.md](testing.md) — what to run before pushing, what CI
   enforces, and what CI structurally cannot.
+- [TROUBLESHOOTING.md](TROUBLESHOOTING.md) — symptoms and fixes, from
+  the preflight through boot, an attempt, and grading.
 
 ## Looking something up
 
@@ -27,7 +29,9 @@ pages are for changing the thing.
 
 ## Project state
 
-- [follow-ups.md](follow-ups.md) — the open backlog.
+- [follow-ups.md](follow-ups.md) — deliberate divergences from the real
+  exam, accepted trade-offs, and constraints that read like gaps. The
+  open backlog is in GitHub issues.
 - [../PRODUCT.md](../PRODUCT.md) — scope, durable constraints, and what
   is deliberately not built.
 - [../DESIGN.md](../DESIGN.md) — the UI design system.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,79 @@
+# Troubleshooting
+
+Symptoms, in the order they tend to happen: before a boot, during a
+boot, during an attempt, and at grading time.
+
+This page is indexed by what you see. [cli.md](cli.md) is indexed by
+command and explains what each one does — when a row here says "see
+cli.md", the explanation is there rather than repeated.
+
+Collect this first:
+
+```bash
+./sim doctor                    # environment preflight
+./sim status                    # which containers are up
+docker compose logs k8s-env     # the cluster host, where boots fail
+```
+
+## Before a boot
+
+Every row here is something `./sim doctor` reports (`sim:66-99`). Run it
+before a first boot on a new machine; it is cheaper than finding these
+twenty minutes in.
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `docker : NOT REACHABLE` | The Docker daemon is not running, or your user cannot reach its socket | Start Docker Desktop, or add yourself to the `docker` group |
+| `compose : MISSING` | Compose v2 is absent. The v1 `docker-compose` binary is not a substitute | Install the Compose v2 plugin |
+| `python3 : MISSING (./sim up needs it)` | `./sim` reads JSON with `python3` (`sim:11`) | Install `python3`. Without it `up` prints no phase lines and spins until `SIM_BOOT_BUDGET` expires rather than finishing |
+| `RAM to docker : NGB << LOW` | Under 8GB reaches Docker. The XFCE desktop plus a two-node cluster wants ~9GB | Raise the VM memory limit in Docker Desktop's Resources settings |
+| `disk for images : NGB << LOW` | Under 25GB free. The images alone are ~10GB | Free space, or `./sim purge` to drop the volumes of an old install |
+| `warm volumes : none` | Not a fault. It means this is a cold first boot, the slowest path | Expect several minutes. Later boots resume |
+
+## During a boot
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `The environment failed to start:` then an error | `/api/boot` reported `failed` (`sim:53-59`) | Read the printed error, then `docker compose logs k8s-env` for the rest |
+| `Gave up waiting after 3600s.` | The boot budget elapsed. The environment may still be working (`sim:31-37`) | `docker compose logs -f k8s-env` to see whether it is progressing. Raise it with `SIM_BOOT_BUDGET=<seconds> ./sim up` |
+| `up` prints no phase lines and never finishes | `python3` is missing, so every poll yields an empty state | Install `python3`; see the row above |
+| The UI loads but shows boot progress rather than the lobby | Expected. The facilitator answers before the cluster is ready | Wait. The page shows the same phases the terminal does |
+| Boot succeeds, then the next `up` rebuilds from scratch | The volumes were removed — `./sim purge` does this, `./sim down` does not | Use `down` to stop and resume; see [Choosing between down, reset and purge](cli.md#choosing-between-down-reset-and-purge) |
+
+## During an attempt
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Copying in the exam terminal does not reach the host clipboard | Reading the host clipboard and writing the terminal's copy back both need a gesture Firefox will not grant | Use Chrome, or use the Clipboard panel, which covers both in any browser. Press `?` for the shortcut list |
+| A pasted em dash arrives as a hyphen, curly quotes arrive straight | The clipboard channel reduces to ASCII and drops non-ASCII outright | Expected. A hyphen beats losing the paste |
+| A documentation page will not load in the exam Firefox | The proxy allowlist matches by subdomain and has no deny-override, so a site outside the allowlist is blocked | Expected. See [../SECURITY.md](../SECURITY.md) for what the proxy permits |
+| A question needs an image the cluster does not have | Nothing verifies `images/k8s-env/preload.txt` against what the banks reference | Report it. A missing preload entry only surfaces as a question that needs the network |
+| Building an image on an instance is slow and disk-hungry | Podman on the instances runs the `vfs` storage driver, chosen over granting the instances more capabilities | Expected. See [follow-ups.md](follow-ups.md) |
+| An Ingress is rejected on `kubectl apply` | The ingress `ValidatingWebhookConfiguration` is left in place, matching the real exam | Fix the Ingress. The rejection is the intended behaviour |
+| An Ingress or NodePort works from the host but the question still fails | Host publishing is for your convenience. No `validate.d` check may depend on it | Test in-cluster, which is what the graders do (see below) |
+
+## At grading time
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| A check scores 0 and the resource looks correct | Questions are graded on behaviour wherever behaviour is the point, not on the shape of the YAML | Reproduce the grader's test in-cluster before assuming a bug |
+| `Reset failed: <error>` | The conductor's reset job did not settle cleanly (`sim:101-115`) | Read the error, then `docker compose logs conductor`. `./sim purge && ./sim up` is the fallback |
+| You want a score without ending the attempt | `./sim grade` runs the session-free scoreboard | It records no result and touches no session state. See [cli.md](cli.md) |
+
+Test the way the graders do — from inside the cluster, not from the
+host:
+
+```bash
+kubectl -n <ns> run tmp --rm -it --restart=Never --image=nginx:alpine -- curl -m 5 <svc>
+```
+
+## Nothing here matches
+
+`./sim purge && ./sim up` rebuilds from nothing. It destroys all eight
+volumes, including any in-progress attempt — see
+[cli.md](cli.md#choosing-between-down-reset-and-purge) for what each
+command removes.
+
+If the failure is in the simulator rather than your environment, open an
+issue with the `./sim doctor` output and the relevant
+`docker compose logs`.


### PR DESCRIPTION
## What this changes

<!-- One or two sentences. The diff shows how; say why. -->

## Verification

CI runs the four bank gates, the Go tests, the UI suite, the image
builds and a shell syntax pass. It cannot run `tests/smoke.sh`, which is
the only thing that checks a fresh environment scores 0 and the
reference solutions score 100%.

- [ ] I ran `tests/smoke.sh` locally
- [ ] Not needed — this change cannot affect grading or the environment

See [docs/testing.md](../blob/main/docs/testing.md).
