### PR TITLE
A hosted tier: the exam stack as one Pod, and a hub that hands them out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        module: [facilitator, conductor, proxy]
+        module: [facilitator, conductor, proxy, hub]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
@@ -121,6 +121,17 @@ jobs:
       # booting, which is smoke.sh's job.
       - name: k8s-env
         run: docker build --build-arg PRELOAD=none -t sim-k8s-env images/k8s-env
+      # bootstrap.sh does not only run from PID 1: a hosted reset re-runs
+      # it over ssh (ENGINE=ssh), and an sshd session inherits none of the
+      # image's ENV. That aborted the rebuild at `set -u` with
+      # "NODE_IMAGE: unbound variable" — after it had already deleted the
+      # cluster, so the session was left with none. `env -i` reproduces
+      # exactly that empty environment.
+      - name: NODE_IMAGE resolves with no environment at all
+        run: |
+          docker run --rm --entrypoint env sim-k8s-env -i sh -c \
+            'NODE_IMAGE="${NODE_IMAGE:-$(cat /opt/sim/node-image)}"; \
+             test -n "$NODE_IMAGE" && echo "resolved to $NODE_IMAGE"'
       - name: instance
         run: docker build -t sim-instance images/instance
       - name: desktop
@@ -131,8 +142,82 @@ jobs:
         run: docker build -t sim-conductor conductor
       - name: docs-proxy
         run: docker build -t sim-proxy proxy
+      # Context is banks/, not the repo root: the root .dockerignore
+      # excludes banks/ so it stays out of the facilitator's context.
+      - name: banks
+        run: docker build -f images/banks/Dockerfile -t sim-banks banks
+      - name: hub
+        run: docker build -t sim-hub hub
+      # FROM scratch: there is no shell to check the image with, and a
+      # broken binary in one would otherwise only surface at deploy time.
+      - name: hub refuses to start misconfigured
+        run: |
+          out=$(docker run --rm -e AUTH_MODE=github sim-hub 2>&1) && {
+            echo "hub started with no GitHub credentials; it must not" >&2; exit 1
+          }
+          echo "$out" | grep -q GITHUB_CLIENT_ID
       - name: Compose config is valid
         run: docker compose config -q
+      # The hosted session Pod is not built from these, but a typo in it
+      # would only surface at deploy time. This parses it and checks the
+      # image names line up with the Dockerfiles above.
+      - name: Session pod manifest is valid YAML
+        run: |
+          python3 - <<'PY'
+          import sys, re
+          src = open('deploy/session-pod.yaml').read()
+          # Stdlib only: no PyYAML on the runner by default, and the
+          # checks worth having here are structural, not schema-deep.
+          for probe in ('hostAliases:', 'initContainers:', 'containers:', 'volumes:'):
+              if probe not in src:
+                  sys.exit(f'session-pod.yaml: missing {probe}')
+          names = set(re.findall(r'image: cjoga/kubestronaut-sim-([a-z0-9-]+):', src))
+          expected = {'banks', 'k8s-env', 'instance', 'desktop', 'facilitator', 'conductor', 'docs-proxy'}
+          if names != expected:
+              sys.exit(f'session-pod.yaml images {sorted(names)} != {sorted(expected)}')
+          # A mutable tag with the default pull policy silently serves a
+          # stale image; every first-party image must opt out.
+          if src.count('imagePullPolicy: Always') - src.count('# imagePullPolicy: Always') != len(re.findall(r'image: cjoga/', src)):
+              sys.exit('session-pod.yaml: every cjoga/ image needs imagePullPolicy: Always')
+          # Pod containers share a UTS namespace, so an instance that does
+          # not name itself shows the candidate the same prompt they typed
+          # `ssh instance-1` at, with no way to tell it worked.
+          for want in ('instance-1', 'instance-2'):
+              if 'SIM_HOSTNAME, value: "%s"' % want not in src:
+                  sys.exit('session-pod.yaml: %s has no SIM_HOSTNAME' % want)
+          # A practical session is a privileged container holding a root
+          # shell for a stranger. Its egress boundary is not optional, and
+          # it is not part of the Pod spec, so assert it exists and still
+          # denies every private range rather than trusting it shipped.
+          np = open('deploy/session-networkpolicy.yaml').read()
+          for cidr in ('10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16',
+                       '100.64.0.0/10', '169.254.0.0/16'):
+              if cidr not in np:
+                  sys.exit('session-networkpolicy.yaml: %s is not denied' % cidr)
+
+          # The MCQ flavour. Its whole reason to exist is being small and
+          # unprivileged, so those are what is asserted: no cluster, no
+          # shells, no privilege.
+          #
+          # Comments are stripped first. Every one of these manifests
+          # explains itself at length, and a check that reads the prose
+          # fails on a file that says "no desktop container exists here"
+          # — which is the file being correct, described correctly.
+          raw = open('deploy/session-pod-mcq.yaml').read()
+          mcq = '\n'.join(re.sub(r'(^|\s)#.*$', '', line) for line in raw.splitlines())
+          if 'privileged: true' in mcq:
+              sys.exit('session-pod-mcq.yaml: an MCQ session must not be privileged')
+          for forbidden in ('name: k8s-env', 'name: instance-1', 'name: desktop', 'image: registry:2'):
+              if forbidden in mcq:
+                  sys.exit('session-pod-mcq.yaml: %s does not belong in an MCQ session' % forbidden)
+          # /shared/ready is the authority on readiness for every service
+          # in the stack. Nothing boots here, so if the init container
+          # stops writing it the facilitator serves a permanent boot
+          # screen over a session that was ready before it started.
+          if '/shared/ready' not in mcq:
+              sys.exit('session-pod-mcq.yaml: nothing writes /shared/ready')
+          print('session-pod.yaml + session-pod-mcq.yaml + session-networkpolicy.yaml ok')
+          PY
 
   shell:
     name: Shell syntax
@@ -151,3 +236,28 @@ jobs:
             bash -n "$f" || { echo "syntax error: $f"; fail=1; }
           done
           exit $fail
+      # /shared is a handoff between containers, and `>` truncates the
+      # destination before it writes it — so a reader polling for the file
+      # can open one that exists, is empty, and is about to be filled.
+      #
+      # Compose makes that window unreachable (every consumer declares
+      # depends_on k8s-env: service_healthy, so nothing reads while this
+      # writes) which is why it survived this long. A Pod has no
+      # depends_on and starts all eight containers at once: a session
+      # booted with instance-1 holding a 5574-byte kubeconfig and
+      # instance-2 holding a 0-byte one, whose kubectl then fell back to
+      # its localhost:8080 default — the facilitator — and failed every
+      # command. Eleven of the bank's twenty-two questions are graded on
+      # instance-2, so half the exam was unscoreable and nothing said so.
+      #
+      # Writers use write_shared() in bootstrap.sh, or the temp+mv that
+      # phase.sh has always used for boot.json. Both rename into place,
+      # and rename is atomic.
+      - name: Writes into /shared are atomic
+        run: |
+          if grep -rnE '>>?[[:space:]]*/shared/' images/ proxy/; then
+            echo "^^ writes into /shared must rename into place, not truncate."
+            echo "   use write_shared (images/k8s-env/bootstrap.sh) or temp+mv."
+            exit 1
+          fi
+          echo "no truncating writes into /shared"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,23 @@ jobs:
           # screen over a session that was ready before it started.
           if '/shared/ready' not in mcq:
               sys.exit('session-pod-mcq.yaml: nothing writes /shared/ready')
+
+          # The conductor's control API resets clusters and switches
+          # banks. Compose keeps it off the exam network entirely; a Pod
+          # is one network namespace, so a TCP port would sit on the
+          # candidate's own loopback and a shell on an instance could
+          # drive it. The socket is the replacement boundary, and the
+          # boundary is the MOUNT — exactly two containers may hold it.
+          plain = '\n'.join(re.sub(r'(^|\s)#.*$', '', line) for line in src.splitlines())
+          sock = 'unix:/run/control/conductor.sock'
+          for name, text in (('session-pod.yaml', plain), ('session-pod-mcq.yaml', mcq)):
+              for var in ('LISTEN', 'CONDUCTOR_ADDR'):
+                  if '%s, value: "%s"' % (var, sock) not in text:
+                      sys.exit('%s: %s must be %s' % (name, var, sock))
+              if ':9000' in text:
+                  sys.exit('%s: the conductor must not listen on TCP in a Pod' % name)
+              if text.count('mountPath: /run/control') != 2:
+                  sys.exit('%s: exactly two containers may mount the control socket' % name)
           print('session-pod.yaml + session-pod-mcq.yaml + session-networkpolicy.yaml ok')
           PY
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,126 @@ jobs:
       - name: Test
         run: npm test
 
+  # The chart is the only place the Pod manifests and the hub meet, and
+  # they meet as bytes: helm renders YAML into JSON, the hub parses that
+  # JSON and stamps out a Pod. Checking each half alone proves nothing
+  # about the join — a manifest that stops declaring an env var the hub
+  # must fill renders perfectly and fails at the first candidate.
+  chart:
+    name: Helm chart
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.16.3
+      - uses: actions/setup-go@v7
+        with:
+          go-version: "1.24"
+          cache-dependency-path: hub/go.mod
+
+      - name: Lint
+        run: |
+          helm lint deploy/helm/kubestronaut-sim \
+            --set hub.baseURL=https://sim.invalid --set hub.existingSecret=hub
+
+      # Every one of these is a deployment that cannot work, and the
+      # chart's job is to say so before anything is applied rather than
+      # leave a CrashLoopBackOff where a working hub used to be.
+      - name: Refuses a deployment it cannot make work
+        run: |
+          fails() {
+            desc="$1"; shift
+            if out=$(helm template sim deploy/helm/kubestronaut-sim -n ks "$@" 2>&1); then
+              echo "should have been refused: $desc" >&2
+              exit 1
+            fi
+            echo "refused ($desc): $(echo "$out" | head -1)"
+          }
+          fails "github mode with no credentials" --set hub.baseURL=https://sim.invalid
+          fails "github mode with no base URL"    --set hub.existingSecret=hub
+          fails "an auth mode that does not exist" \
+            --set hub.existingSecret=hub --set hub.auth.mode=oidc
+          fails "an HTTPRoute attached to no Gateway" \
+            --set hub.existingSecret=hub --set hub.baseURL=https://sim.invalid \
+            --set httpRoute.enabled=true
+
+      - name: Render
+        run: |
+          helm template sim deploy/helm/kubestronaut-sim -n kubestronaut-sim \
+            --set hub.baseURL=https://sim.invalid --set hub.existingSecret=hub \
+            --show-only templates/configmap-session-pods.yaml > /tmp/cm.yaml
+
+      # What the chart is responsible for, as opposed to what the
+      # manifests are: that every first-party image was rewritten to the
+      # configured registry and tag, that no container was lost on the
+      # way through, and that privilege did not spread.
+      - name: The rendered Pods are the manifests, with the images moved
+        run: |
+          mkdir -p /tmp/rendered
+          python3 - <<'PY'
+          import json, re, sys
+          # No PyYAML on the runner, and none is needed: toJson emits one
+          # line per key, so the ConfigMap is read by indentation.
+          docs, key = {}, None
+          for line in open('/tmp/cm.yaml'):
+              line = line.rstrip('\n')
+              m = re.match(r'^  ([A-Za-z0-9._-]+\.json): \|\s*$', line)
+              if m:
+                  key = m.group(1); docs[key] = []; continue
+              if key is None:
+                  continue
+              if line.startswith('    '):
+                  docs[key].append(line[4:])
+              elif line.strip():
+                  key = None
+          # From Chart.yaml, so a version bump is one edit and not two.
+          tag = re.search(r'^appVersion:\s*"?([^"\s]+)"?',
+                          open('deploy/helm/kubestronaut-sim/Chart.yaml').read(),
+                          re.M).group(1)
+          want = {'session-pod.json': (1, 8, 1), 'session-pod-mcq.json': (1, 2, 0)}
+          if set(docs) != set(want):
+              sys.exit(f'rendered {sorted(docs)}, want {sorted(want)}')
+          for name, (inits, containers, privileged) in want.items():
+              pod = json.loads('\n'.join(docs[name]))
+              open('/tmp/rendered/' + name, 'w').write(json.dumps(pod))
+              if pod['kind'] != 'Pod':
+                  sys.exit(f'{name}: rendered a {pod["kind"]}')
+              # The API server rejects a create whose body names a
+              # different namespace from the URL, and defaults an empty
+              # one silently — which is worse.
+              if not pod['metadata'].get('namespace'):
+                  sys.exit(f'{name}: no namespace')
+              got = (len(pod['spec'].get('initContainers', [])), len(pod['spec']['containers']))
+              if got != (inits, containers):
+                  sys.exit(f'{name}: {got[0]} init + {got[1]} containers, want {inits} + {containers}')
+              priv = [c['name'] for c in pod['spec']['containers']
+                      if c.get('securityContext', {}).get('privileged')]
+              if len(priv) != privileged:
+                  sys.exit(f'{name}: privileged containers {priv}, want {privileged}')
+              if privileged and priv != ['k8s-env']:
+                  sys.exit(f'{name}: {priv} is privileged, only k8s-env may be')
+              for c in pod['spec'].get('initContainers', []) + pod['spec']['containers']:
+                  first_party = c['image'].startswith('docker.io/cjoga/kubestronaut-sim-')
+                  if first_party and not c['image'].endswith(':' + tag):
+                      sys.exit(f'{name}: {c["name"]} is on {c["image"]}, not the chart appVersion')
+                  # An upstream pinned tag is not the chart's to move.
+                  if c['image'] == 'registry:2':
+                      continue
+                  if not first_party:
+                      sys.exit(f'{name}: {c["name"]} image {c["image"]} was not rewritten')
+              print(f'{name}: {inits} init + {containers} containers, images rewritten')
+          PY
+
+      # The join. render() is the hub's, the JSON is the chart's, and
+      # this is the only thing that runs one against the other.
+      - name: The hub can stamp out what the chart renders
+        working-directory: hub
+        env:
+          GOFLAGS: -buildvcs=false
+          SESSION_POD_JSON: /tmp/rendered/session-pod.json:/tmp/rendered/session-pod-mcq.json
+        run: go test ./internal/session/ -run TestTheChart -v
+
   images:
     name: Images build
     runs-on: ubuntu-latest
@@ -165,7 +285,7 @@ jobs:
         run: |
           python3 - <<'PY'
           import sys, re
-          src = open('deploy/session-pod.yaml').read()
+          src = open('deploy/helm/kubestronaut-sim/files/session-pod.yaml').read()
           # Stdlib only: no PyYAML on the runner by default, and the
           # checks worth having here are structural, not schema-deep.
           for probe in ('hostAliases:', 'initContainers:', 'containers:', 'volumes:'):
@@ -189,11 +309,11 @@ jobs:
           # shell for a stranger. Its egress boundary is not optional, and
           # it is not part of the Pod spec, so assert it exists and still
           # denies every private range rather than trusting it shipped.
-          np = open('deploy/session-networkpolicy.yaml').read()
+          np = open('deploy/helm/kubestronaut-sim/templates/networkpolicy.yaml').read()
           for cidr in ('10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16',
                        '100.64.0.0/10', '169.254.0.0/16'):
               if cidr not in np:
-                  sys.exit('session-networkpolicy.yaml: %s is not denied' % cidr)
+                  sys.exit('networkpolicy.yaml: %s is not denied' % cidr)
 
           # The MCQ flavour. Its whole reason to exist is being small and
           # unprivileged, so those are what is asserted: no cluster, no
@@ -203,7 +323,7 @@ jobs:
           # explains itself at length, and a check that reads the prose
           # fails on a file that says "no desktop container exists here"
           # — which is the file being correct, described correctly.
-          raw = open('deploy/session-pod-mcq.yaml').read()
+          raw = open('deploy/helm/kubestronaut-sim/files/session-pod-mcq.yaml').read()
           mcq = '\n'.join(re.sub(r'(^|\s)#.*$', '', line) for line in raw.splitlines())
           if 'privileged: true' in mcq:
               sys.exit('session-pod-mcq.yaml: an MCQ session must not be privileged')
@@ -245,7 +365,7 @@ jobs:
           # through a CDN is closed out from under the candidate.
           if '--heartbeat' not in open('images/desktop/entrypoint.sh').read():
               sys.exit('images/desktop/entrypoint.sh: websockify needs --heartbeat or a hosted desktop drops when idle')
-          print('session-pod.yaml + session-pod-mcq.yaml + session-networkpolicy.yaml ok')
+          print('session-pod.yaml + session-pod-mcq.yaml + networkpolicy.yaml ok')
           PY
 
   shell:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,18 @@ jobs:
                   sys.exit('%s: the conductor must not listen on TCP in a Pod' % name)
               if text.count('mountPath: /run/control') != 2:
                   sys.exit('%s: exactly two containers may mount the control socket' % name)
+              # The hub fills these per session, and can only fill an env
+              # var the manifest already declares. Without them a hosted
+              # attempt is graded, shown, and then lost with the Pod —
+              # which the candidate discovers the next day.
+              for var in ('HISTORY_WEBHOOK_URL', 'HISTORY_WEBHOOK_TOKEN'):
+                  if '%s, value: ""' % var not in text:
+                      sys.exit('%s: the facilitator must declare an empty %s' % (name, var))
+
+          # A still VNC screen sends nothing, and an idle WebSocket
+          # through a CDN is closed out from under the candidate.
+          if '--heartbeat' not in open('images/desktop/entrypoint.sh').read():
+              sys.exit('images/desktop/entrypoint.sh: websockify needs --heartbeat or a hosted desktop drops when idle')
           print('session-pod.yaml + session-pod-mcq.yaml + session-networkpolicy.yaml ok')
           PY
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
-# Publishes the seven images a hosted session is built from.
+# Publishes the seven images a hosted session is built from, and the hub
+# that hands sessions out. Eight in all; the hub is not part of a session,
+# which is why the coverage job below has to check for it separately.
 #
 # Until this existed the only copies on Docker Hub were `:dev` tags pushed
 # by hand from a laptop — cross-compiled to linux/amd64 through emulation,
@@ -39,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       # One image per runner, so k8s-env's 2.6 GB has a disk to itself and
-      # a single failure still tells you about the other six.
+      # a single failure still tells you about the other seven.
       fail-fast: false
       matrix:
         include:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,8 @@ jobs:
           wf = open('.github/workflows/release.yml').read()
           have = set(re.findall(r'- image: ([a-z0-9-]+)\n', wf))
           need = set()
-          for manifest in ('deploy/session-pod.yaml', 'deploy/session-pod-mcq.yaml'):
+          for manifest in ('deploy/helm/kubestronaut-sim/files/session-pod.yaml',
+                           'deploy/helm/kubestronaut-sim/files/session-pod-mcq.yaml'):
               need |= set(re.findall(r'image: cjoga/kubestronaut-sim-([a-z0-9-]+):', open(manifest).read()))
           missing = need - have
           if missing:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,205 @@
+# Publishes the seven images a hosted session is built from.
+#
+# Until this existed the only copies on Docker Hub were `:dev` tags pushed
+# by hand from a laptop — cross-compiled to linux/amd64 through emulation,
+# untraceable to a commit, and overwritten by whoever pushed last. A hub
+# that creates session Pods cannot depend on that.
+#
+# Deliberately NOT on every push: these are ~4.5 GB in total and nothing
+# consumes them until a session is deployed. Tags only.
+#
+# Single-architecture (linux/amd64) on purpose. The runner is already
+# amd64, so every build here is native; the only consumer is the cluster,
+# which is amd64 too. Adding arm64 would mean QEMU emulation of a
+# 2.6 GB image build for nobody. Local development on an arm64 Mac keeps
+# building its own images, which is what `./sim up` has always done.
+name: Release images
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Version to publish, e.g. v0.3.0"
+        required: true
+
+permissions:
+  contents: read
+
+# Two releases of the same tag racing would leave whichever finished last
+# on `:latest`, with no way to tell from the outside which one that was.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    strategy:
+      # One image per runner, so k8s-env's 2.6 GB has a disk to itself and
+      # a single failure still tells you about the other six.
+      fail-fast: false
+      matrix:
+        include:
+          - image: banks
+            context: banks
+            file: images/banks/Dockerfile
+          - image: k8s-env
+            context: images/k8s-env
+            file: images/k8s-env/Dockerfile
+            # The whole point of a released k8s-env. CI builds it with
+            # PRELOAD=none to check the Dockerfile still parses; a
+            # published one bakes the node image and the workload images
+            # the banks pull, which is what makes a cold session boot in
+            # minutes instead of downloading ~1 GB inside the cluster.
+            build_args: PRELOAD=full
+          - image: instance
+            context: images/instance
+            file: images/instance/Dockerfile
+          - image: desktop
+            context: images/desktop
+            file: images/desktop/Dockerfile
+          - image: facilitator
+            context: .
+            file: facilitator/Dockerfile
+          - image: conductor
+            context: conductor
+            file: conductor/Dockerfile
+          # Context is banks/ for the banks image and proxy/ here: the
+          # root .dockerignore excludes banks/ so it stays out of the
+          # facilitator's context.
+          - image: docs-proxy
+            context: proxy
+            file: proxy/Dockerfile
+          # Not a session container: the hub runs once per deployment, in
+          # front of every session Pod. It is published here because it
+          # ships from this repo and versions with the images it starts —
+          # the pod template it renders is this repo's manifest.
+          - image: hub
+            context: hub
+            file: hub/Dockerfile
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Resolve the version
+        id: v
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          version="${INPUT_TAG:-$GITHUB_REF_NAME}"
+          # A tag typo would otherwise publish `:main` or `:v` to the
+          # world and move `:latest` onto it.
+          case "$version" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *) echo "refusing to publish '$version': expected vMAJOR.MINOR.PATCH" >&2; exit 1 ;;
+          esac
+          echo "version=$version" >>"$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          if [ -z "${DOCKERHUB_TOKEN:-}" ] || [ -z "${DOCKERHUB_USERNAME:-}" ]; then
+            echo "DOCKERHUB_USERNAME and DOCKERHUB_TOKEN must be set as repository secrets" >&2
+            exit 1
+          fi
+          printf '%s' "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+
+      - name: Build
+        env:
+          REPO: cjoga/kubestronaut-sim-${{ matrix.image }}
+          VERSION: ${{ steps.v.outputs.version }}
+          BUILD_ARGS: ${{ matrix.build_args }}
+          CONTEXT: ${{ matrix.context }}
+          FILE: ${{ matrix.file }}
+        run: |
+          # An `if`, not `[ -n ... ] && extra=(...)`: the latter works only
+          # because a failing non-final command in an AND-list is exempt
+          # from `set -e`, which stops being true the moment anyone moves
+          # this to the end of the step.
+          extra=()
+          if [ -n "${BUILD_ARGS:-}" ]; then
+            extra=(--build-arg "$BUILD_ARGS")
+          fi
+          docker build "${extra[@]}" \
+            -f "$FILE" \
+            --label "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}" \
+            --label "org.opencontainers.image.revision=${GITHUB_SHA}" \
+            --label "org.opencontainers.image.version=${VERSION}" \
+            -t "$REPO:$VERSION" \
+            -t "$REPO:latest" \
+            "$CONTEXT"
+
+      # Ties this image to the fix that made a hosted reset survive being
+      # re-run over ssh: NODE_IMAGE is baked as a file because an sshd
+      # session inherits none of the image's ENV. A published k8s-env
+      # without it would abort the rebuild at `set -u`, having already
+      # deleted the cluster.
+      - name: k8s-env carries its node-image constant
+        if: matrix.image == 'k8s-env'
+        env:
+          REPO: cjoga/kubestronaut-sim-${{ matrix.image }}
+          VERSION: ${{ steps.v.outputs.version }}
+        run: |
+          docker run --rm --entrypoint env "$REPO:$VERSION" -i sh -c \
+            'NODE_IMAGE="${NODE_IMAGE:-$(cat /opt/sim/node-image)}"; \
+             test -n "$NODE_IMAGE" && echo "resolves with no environment: $NODE_IMAGE"'
+
+      # The hub image is FROM scratch, so a missing binary or a bad
+      # linker flag produces an image that cannot even fail usefully.
+      # Starting it misconfigured proves both that the binary runs and
+      # that it refuses to serve a login it could never complete.
+      - name: hub starts and refuses to run misconfigured
+        if: matrix.image == 'hub'
+        env:
+          REPO: cjoga/kubestronaut-sim-${{ matrix.image }}
+          VERSION: ${{ steps.v.outputs.version }}
+        run: |
+          out=$(docker run --rm -e AUTH_MODE=github "$REPO:$VERSION" 2>&1) && {
+            echo "hub started with no GitHub credentials; it must not" >&2; exit 1
+          }
+          echo "$out"
+          echo "$out" | grep -q GITHUB_CLIENT_ID
+
+      - name: Push
+        env:
+          REPO: cjoga/kubestronaut-sim-${{ matrix.image }}
+          VERSION: ${{ steps.v.outputs.version }}
+        run: |
+          docker push "$REPO:$VERSION"
+          docker push "$REPO:latest"
+          # The digest is the only thing that identifies what shipped once
+          # `:latest` has moved on. Printed so a deployment can pin it.
+          docker image inspect "$REPO:$VERSION" \
+            --format 'published {{index .RepoDigests 0}} ({{.Architecture}}/{{.Os}}, {{.Size}} bytes)'
+
+  # A session Pod that references an image this workflow does not build
+  # fails at deploy time with ImagePullBackOff and no explanation. The
+  # eighth container, registry:2, is upstream and deliberately absent.
+  coverage:
+    name: Every Pod image is published here
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: |
+          python3 - <<'PY'
+          import re, sys
+          wf = open('.github/workflows/release.yml').read()
+          have = set(re.findall(r'- image: ([a-z0-9-]+)\n', wf))
+          need = set()
+          for manifest in ('deploy/session-pod.yaml', 'deploy/session-pod-mcq.yaml'):
+              need |= set(re.findall(r'image: cjoga/kubestronaut-sim-([a-z0-9-]+):', open(manifest).read()))
+          missing = need - have
+          if missing:
+              sys.exit(f'release.yml does not publish: {sorted(missing)}')
+          # The hub is not in either manifest — it runs in front of them —
+          # so it would never be caught by the check above, and a release
+          # that publishes every session image and not the thing that
+          # starts them is a release that cannot be deployed.
+          if 'hub' not in have:
+              sys.exit('release.yml does not publish the hub')
+          print(f'publishes all {len(need)} Pod images plus the hub: {sorted(need)}')
+          PY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Makefile; the commands below are what CI runs
 | Stop it | `./sim down` | repo root |
 | Bank gates | `tests/bank-weights.sh && tests/check-lint.sh && tests/check-lib.sh && tests/bank-hints.sh && tests/bank-mcq.sh` | repo root |
 | Landing page | `site/build.sh --check` | repo root |
-| Go tests | `for m in conductor facilitator proxy; do (cd $m && go test ./... && go vet ./...); done` | repo root |
+| Go tests | `for m in conductor facilitator proxy hub; do (cd $m && go test ./... && go vet ./...); done` | repo root |
 | UI tests | `npm ci && npx tsc --noEmit && npm run lint && npm test` | **`ui/`** |
 | Smoke suite | `tests/smoke.sh` | repo root |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ take seconds:
 ```bash
 tests/bank-weights.sh && tests/check-lint.sh && tests/check-lib.sh \
   && tests/bank-hints.sh && tests/bank-mcq.sh
-for m in conductor facilitator proxy; do (cd $m && go test ./... && go vet ./...); done
+for m in conductor facilitator proxy hub; do (cd $m && go test ./... && go vet ./...); done
 (cd ui && npm ci && npx tsc --noEmit && npm run lint && npm test)
 ```
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -127,9 +127,13 @@ The parts that constrain product decisions:
 
 **Durable constraints**
 
-- **No authentication anywhere, permanently.** This is a local
-  single-user tool; a password field would be theatre. The only real
-  control is which interface it binds to.
+- **No authentication anywhere in the simulator, permanently.** `./sim
+  up` is a local single-user tool; a password field would be theatre,
+  and the only real control is which interface it binds to. This
+  survived the hosted tier rather than being weakened by it: the hub is
+  a separate process in front of the facilitator, which still has no
+  authentication of any kind and is simply never reachable except
+  through it. See [docs/hosting.md](docs/hosting.md).
 - The session-state gates on desktop access and the solutions endpoint
   exist for UX fidelity, not security. Training mode deliberately
   relaxes the solutions gate, because reading the solution is the point
@@ -147,9 +151,13 @@ The parts that constrain product decisions:
     domain-filtered or short draw is kept and shown, but cannot set a
     best score or claim a pass: 100% on a ten-task drill of one domain
     is a good session and is not a CKAD pass.
-  - It stays on the candidate's machine. Nothing is uploaded, and the
-    only ways it leaves are the export the candidate asks for and the
-    delete they confirm.
+  - Run locally it stays on the candidate's machine. Nothing is
+    uploaded, and the only ways it leaves are the export the candidate
+    asks for and the delete they confirm. In a hosted session it is
+    additionally posted to the deployment that is hosting it, because
+    the environment is destroyed on purpose and that copy is the one the
+    candidate still has tomorrow — the local behaviour is unchanged and
+    is the stricter of the two.
 - The timer is server-side. In Exam mode it cannot be paused.
 - The exam requires a desktop-sized screen. Small screens get an
   explanation instead of a broken layout.
@@ -164,13 +172,27 @@ The parts that constrain product decisions:
   attempt, for someone who wants the pressure of a countdown at a pace
   they set. Training mode already covers the untimed case.
 
-**Explicitly out of scope**
+**Hosted, with limits**
 
-- Hosting, accounts, and multi-user separation. Local single-user is the
-  permanent model, so notes elsewhere of the form "needs auth once
-  hosted" describe a scenario that is not planned.
-- Running this somewhere shared or persistent. Nothing in it assumes an
-  adversary.
+Overturned deliberately. "Hosting, accounts and multi-user separation
+are out of scope" was a durable constraint until the hardware most
+people have made it the wrong one: a 9GB, forty-minute first boot is a
+real barrier to trying this at all. There is now a hosted tier, and the
+shape of it is what kept the constraint above true.
+
+- **The hosted tier is capped and the local one is the reference.**
+  A hosted session is a try-it-out: a handful of concurrent hands-on
+  seats, an idle timeout, and a hard cap on how long one lasts. Local is
+  uncapped, has no accounts, and needs no configuration. Anyone who
+  wants the uncapped one clones this.
+- **The simulator did not change to make it possible.** Identity, seats
+  and history live in `hub/`, a separate module that sits in front. The
+  facilitator gained one optional webhook, off unless configured.
+- **A third party can host it too**, with their own limits and their own
+  identity — the chart takes an auth mode that trusts a proxy they
+  already run. That is why the caps are values rather than constants.
+- Still out of scope: anything that would make the local product assume
+  an adversary. Nothing in `./sim up` does.
 
 ## Brand Commitments
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ for the full command and configuration reference.
 >
 > See [SECURITY.md](SECURITY.md) for what is and is not defended.
 
+## Running it for other people
+
+`./sim up` is the reference and it is uncapped. If you want to put it in
+front of a group — or in front of the internet — there is a Helm chart
+in [`deploy/helm/`](deploy/helm/kubestronaut-sim) that deploys a front
+door: sign-in, a capped pool of concurrent sessions with a queue, and
+attempt history kept per user that outlives the environment it was made
+in. Each candidate gets the whole eight-container stack as one Pod.
+
+The simulator itself does not change to make that work — the front door
+is a separate process in front of it — so nothing above is affected.
+Read [docs/hosting.md](docs/hosting.md) before you deploy one: a
+hands-on session runs a privileged container, and the nodes it runs on
+should be ones you are willing to rebuild.
+
 ## What the exam feels like
 
 1. **Exams** — every certification on the Kubestronaut path, with each
@@ -123,6 +138,7 @@ networks and boot sequence.
 | [docs/api.md](docs/api.md) | HTTP API for the facilitator and conductor |
 | [docs/bank-spec.md](docs/bank-spec.md) | Question bank format and the validator contract |
 | [docs/testing.md](docs/testing.md) | What CI enforces, and what only the smoke suite does |
+| [docs/hosting.md](docs/hosting.md) | The chart, its values, and what hosted mode does differently |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Building, testing, and submitting changes |
 | [SECURITY.md](SECURITY.md) | Threat model and the boundaries that exist |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,6 +10,14 @@ There is no account system, no multi-user separation, and no attempt to
 stop the person at the keyboard from doing anything — they own the
 machine already.
 
+**This document is about `./sim up`,** which is what almost every copy
+of this is. A hosted deployment puts a different process in front of the
+same simulator and has a genuinely different threat model — a stranger
+at one end and a privileged container at the other. That is
+[docs/hosting.md](docs/hosting.md), and the short version is at the
+bottom of this page. Everything between here and there describes the
+local tool and is unchanged by it.
+
 **Not defended, by design:**
 
 - the candidate against themselves — you can read every answer off disk
@@ -126,9 +134,50 @@ deny-override, so permitting `kubernetes.io` necessarily permits
 The instances, unlike the desktop, do have direct internet access.
 `podman build` needs it to resolve short image names against Docker Hub.
 
+## Hosted deployments
+
+Everything above describes `./sim up`. A hosted deployment — this
+repository's `hub/` in front of session Pods, deployed with the chart in
+`deploy/helm/` — inverts the assumption the rest of this page rests on:
+the person at the keyboard is a stranger, and the thing they are handed
+is still a privileged container with a root shell in it.
+
+What that changes, in full:
+
+- **A practical session is privileged and that is not fixable.** It runs
+  a container runtime and builds a real cluster inside itself. User
+  namespaces are explicitly incompatible with `privileged`, and the
+  sandboxed runtimes either cannot host a nested runtime or need nested
+  virtualization. So the containment is placement, not isolation: run
+  these on nodes you are willing to rebuild, and on nothing else.
+- **A NetworkPolicy is part of the deployment, not an option.** It
+  denies a session every private range — the cluster's own API and
+  Services, other namespaces, the nodes, and the link-local range cloud
+  metadata answers on. The chart installs it by default. Without it a
+  session reaches the API server of the cluster hosting it.
+- **The documentation allowlist stops being a network boundary.** A Pod
+  is one network namespace and a NetworkPolicy selects Pods, not
+  containers, so the desktop and the candidate's shells share one egress
+  — and the shells need theirs, because a question builds an image from
+  Docker Hub. The allowlist still governs the browser. Local behaviour
+  is unchanged and is the stricter of the two.
+- **One candidate cannot reach another.** Each session is its own Pod,
+  addressed by the hub from the cookie it verified, and history is
+  stored per user with the attempt id scoped to the owner's directory.
+- **The one credential is `COOKIE_KEY`.** It signs login cookies and,
+  under a derived key, the per-Pod ticket a session presents to record
+  an attempt. Derived so that a ticket read out of a Pod spec can never
+  be spent as that candidate's login.
+
+The MCQ flavour has none of this: no cluster, no shell, no privilege.
+
 ## Reporting
 
-There is no security contact and no coordinated disclosure process,
-because there is no deployed service to compromise: every instance of
-this runs on somebody's laptop, from source they can read. If you find
-something wrong here, open an issue.
+There is no security contact and no coordinated disclosure process for
+the tool itself: almost every instance of this runs on somebody's
+laptop, from source they can read. If you find something wrong here,
+open an issue.
+
+If you find something wrong in a hosted deployment of it, that is
+between you and whoever runs that deployment. Nothing in this repository
+identifies one.

--- a/banks/ckad-mock-01/q09/solution.md
+++ b/banks/ckad-mock-01/q09/solution.md
@@ -65,9 +65,24 @@ Podman has two entirely separate worlds. Rootless podman keeps images in
 `~/.local/share/containers`; rootful keeps them in `/var/lib/containers`.
 They cannot see each other's images, so a build in one and a `run` in the
 other produces a baffling "image not found" for an image you just watched
-build. On these instances rootless builds fail outright, so `sudo` is the
-only path — but the same split exists on real machines where both work,
-and it is a common way to lose ten minutes.
+build.
+
+On these instances the split bites in a particular way, and it is worth
+recognising: a rootless `podman build` *succeeds*, and then the rootless
+`podman run` fails with
+
+```
+Error: crun: mount `proc` to `proc`: Operation not permitted
+```
+
+Nothing is wrong with the image you just built. Rootless podman starts
+its container in a new user namespace, and the kernel will not let a
+process in one mount a fresh `/proc` while the surrounding `/proc` has
+parts masked off — which is how every container runtime hides things like
+`/proc/kcore`. Root podman creates no such namespace, so the restriction
+never applies. That is why `sudo` is the path that works end to end here.
+The same rootless/rootful split exists on real machines where both halves
+work, and it is a common way to lose ten minutes.
 
 ## ENV at build time vs run time
 

--- a/conductor/Dockerfile
+++ b/conductor/Dockerfile
@@ -9,7 +9,17 @@ FROM alpine:3.21
 # yq: the entrypoint pre-converts bank exam.yaml files to JSON, same
 # approach as the other bank-reading services (the Go binaries never
 # parse YAML).
-RUN apk add --no-cache yq
+#
+# openssh-client: only ENGINE=ssh uses it, for the hosted deployment
+# where the whole stack is one Pod and there is no Docker socket to
+# reach the other containers through. internal/sshexec shells out to
+# this binary rather than speaking the protocol, the same way
+# facilitator/internal/evaluate reaches the instances to grade. Idle
+# under compose, which keeps ENGINE=docker.
+#
+# Still no docker CLI, deliberately: the Engine API client is
+# hand-written precisely so this image does not need one.
+RUN apk add --no-cache yq openssh-client
 COPY --from=build /conductor /conductor
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/conductor/cmd/conductor/listen_test.go
+++ b/conductor/cmd/conductor/listen_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"io/fs"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestListenOnTCPIsUnchanged(t *testing.T) {
+	ln, err := listen("127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	if _, ok := ln.Addr().(*net.TCPAddr); !ok {
+		t.Errorf("addr = %T, want a TCP address", ln.Addr())
+	}
+}
+
+func TestListenOnASocketCreatesItPrivate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sub", "c.sock")
+	ln, err := listen(unixPrefix + path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("socket was not created: %v", err)
+	}
+	// 0600 is the second lock on a boundary the mount already draws.
+	// Loosening it silently would put the control API back within reach
+	// of anything that later shares the volume.
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("mode = %v, want 0600", perm)
+	}
+	if info.Mode().Type()&fs.ModeSocket == 0 {
+		t.Errorf("%s is not a socket (%v)", path, info.Mode())
+	}
+	if _, err := net.Dial("unix", path); err != nil {
+		t.Errorf("nothing is listening: %v", err)
+	}
+}
+
+// A socket file outlives a process that dies without closing it, and
+// net.Listen refuses to bind over one. Go unlinks on a clean Close, so
+// the case only arises when the conductor is killed — a SIGKILL, an
+// OOM, a `docker compose kill` — and then the volume still holds the
+// file the next start has to bind. SetUnlinkOnClose(false) is that
+// death, reproduced: without the unlink, every restart after a hard
+// kill fails against a file nothing is listening on.
+func TestListenReplacesASocketLeftByAKilledConductor(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "c.sock")
+	stale, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale.(*net.UnixListener).SetUnlinkOnClose(false)
+	stale.Close()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("setup did not leave a socket behind: %v", err)
+	}
+
+	ln, err := listen(unixPrefix + path)
+	if err != nil {
+		t.Fatalf("stale socket was not replaced: %v", err)
+	}
+	defer ln.Close()
+	if _, err := net.Dial("unix", path); err != nil {
+		t.Errorf("nothing is listening after replacing: %v", err)
+	}
+}

--- a/conductor/cmd/conductor/main.go
+++ b/conductor/cmd/conductor/main.go
@@ -6,9 +6,12 @@
 package main
 
 import (
+	"errors"
 	"log"
+	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -22,8 +25,12 @@ import (
 
 const readHeaderTimeout = 10 * time.Second
 
+// unixPrefix marks a LISTEN value as a filesystem socket rather than a
+// TCP address.
+const unixPrefix = "unix:"
+
 func main() {
-	listen := envOr("LISTEN", ":9000")
+	listenAddr := envOr("LISTEN", ":9000")
 	engine, engineName := newEngine()
 	project := envOr("COMPOSE_PROJECT", "kubestronaut-sim")
 	facilitatorURL := envOr("FACILITATOR_URL", "http://facilitator:8080")
@@ -53,13 +60,55 @@ func main() {
 		RestartExtra:   strings.Split(envOr("RESTART_EXTRA", "docs-proxy,facilitator"), ","),
 	}
 
+	ln, err := listen(listenAddr)
+	if err != nil {
+		log.Fatalf("conductor: listen on %s: %v", listenAddr, err)
+	}
 	srv := &http.Server{
-		Addr:              listen,
 		Handler:           api.New(ctrl, store),
 		ReadHeaderTimeout: readHeaderTimeout,
 	}
-	log.Printf("conductor listening on %s (project %s, engine %s)", listen, project, engineName)
-	log.Fatal(srv.ListenAndServe())
+	log.Printf("conductor listening on %s (project %s, engine %s)", listenAddr, project, engineName)
+	log.Fatal(srv.Serve(ln))
+}
+
+// listen opens the control API's listener.
+//
+// A TCP address is what compose runs, where `controlnet: internal:
+// true` puts the conductor on a network the candidate's containers are
+// not on. A hosted session has no such thing: the whole stack is one
+// Pod, one network namespace, and `127.0.0.1:9000` from the candidate's
+// own shell would reach the API that resets their cluster. A unix
+// socket is the boundary that survives sharing a namespace — it is
+// reachable only from a container that mounts the volume holding it,
+// which is the facilitator and nothing else.
+func listen(addr string) (net.Listener, error) {
+	path, ok := strings.CutPrefix(addr, unixPrefix)
+	if !ok {
+		return net.Listen("tcp", addr)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, err
+	}
+	// A socket file outlives the process that made it, and net.Listen
+	// refuses to bind over one. Removing it is safe because exactly one
+	// conductor exists per stack; leaving it would make every restart
+	// fail with "address already in use" against a file nothing is
+	// listening on.
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, err
+	}
+	// The mount is the boundary; the mode is a second lock on it. Both
+	// containers run as root today, so 0600 costs nothing.
+	if err := os.Chmod(path, 0o600); err != nil {
+		ln.Close()
+		return nil, err
+	}
+	return ln, nil
 }
 
 // newEngine picks how the conductor reaches the other containers.

--- a/conductor/cmd/conductor/main.go
+++ b/conductor/cmd/conductor/main.go
@@ -17,13 +17,14 @@ import (
 	"kubestronaut-sim/conductor/internal/control"
 	"kubestronaut-sim/conductor/internal/docker"
 	"kubestronaut-sim/conductor/internal/job"
+	"kubestronaut-sim/conductor/internal/sshexec"
 )
 
 const readHeaderTimeout = 10 * time.Second
 
 func main() {
 	listen := envOr("LISTEN", ":9000")
-	socket := envOr("DOCKER_SOCKET", "/var/run/docker.sock")
+	engine, engineName := newEngine()
 	project := envOr("COMPOSE_PROJECT", "kubestronaut-sim")
 	facilitatorURL := envOr("FACILITATOR_URL", "http://facilitator:8080")
 	instances := strings.Split(envOr("INSTANCES", "instance-1,instance-2"), ",")
@@ -36,7 +37,7 @@ func main() {
 
 	store := job.NewStore(time.Now)
 	ctrl := &control.Controller{
-		Engine:         docker.New(socket),
+		Engine:         engine,
 		Store:          store,
 		Project:        project,
 		FacilitatorURL: facilitatorURL,
@@ -57,8 +58,34 @@ func main() {
 		Handler:           api.New(ctrl, store),
 		ReadHeaderTimeout: readHeaderTimeout,
 	}
-	log.Printf("conductor listening on %s (project %s)", listen, project)
+	log.Printf("conductor listening on %s (project %s, engine %s)", listen, project, engineName)
 	log.Fatal(srv.ListenAndServe())
+}
+
+// newEngine picks how the conductor reaches the other containers.
+//
+// docker is the default and is what compose runs: the socket is mounted,
+// and services are found by the labels compose stamps on them. ssh is for
+// the hosted deployment, where the whole stack is one Kubernetes Pod —
+// there is no socket to mount and no container to look up, so the same
+// calls go over ssh to the service's hostname.
+//
+// An unrecognised value is fatal rather than a silent fall back to
+// docker: getting this wrong means every control operation fails at the
+// first exec, minutes into a job, instead of at startup.
+func newEngine() (control.Engine, string) {
+	switch name := strings.ToLower(envOr("ENGINE", "docker")); name {
+	case "docker":
+		return docker.New(envOr("DOCKER_SOCKET", "/var/run/docker.sock")), name
+	case "ssh":
+		return sshexec.New(
+			envOr("SSH_KEY", "/shared/ssh/id_ed25519"),
+			envOr("SSH_USER", "root"),
+		), name
+	default:
+		log.Fatalf("conductor: unknown ENGINE %q (want docker or ssh)", name)
+		return nil, ""
+	}
 }
 
 func envOr(key, fallback string) string {

--- a/conductor/internal/api/api.go
+++ b/conductor/internal/api/api.go
@@ -134,6 +134,10 @@ func writeOpError(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusConflict, "a session is running — end the exam first")
 	case errors.Is(err, control.ErrInvalidBank):
 		writeError(w, http.StatusBadRequest, err.Error())
+	case errors.Is(err, control.ErrRestartUnavailable):
+		// 501, not 403: the operation is understood and legitimate, this
+		// deployment just has no way to carry it out.
+		writeError(w, http.StatusNotImplemented, err.Error())
 	case errors.Is(err, control.ErrUnknownQuestion):
 		writeError(w, http.StatusBadRequest, err.Error())
 	case errors.Is(err, control.ErrReseedBusy):

--- a/conductor/internal/control/control.go
+++ b/conductor/internal/control/control.go
@@ -29,12 +29,41 @@ var ErrInvalidBank = errors.New("control: invalid bank")
 // explicit "abandon this attempt" operation.)
 var ErrSessionRunning = errors.New("control: a session is running — end the exam first")
 
+// ErrRestartUnavailable rejects reset and switch on an engine that cannot
+// restart a container at all — the ssh engine a hosted session runs,
+// where a Pod offers no per-container restart and restartPolicy: Never
+// makes killing PID 1 terminal.
+//
+// It is checked BEFORE either job begins, and that ordering is the whole
+// point of it. Both jobs wipe the instances, and switch also rewrites the
+// active bank, several phases before they reach the restart that cannot
+// work: a hosted switch got as far as "the bank file says mcq, while
+// docs-proxy and the facilitator are still serving the practical exam"
+// and then stopped, leaving a session that was neither exam. An operation
+// that cannot finish must not be allowed to start. Mapped to 501.
+var ErrRestartUnavailable = errors.New("control: this deployment cannot restart containers — start a new session instead")
+
 // Engine is the slice of the Docker Engine API the controller needs.
 // containerIDs returned by FindContainer are opaque to this package.
 type Engine interface {
 	FindContainer(ctx context.Context, project, service string) (string, error)
 	Exec(ctx context.Context, containerID string, cmd []string, onLine func(string)) (exitCode int, output string, err error)
 	Restart(ctx context.Context, containerID string, timeoutSec int) error
+}
+
+// restartCapable lets an Engine declare up front that Restart will always
+// fail, so a job needing one can be refused before its earlier phases
+// destroy anything. Deliberately optional rather than a fourth Engine
+// method: an engine that says nothing is assumed capable, which is true
+// of the Docker engine and of every test fake.
+type restartCapable interface {
+	CanRestart() bool
+}
+
+// canRestart reports whether the engine can restart containers at all.
+func (c *Controller) canRestart() bool {
+	rc, ok := c.Engine.(restartCapable)
+	return !ok || rc.CanRestart()
 }
 
 // Controller wires the engine, job store, and facilitator endpoint into
@@ -152,10 +181,17 @@ func resetPhases(mcq bool) []job.PhaseSpec {
 	}
 }
 
-// StartReset begins an asynchronous reset job, returning the job record
-// or job.ErrBusy if another operation is in flight.
+// StartReset begins an asynchronous reset job, returning the job record,
+// job.ErrBusy if another operation is in flight, or ErrRestartUnavailable
+// if the engine could not complete the job's restart phase.
 func (c *Controller) StartReset() (job.Job, error) {
 	mcq := c.bankIsMCQ(c.activeBank())
+	// A hands-on reset restarts the instances after rebuilding the cluster
+	// (resetPhases); an MCQ reset has neither phase, so it stays available
+	// on an engine that cannot restart anything.
+	if !mcq && !c.canRestart() {
+		return job.Job{}, ErrRestartUnavailable
+	}
 	j, err := c.Store.Begin("reset", "", resetPhases(mcq))
 	if err != nil {
 		return job.Job{}, err
@@ -250,6 +286,20 @@ func (c *Controller) StartSwitch(bank string) (job.Job, error) {
 	if err := c.Catalog.Switchable(bank); err != nil {
 		return job.Job{}, fmt.Errorf("%w: %v", ErrInvalidBank, err)
 	}
+	mcq := c.bankIsMCQ(bank)
+	// Every switch restarts the bank-reading services (RestartExtra), and
+	// a hands-on target restarts the instances too. Unlike reset there is
+	// no variant that needs none, so on an engine that cannot restart, a
+	// switch is refused outright rather than half-performed.
+	//
+	// Checked before the session-state probe below because this is a
+	// static property of the deployment: an operation this engine can
+	// never carry out should not first cost a round-trip to the
+	// facilitator, nor report a transport failure in its place.
+	if (!mcq || len(c.RestartExtra) > 0) && !c.canRestart() {
+		return job.Job{}, ErrRestartUnavailable
+	}
+
 	state, err := c.sessionState(context.Background())
 	if err != nil {
 		return job.Job{}, fmt.Errorf("control: check session state: %w", err)
@@ -258,7 +308,6 @@ func (c *Controller) StartSwitch(bank string) (job.Job, error) {
 		return job.Job{}, ErrSessionRunning
 	}
 
-	mcq := c.bankIsMCQ(bank)
 	j, err := c.Store.Begin("switch", bank, switchPhases(mcq))
 	if err != nil {
 		return job.Job{}, err

--- a/conductor/internal/control/restart_guard_test.go
+++ b/conductor/internal/control/restart_guard_test.go
@@ -1,0 +1,115 @@
+package control
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// An engine that cannot restart a container: the hosted deployment's ssh
+// engine, where a Pod has no per-container restart and restartPolicy:
+// Never makes killing PID 1 terminal.
+type noRestartEngine struct{ fakeEngine }
+
+func (*noRestartEngine) CanRestart() bool { return false }
+
+// The bug these guard against was not that reset and switch failed — it
+// was WHERE they failed. Both wipe the instances, and switch also
+// rewrites the active bank, several phases before they reach the restart
+// that cannot work. A hosted switch stopped with the bank file already
+// saying "mcq" while docs-proxy and the facilitator were still serving
+// the practical exam: a session that was neither exam and could not be
+// put back. Refusing costs nothing; a half-performed switch costs the
+// session.
+
+func TestResetIsRefusedBeforeItTouchesAnythingWhenRestartIsUnavailable(t *testing.T) {
+	facilitator := healthyFacilitator(t)
+	defer facilitator.Close()
+
+	eng := &noRestartEngine{}
+	c := newTestController(t, eng, facilitator.URL)
+
+	if _, err := c.StartReset(); !errors.Is(err, ErrRestartUnavailable) {
+		t.Fatalf("StartReset error = %v, want ErrRestartUnavailable", err)
+	}
+	if calls := strings.Join(eng.recorded(), "\n"); calls != "" {
+		t.Errorf("a refused reset still touched the engine:\n%s", calls)
+	}
+	// Not even a failed job record: nothing began, so there is nothing to
+	// report as having gone wrong.
+	if snap := c.Store.Status(); snap.LastJob != nil {
+		t.Errorf("a refused reset started a job: %+v", snap.LastJob)
+	}
+}
+
+func TestSwitchIsRefusedAndLeavesTheOutgoingBankActive(t *testing.T) {
+	facilitator := healthyFacilitator(t)
+	defer facilitator.Close()
+
+	eng := &noRestartEngine{}
+	c := newTestController(t, eng, facilitator.URL)
+	c.Catalog = testCatalogWithMCQ(t)
+	c.RestartExtra = []string{"docs-proxy", "facilitator"}
+	c.BankFile = filepath.Join(t.TempDir(), "bank")
+	if err := os.WriteFile(c.BankFile, []byte("cka-mock-01\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := c.StartSwitch("kcna-mock"); !errors.Is(err, ErrRestartUnavailable) {
+		t.Fatalf("StartSwitch error = %v, want ErrRestartUnavailable", err)
+	}
+	// The exact regression: this file is the runtime source of truth for
+	// which exam is live, and the failed switch had already rewritten it.
+	got, err := os.ReadFile(c.BankFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(got)) != "cka-mock-01" {
+		t.Errorf("bank file = %q, want the outgoing bank still active", got)
+	}
+	if calls := strings.Join(eng.recorded(), "\n"); calls != "" {
+		t.Errorf("a refused switch still touched the engine:\n%s", calls)
+	}
+}
+
+// The guard is scoped to what each job actually needs, not applied to the
+// whole engine: an MCQ reset has no cluster rebuild and no instance
+// restart, so it stays available in a hosted session.
+func TestMCQResetSurvivesAnEngineThatCannotRestart(t *testing.T) {
+	facilitator := healthyFacilitator(t)
+	defer facilitator.Close()
+
+	eng := &noRestartEngine{}
+	c := newTestController(t, eng, facilitator.URL)
+	c.Catalog = testCatalogWithMCQ(t)
+	c.BankFile = filepath.Join(t.TempDir(), "bank")
+	if err := os.WriteFile(c.BankFile, []byte("kcna-mock\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := c.StartReset(); err != nil {
+		t.Fatalf("StartReset on an mcq bank = %v, want it to be allowed", err)
+	}
+	snap := waitIdle(t, c.Store)
+	if snap.LastJob == nil || snap.LastJob.Error != "" {
+		t.Fatalf("mcq reset job = %+v, want clean completion", snap.LastJob)
+	}
+}
+
+// A capable engine must be unaffected — the optional interface means an
+// Engine that says nothing is assumed able to restart, which is what the
+// Docker engine and every other fake in this package rely on.
+func TestResetIsUnaffectedOnAnEngineThatCanRestart(t *testing.T) {
+	facilitator := healthyFacilitator(t)
+	defer facilitator.Close()
+
+	c := newTestController(t, &fakeEngine{}, facilitator.URL)
+	if !c.canRestart() {
+		t.Fatal("an Engine without CanRestart must be assumed capable")
+	}
+	if _, err := c.StartReset(); err != nil {
+		t.Fatalf("StartReset: %v", err)
+	}
+}

--- a/conductor/internal/sshexec/sshexec.go
+++ b/conductor/internal/sshexec/sshexec.go
@@ -1,0 +1,174 @@
+// Package sshexec is a control.Engine for deployments with no Docker
+// socket to hold. Under compose the conductor finds a service's container
+// by its compose labels and drives it over the Engine API; in a Kubernetes
+// Pod there is no socket to mount and no container to look up, so the same
+// three calls go over ssh to the service's hostname instead.
+//
+// It shells out to the ssh binary rather than speaking the protocol,
+// which is what facilitator/internal/evaluate already does to reach the
+// instances for grading — same flags, same assumption that the key in
+// /shared is the one that works.
+//
+// What this deliberately cannot do is Restart: there is no per-container
+// restart in a Pod, and the hosted deployment does not want one. Reset and
+// bank switch are the hub's job there, and it does them by recycling the
+// whole Pod. Only training-mode reseed still needs a live exec.
+package sshexec
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// ErrRestartUnsupported is returned by Restart. It is a distinct error so
+// a caller can tell "this engine cannot" from "this restart failed".
+var ErrRestartUnsupported = errors.New("sshexec: restart is not available over ssh; recycle the Pod instead")
+
+// CanRestart reports false — see Restart. The controller asks before it
+// begins a reset or a switch, so a job that would die at its restart
+// phase is refused up front instead of after its earlier phases have
+// wiped the instances and rewritten the active bank.
+func (c *Client) CanRestart() bool { return false }
+
+// Client runs commands on the other containers of its own Pod over ssh.
+type Client struct {
+	keyPath string
+	user    string
+}
+
+// New returns a Client authenticating with the private key at keyPath as
+// user. keyPath is the shared key k8s-env generates during bootstrap.
+func New(keyPath, user string) *Client {
+	if user == "" {
+		user = "root"
+	}
+	return &Client{keyPath: keyPath, user: user}
+}
+
+// FindContainer returns service unchanged. The Engine contract is "resolve
+// a service name to something Exec accepts", and over ssh that is the
+// hostname — which hostAliases in the Pod spec points at the right
+// loopback address. project is meaningless here and is ignored.
+func (c *Client) FindContainer(_ context.Context, _, service string) (string, error) {
+	if service == "" {
+		return "", errors.New("sshexec: empty service name")
+	}
+	return service, nil
+}
+
+// Exec runs cmd on host, waiting for completion, and returns the exit code
+// plus the combined stdout+stderr output.
+//
+// onLine (may be nil) receives each complete output line as it arrives,
+// giving a multi-minute command a visible heartbeat — the same contract
+// the Docker engine's exec stream provides.
+//
+// cmd is an argv, but ssh hands its arguments to the remote login shell as
+// one string, so every element is single-quoted to survive that re-parse.
+// Without it a command like `sh -c "podman rm -af; podman rmi -af"` would
+// be split on the remote side and the second half would run in the wrong
+// context.
+func (c *Client) Exec(ctx context.Context, host string, cmd []string, onLine func(string)) (int, string, error) {
+	if len(cmd) == 0 {
+		return 0, "", errors.New("sshexec: empty command")
+	}
+
+	w := &lineWriter{onLine: onLine}
+	proc := exec.CommandContext(ctx, "ssh", c.args(host, cmd)...)
+	// Assigning the identical writer to both means os/exec serialises the
+	// two streams onto it for us, so interleaving needs no lock here.
+	proc.Stdout = w
+	proc.Stderr = w
+
+	err := proc.Run()
+	w.flush()
+	out := w.all.String()
+
+	if err == nil {
+		return 0, out, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		// ssh reports its own failures as 255, which a remote command may
+		// also legitimately return. The output is the only way to tell
+		// them apart, and it is already being surfaced to the caller.
+		return exitErr.ExitCode(), out, nil
+	}
+	return 0, out, fmt.Errorf("sshexec: run ssh to %s: %w", host, err)
+}
+
+// Restart always fails. See the package comment.
+func (c *Client) Restart(_ context.Context, host string, _ int) error {
+	return fmt.Errorf("%w (host %s)", ErrRestartUnsupported, host)
+}
+
+// args builds the ssh argv, matching the flags
+// facilitator/internal/evaluate uses so both paths behave the same way
+// against the same key and the same throwaway host keys.
+func (c *Client) args(host string, cmd []string) []string {
+	args := []string{
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"-o", "LogLevel=ERROR",
+		"-o", "BatchMode=yes",
+		"-o", "ConnectTimeout=10",
+	}
+	if c.keyPath != "" {
+		args = append(args, "-i", c.keyPath)
+	}
+	return append(args, c.user+"@"+host, remoteCommand(cmd))
+}
+
+// remoteCommand renders an argv as one shell word-list the remote shell
+// will parse back into the same argv.
+func remoteCommand(cmd []string) string {
+	quoted := make([]string, len(cmd))
+	for i, a := range cmd {
+		quoted[i] = shellQuote(a)
+	}
+	return strings.Join(quoted, " ")
+}
+
+// shellQuote wraps s so a POSIX shell reproduces it verbatim. Single
+// quotes protect everything except a single quote itself, which has to
+// leave the quoted run, emit an escaped one, and re-enter.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// lineWriter accumulates everything written to it and publishes complete
+// lines to onLine as they arrive.
+type lineWriter struct {
+	all     bytes.Buffer
+	partial bytes.Buffer
+	onLine  func(string)
+}
+
+func (w *lineWriter) Write(p []byte) (int, error) {
+	w.all.Write(p)
+	if w.onLine == nil {
+		return len(p), nil
+	}
+	for _, b := range p {
+		if b == '\n' {
+			w.onLine(strings.TrimRight(w.partial.String(), "\r"))
+			w.partial.Reset()
+			continue
+		}
+		w.partial.WriteByte(b)
+	}
+	return len(p), nil
+}
+
+// flush publishes a trailing line that never got its newline.
+func (w *lineWriter) flush() {
+	if w.onLine == nil || w.partial.Len() == 0 {
+		return
+	}
+	w.onLine(strings.TrimRight(w.partial.String(), "\r"))
+	w.partial.Reset()
+}

--- a/conductor/internal/sshexec/sshexec_test.go
+++ b/conductor/internal/sshexec/sshexec_test.go
@@ -1,0 +1,156 @@
+package sshexec
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestShellQuote(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "bash", `'bash'`},
+		{"spaces", "a b", `'a b'`},
+		{"semicolon", "podman rm -af; podman rmi -af", `'podman rm -af; podman rmi -af'`},
+		{"double quote", `say "hi"`, `'say "hi"'`},
+		{"single quote", "it's", `'it'\''s'`},
+		{"empty", "", `''`},
+		{"dollar", "$HOME", `'$HOME'`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shellQuote(c.in); got != c.want {
+				t.Errorf("shellQuote(%q) = %s, want %s", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// The commands the conductor actually sends are argv triples whose third
+// element is a whole shell script. Losing that grouping is the failure
+// this quoting exists to prevent.
+func TestRemoteCommandKeepsScriptAsOneWord(t *testing.T) {
+	got := remoteCommand(wipeLike())
+	want := `'sh' '-c' 'find /opt/course -mindepth 1 -delete; podman rm -af; podman rmi -af'`
+	if got != want {
+		t.Errorf("remoteCommand:\n got %s\nwant %s", got, want)
+	}
+}
+
+func wipeLike() []string {
+	return []string{"sh", "-c", "find /opt/course -mindepth 1 -delete; podman rm -af; podman rmi -af"}
+}
+
+func TestArgsCarryKeyUserHostAndCommand(t *testing.T) {
+	c := New("/shared/ssh/id_ed25519", "")
+	args := c.args("k8s-env", []string{"bash", "-c", "echo hi"})
+
+	joined := strings.Join(args, " ")
+	for _, want := range []string{
+		"-o StrictHostKeyChecking=no",
+		"-o UserKnownHostsFile=/dev/null",
+		"-o BatchMode=yes",
+		"-i /shared/ssh/id_ed25519",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("args missing %q; got %v", want, args)
+		}
+	}
+	// Destination then command, in that order, as the last two arguments.
+	if got := args[len(args)-2]; got != "root@k8s-env" {
+		t.Errorf("destination = %q, want root@k8s-env (default user)", got)
+	}
+	if got := args[len(args)-1]; got != `'bash' '-c' 'echo hi'` {
+		t.Errorf("remote command = %s", got)
+	}
+}
+
+func TestArgsOmitsKeyFlagWhenNoKey(t *testing.T) {
+	c := New("", "candidate")
+	for _, a := range c.args("instance-1", []string{"true"}) {
+		if a == "-i" {
+			t.Fatal("args included -i with no key path")
+		}
+	}
+}
+
+// FindContainer is the seam that makes a service name usable by Exec.
+// Over ssh that is identity — hostAliases does the real resolution.
+func TestFindContainerReturnsServiceName(t *testing.T) {
+	c := New("/k", "root")
+	got, err := c.FindContainer(context.Background(), "ignored-project", "k8s-env")
+	if err != nil {
+		t.Fatalf("FindContainer: %v", err)
+	}
+	if got != "k8s-env" {
+		t.Errorf("FindContainer = %q, want k8s-env", got)
+	}
+	if _, err := c.FindContainer(context.Background(), "p", ""); err == nil {
+		t.Error("empty service name should be an error")
+	}
+}
+
+func TestRestartIsUnsupported(t *testing.T) {
+	c := New("/k", "root")
+	err := c.Restart(context.Background(), "instance-1", 10)
+	if !errors.Is(err, ErrRestartUnsupported) {
+		t.Fatalf("Restart error = %v, want ErrRestartUnsupported", err)
+	}
+	if !strings.Contains(err.Error(), "instance-1") {
+		t.Errorf("Restart error should name the host; got %v", err)
+	}
+}
+
+func TestExecRejectsEmptyCommand(t *testing.T) {
+	c := New("/k", "root")
+	if _, _, err := c.Exec(context.Background(), "k8s-env", nil, nil); err == nil {
+		t.Error("empty command should be an error")
+	}
+}
+
+func TestLineWriterPublishesCompleteLinesAsTheyArrive(t *testing.T) {
+	var got []string
+	w := &lineWriter{onLine: func(s string) { got = append(got, s) }}
+
+	// Split mid-line on purpose: the Docker engine's stream does this too,
+	// and a writer that only split per Write call would emit fragments.
+	w.Write([]byte("first\nsec"))
+	if len(got) != 1 || got[0] != "first" {
+		t.Fatalf("after partial write, lines = %v, want [first]", got)
+	}
+	w.Write([]byte("ond\nthird"))
+	if len(got) != 2 || got[1] != "second" {
+		t.Fatalf("lines = %v, want [first second]", got)
+	}
+
+	// "third" has no newline; only flush should release it.
+	w.flush()
+	if len(got) != 3 || got[2] != "third" {
+		t.Fatalf("after flush, lines = %v, want [first second third]", got)
+	}
+	if w.all.String() != "first\nsecond\nthird" {
+		t.Errorf("accumulated output = %q", w.all.String())
+	}
+}
+
+func TestLineWriterStripsCarriageReturns(t *testing.T) {
+	var got []string
+	w := &lineWriter{onLine: func(s string) { got = append(got, s) }}
+	w.Write([]byte("progress\r\n"))
+	if len(got) != 1 || got[0] != "progress" {
+		t.Errorf("lines = %q, want [progress]", got)
+	}
+}
+
+func TestLineWriterWithoutCallbackStillAccumulates(t *testing.T) {
+	w := &lineWriter{}
+	w.Write([]byte("a\nb\n"))
+	w.flush()
+	if w.all.String() != "a\nb\n" {
+		t.Errorf("accumulated = %q, want \"a\\nb\\n\"", w.all.String())
+	}
+}

--- a/deploy/helm/kubestronaut-sim/.helmignore
+++ b/deploy/helm/kubestronaut-sim/.helmignore
@@ -1,0 +1,6 @@
+.DS_Store
+.git/
+.gitignore
+*.tmproj
+*.orig
+*.bak

--- a/deploy/helm/kubestronaut-sim/Chart.yaml
+++ b/deploy/helm/kubestronaut-sim/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+name: kubestronaut-sim
+description: A hosted kubestronaut-sim — the hub, and the session Pods it creates
+type: application
+
+# The chart versions independently of the images: a values-only change
+# (more seats, a different bank) is a chart bump and no new image.
+version: 0.1.0
+
+# The image tag every container defaults to. `images.tag` in values.yaml
+# overrides it; nothing else here reads it. It is a released tag rather
+# than `dev` on purpose — `dev` is whatever was last pushed by hand, and
+# a hosted deployment must be able to say what it is running.
+appVersion: "v0.1.0"
+
+home: https://github.com/Camilool8/kubestronaut-sim
+sources:
+  - https://github.com/Camilool8/kubestronaut-sim
+keywords:
+  - kubernetes
+  - cka
+  - ckad
+  - cks
+  - kcna
+  - exam
+maintainers:
+  - name: Camilool8
+    url: https://github.com/Camilool8

--- a/deploy/helm/kubestronaut-sim/files/session-pod-mcq.yaml
+++ b/deploy/helm/kubestronaut-sim/files/session-pod-mcq.yaml
@@ -11,6 +11,10 @@
 # would add it. Two files that each say plainly what they are beats one
 # that has to be read twice.
 #
+# Like its sibling, this is a plain manifest and not a chart template:
+# the chart parses it and rewrites only the images, the namespace,
+# placement and resources. See session-pod.yaml.
+#
 # The conductor is here and the desktop is not, which looks arbitrary
 # until you look at what answers GET /api/catalog: the facilitator, from
 # a server-side call to the conductor's bank list. Drop the conductor and

--- a/deploy/helm/kubestronaut-sim/files/session-pod.yaml
+++ b/deploy/helm/kubestronaut-sim/files/session-pod.yaml
@@ -1,8 +1,18 @@
 # One practical exam session, as a single Pod.
 #
-# This is the compose stack translated container-for-container. It is kept
-# as a concrete manifest rather than a chart template so it can be applied
-# and debugged directly; the Helm chart wraps this once it boots clean.
+# This is the compose stack translated container-for-container. It lives
+# inside the chart but it is NOT a chart template: it has no templating
+# in it and can be applied and debugged as it stands —
+#
+#   kubectl apply -f deploy/helm/kubestronaut-sim/files/session-pod.yaml
+#
+# The chart reads it, rewrites exactly four things and hands the result
+# to the hub as JSON: the first-party image references and their pull
+# policy, metadata.namespace, nodeSelector/tolerations, and per-container
+# resources. Every other line here reaches the API server as written. So
+# the fields below that the chart overrides — the image tags, the
+# namespace, the nodeSelector — are what a bare `kubectl apply` gets, and
+# values.yaml is what a deployment gets.
 #
 # Three things differ from docker-compose.yaml, and only three:
 #
@@ -25,7 +35,9 @@
 # imagePullPolicy: Always on every first-party image, because :dev is a
 # mutable tag — without it the node serves its cached copy and a rebuild
 # never reaches the Pod. Upstream pinned tags (registry:2) keep the
-# default IfNotPresent on purpose.
+# default IfNotPresent on purpose. A chart install replaces both the tag
+# and this policy (images.tag, images.pullPolicy), because a released tag
+# is immutable and re-checking a 2.6 GB image every boot buys nothing.
 #
 # The privilege story: k8s-env is privileged because it runs dockerd and
 # `kind create cluster`. The instances are NOT — they carry exactly the
@@ -47,6 +59,8 @@ spec:
   # candidate works against is the kind cluster inside k8s-env.
   automountServiceAccountToken: false
   enableServiceLinks: false
+  # Placement is the cluster operator's, not this file's: a chart install
+  # replaces this wholesale from sessions.practical.nodeSelector.
   nodeSelector:
     kubestronaut-sim/session: "true"
   terminationGracePeriodSeconds: 30

--- a/deploy/helm/kubestronaut-sim/templates/NOTES.txt
+++ b/deploy/helm/kubestronaut-sim/templates/NOTES.txt
@@ -1,0 +1,35 @@
+{{ include "kubestronaut-sim.fullname" . }} is installed in namespace {{ .Release.Namespace }}.
+
+Images:  {{ .Values.images.prefix }}*:{{ .Values.images.tag | default .Chart.AppVersion }}
+Auth:    {{ .Values.hub.auth.mode }}{{ if .Values.hub.baseURL }} at {{ .Values.hub.baseURL }}{{ end }}
+Seats:   {{ .Values.sessions.practical.seats }} practical ({{ .Values.sessions.practical.bank }}), {{ .Values.sessions.mcq.seats }} MCQ ({{ .Values.sessions.mcq.bank }})
+History: {{ if .Values.hub.state.existingClaim }}{{ .Values.hub.state.existingClaim }} (existing){{ else }}{{ include "kubestronaut-sim.fullname" . }}-state, {{ .Values.hub.state.size }}{{ end }}
+
+{{ if not .Values.httpRoute.enabled -}}
+Nothing routes traffic to the hub yet. Point your Ingress, Gateway or
+tunnel at Service/{{ include "kubestronaut-sim.fullname" . }}:{{ .Values.hub.service.port }}, or try it directly:
+
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "kubestronaut-sim.fullname" . }} 8080:{{ .Values.hub.service.port }}
+
+{{ end -}}
+{{- if gt (int .Values.sessions.practical.seats) 0 }}
+A practical session runs a privileged container: it builds a real
+two-node Kubernetes cluster and hands the candidate a root shell with a
+container runtime in it. Label the nodes you have decided may run that:
+
+  kubectl label node <node> {{ range $k, $v := .Values.sessions.practical.nodeSelector }}{{ $k }}={{ $v }} {{ end }}
+
+{{- if not .Values.sessions.networkPolicy.enabled }}
+
+  WARNING: sessions.networkPolicy.enabled is false. Nothing stops a
+  session reaching this cluster's API server, its other namespaces or
+  the node metadata service.
+{{- end }}
+{{- end }}
+
+{{- if and (eq .Values.hub.auth.mode "header") (not .Values.hub.existingSecret) (not .Values.hub.secret.cookieKey) }}
+
+  NOTE: AUTH_MODE=header with no COOKIE_KEY. Seats and the proxy work;
+  graded attempts are shown to the candidate and then lost with the Pod,
+  because nothing signs the ticket a session records history with.
+{{- end }}

--- a/deploy/helm/kubestronaut-sim/templates/_helpers.tpl
+++ b/deploy/helm/kubestronaut-sim/templates/_helpers.tpl
@@ -1,0 +1,160 @@
+{{/*
+Names and labels.
+*/}}
+{{- define "kubestronaut-sim.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kubestronaut-sim.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kubestronaut-sim.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "kubestronaut-sim.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "kubestronaut-sim.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubestronaut-sim.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: hub
+{{- end -}}
+
+{{- define "kubestronaut-sim.serviceAccountName" -}}
+{{ include "kubestronaut-sim.fullname" . }}
+{{- end -}}
+
+{{/*
+Where session Pods are created. The hub can only create them where its
+Role says it may, so this is one value and both places read it.
+*/}}
+{{- define "kubestronaut-sim.sessionNamespace" -}}
+{{- .Values.sessions.namespace | default .Release.Namespace -}}
+{{- end -}}
+
+{{/*
+The name of the Secret holding COOKIE_KEY and the GitHub credentials —
+one this chart created, or one that was already there.
+*/}}
+{{- define "kubestronaut-sim.secretName" -}}
+{{- if .Values.hub.existingSecret -}}
+{{- .Values.hub.existingSecret -}}
+{{- else -}}
+{{- include "kubestronaut-sim.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kubestronaut-sim.createSecret" -}}
+{{- if .Values.hub.existingSecret -}}
+{{- else if or .Values.hub.secret.cookieKey .Values.hub.secret.githubClientID .Values.hub.secret.githubClientSecret -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+One image name. Every image this chart runs is <prefix><short>:<tag> —
+the seven session images plus the hub, from one release workflow.
+*/}}
+{{- define "kubestronaut-sim.image" -}}
+{{- $ctx := .ctx -}}
+{{- printf "%s%s:%s" $ctx.Values.images.prefix .name ($ctx.Values.images.tag | default $ctx.Chart.AppVersion) -}}
+{{- end -}}
+
+{{/*
+kubestronaut-sim.sessionPod renders one of the Pod manifests in files/
+into the JSON the hub stamps out per candidate.
+
+The manifest is the source of truth and it is NOT a template. It is
+parsed, four things are rewritten, and it is handed back:
+
+  1. image and imagePullPolicy on every first-party container, so a
+     deployment can pull a chosen release from a chosen registry;
+  2. metadata.namespace, because the API server rejects a create whose
+     body names a different namespace from the URL;
+  3. nodeSelector and tolerations, which are placement policy and belong
+     to whoever runs the cluster, not to the manifest;
+  4. per-container resources, merged over what the manifest declares.
+
+Everything else — every container, capability, volume, probe, hostAlias
+and env var — survives untouched. That is the whole point: the file in
+files/ is what was debugged against a real cluster, and this chart
+cannot silently disagree with it.
+
+Called with a dict: ctx (the root context), file, flavour (the
+.Values.sessions.<kind> block).
+*/}}
+{{- define "kubestronaut-sim.sessionPod" -}}
+{{- $ctx := .ctx -}}
+{{- $flavour := .flavour -}}
+{{- $raw := $ctx.Files.Get .file -}}
+{{- if not $raw -}}
+{{- fail (printf "kubestronaut-sim: the chart is missing %s" .file) -}}
+{{- end -}}
+{{- $pod := fromYaml $raw -}}
+{{- if hasKey $pod "Error" -}}
+{{- fail (printf "kubestronaut-sim: %s is not valid YAML: %v" .file (index $pod "Error")) -}}
+{{- end -}}
+{{- if ne (index $pod "kind") "Pod" -}}
+{{- fail (printf "kubestronaut-sim: %s is a %v, want a Pod" .file (index $pod "kind")) -}}
+{{- end -}}
+{{- $spec := $pod.spec -}}
+
+{{- $_ := set $pod.metadata "namespace" (include "kubestronaut-sim.sessionNamespace" $ctx) -}}
+
+{{- $tag := $ctx.Values.images.tag | default $ctx.Chart.AppVersion -}}
+{{- $rewritten := 0 -}}
+{{- range $key := list "initContainers" "containers" -}}
+{{- range $c := (index $spec $key | default list) -}}
+{{- $repo := splitList ":" $c.image | first -}}
+{{- if hasPrefix "cjoga/kubestronaut-sim-" $repo -}}
+{{- $short := trimPrefix "cjoga/kubestronaut-sim-" $repo -}}
+{{- $_ := set $c "image" (printf "%s%s:%s" $ctx.Values.images.prefix $short $tag) -}}
+{{- $_ := set $c "imagePullPolicy" $ctx.Values.images.pullPolicy -}}
+{{- $rewritten = add1 $rewritten -}}
+{{- end -}}
+{{- with (index ($flavour.resources | default dict) $c.name) -}}
+{{- $_ := set $c "resources" (mergeOverwrite (index $c "resources" | default dict) .) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if eq $rewritten 0 -}}
+{{- fail (printf "kubestronaut-sim: no container in %s carries a first-party image, so images.prefix and images.tag would go nowhere" .file) -}}
+{{- end -}}
+
+{{- $pullSecrets := list -}}
+{{- range $ctx.Values.images.pullSecrets -}}
+{{- $pullSecrets = append $pullSecrets (dict "name" .) -}}
+{{- end -}}
+{{- if $pullSecrets -}}
+{{- $_ := set $spec "imagePullSecrets" $pullSecrets -}}
+{{- end -}}
+
+{{/* Values are authoritative for placement, including when they are
+     empty: `nodeSelector: {}` means "schedule this anywhere", and a
+     manifest default left in place would quietly ignore it. */}}
+{{- if $flavour.nodeSelector -}}
+{{- $_ := set $spec "nodeSelector" $flavour.nodeSelector -}}
+{{- else -}}
+{{- $_ := unset $spec "nodeSelector" -}}
+{{- end -}}
+{{- if $flavour.tolerations -}}
+{{- $_ := set $spec "tolerations" $flavour.tolerations -}}
+{{- else -}}
+{{- $_ := unset $spec "tolerations" -}}
+{{- end -}}
+
+{{- $pod | toJson -}}
+{{- end -}}

--- a/deploy/helm/kubestronaut-sim/templates/configmap-session-pods.yaml
+++ b/deploy/helm/kubestronaut-sim/templates/configmap-session-pods.yaml
@@ -1,0 +1,24 @@
+{{- if or (gt (int .Values.sessions.practical.seats) 0) (gt (int .Values.sessions.mcq.seats) 0) }}
+# The two Pod manifests, as JSON, for the hub to stamp out.
+#
+# JSON because the hub is stdlib-only and the standard library has no
+# YAML parser — a rule this repo keeps everywhere, and the conversion is
+# a one-liner here. The YAML in files/ stays the single source of truth,
+# comments and all, and no second copy of the spec exists to drift.
+#
+# Rendered from files/ at install time, so `helm template` shows exactly
+# what a session will be. See the sessionPod helper for the four fields
+# this chart rewrites and why.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kubestronaut-sim.fullname" . }}-session-pods
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubestronaut-sim.labels" . | nindent 4 }}
+data:
+  session-pod.json: |
+    {{- include "kubestronaut-sim.sessionPod" (dict "ctx" . "file" "files/session-pod.yaml" "flavour" .Values.sessions.practical) | nindent 4 }}
+  session-pod-mcq.json: |
+    {{- include "kubestronaut-sim.sessionPod" (dict "ctx" . "file" "files/session-pod-mcq.yaml" "flavour" .Values.sessions.mcq) | nindent 4 }}
+{{- end }}

--- a/deploy/helm/kubestronaut-sim/templates/deployment.yaml
+++ b/deploy/helm/kubestronaut-sim/templates/deployment.yaml
@@ -1,0 +1,173 @@
+{{- $sessions := or (gt (int .Values.sessions.practical.seats) 0) (gt (int .Values.sessions.mcq.seats) 0) -}}
+{{- $secret := include "kubestronaut-sim.secretName" . -}}
+
+{{/* Checked here rather than left to the hub's own boot-time check.
+     Both refuse, but only one of them refuses before anything is
+     applied — and a hub that CrashLoopBackOffs on a missing client ID
+     has already replaced the working one. */}}
+{{- if eq .Values.hub.auth.mode "github" -}}
+{{- if not .Values.hub.baseURL -}}
+{{- fail "kubestronaut-sim: hub.baseURL is required — it is the OAuth redirect target and the address session Pods post attempts back to" -}}
+{{- end -}}
+{{- if and (not .Values.hub.existingSecret) (not (include "kubestronaut-sim.createSecret" .)) -}}
+{{- fail "kubestronaut-sim: hub.auth.mode=github needs COOKIE_KEY, GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET — set hub.existingSecret or hub.secret.*" -}}
+{{- end -}}
+{{- end -}}
+{{- if not (has .Values.hub.auth.mode (list "github" "header" "none")) -}}
+{{- fail (printf "kubestronaut-sim: hub.auth.mode=%q — want github, header or none" .Values.hub.auth.mode) -}}
+{{- end -}}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kubestronaut-sim.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubestronaut-sim.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.hub.replicas }}
+  # Recreate, not RollingUpdate: /state is ReadWriteOnce, so a second
+  # replica cannot mount it and a rolling upgrade would wait forever for
+  # a Pod that can never schedule. The cost is a few seconds of downtime
+  # on an upgrade, during which running sessions are untouched — they are
+  # Pods in their own right, and the hub re-adopts them when it comes
+  # back rather than counting their seats as free.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "kubestronaut-sim.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "kubestronaut-sim.labels" . | nindent 8 }}
+      annotations:
+        {{- if $sessions }}
+        # The Pod manifests are read once, at startup. Without this a
+        # `helm upgrade` that changes a session's spec would update the
+        # ConfigMap and leave the running hub stamping out the old one.
+        checksum/session-pods: {{ include (print $.Template.BasePath "/configmap-session-pods.yaml") . | sha256sum }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "kubestronaut-sim.serviceAccountName" . }}
+      # The hub is the one process here that talks to the Kubernetes API,
+      # so it is the one that needs its token.
+      automountServiceAccountToken: {{ $sessions }}
+      enableServiceLinks: false
+      {{- with .Values.images.pullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: hub
+          image: {{ include "kubestronaut-sim.image" (dict "ctx" . "name" "hub") | quote }}
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          # A FROM scratch image with one static binary and one writable
+          # volume. There is nothing else here to protect.
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - {name: ADDR, value: ":8080"}
+            - {name: STATE_DIR, value: "/state"}
+            - {name: AUTH_MODE, value: {{ .Values.hub.auth.mode | quote }}}
+            - {name: AUTH_HEADER, value: {{ .Values.hub.auth.header | quote }}}
+            - {name: SESSION_TTL, value: {{ .Values.hub.auth.ttl | quote }}}
+            - {name: COOKIE_SECURE, value: {{ .Values.hub.auth.cookieSecure | quote }}}
+            - {name: HUB_BASE_URL, value: {{ .Values.hub.baseURL | quote }}}
+
+            # optional: true throughout, and not because they are
+            # optional. In header and none modes there may legitimately
+            # be no GitHub app at all — and COOKIE_KEY is what turns
+            # durable history on rather than what turns login on, so a
+            # self-hoster behind their own SSO sets one and no client
+            # credentials. A hub that needs one of these and cannot find
+            # it says so by name at boot, which is a better error than a
+            # Pod that will not start.
+            - name: COOKIE_KEY
+              valueFrom:
+                secretKeyRef: {name: {{ $secret | quote }}, key: COOKIE_KEY, optional: true}
+            - name: GITHUB_CLIENT_ID
+              valueFrom:
+                secretKeyRef: {name: {{ $secret | quote }}, key: GITHUB_CLIENT_ID, optional: true}
+            - name: GITHUB_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef: {name: {{ $secret | quote }}, key: GITHUB_CLIENT_SECRET, optional: true}
+
+            {{- if $sessions }}
+            - {name: SESSION_NAMESPACE, value: {{ include "kubestronaut-sim.sessionNamespace" . | quote }}}
+            - {name: DEFAULT_KIND, value: {{ .Values.sessions.defaultKind | quote }}}
+            - {name: POD_PREFIX, value: {{ .Values.sessions.podPrefix | quote }}}
+            - {name: SESSION_MAX_AGE, value: {{ .Values.sessions.maxAge | quote }}}
+            - {name: IDLE_TIMEOUT, value: {{ .Values.sessions.idleTimeout | quote }}}
+            - {name: QUEUE_HOLD, value: {{ .Values.sessions.queueHold | quote }}}
+            - {name: BOOT_TIMEOUT, value: {{ .Values.sessions.bootTimeout | quote }}}
+            - {name: BOOT_CONCURRENCY, value: {{ .Values.sessions.bootConcurrency | quote }}}
+            {{- if gt (int .Values.sessions.practical.seats) 0 }}
+            - {name: PRACTICAL_SEATS, value: {{ .Values.sessions.practical.seats | quote }}}
+            - {name: PRACTICAL_BANK, value: {{ .Values.sessions.practical.bank | quote }}}
+            - {name: SESSION_POD_TEMPLATE, value: "/etc/hub/session-pod.json"}
+            {{- end }}
+            {{- if gt (int .Values.sessions.mcq.seats) 0 }}
+            - {name: MCQ_SEATS, value: {{ .Values.sessions.mcq.seats | quote }}}
+            - {name: MCQ_BANK, value: {{ .Values.sessions.mcq.bank | quote }}}
+            - {name: SESSION_POD_TEMPLATE_MCQ, value: "/etc/hub/session-pod-mcq.json"}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.hub.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - {name: state, mountPath: /state}
+            {{- if $sessions }}
+            - {name: session-pods, mountPath: /etc/hub, readOnly: true}
+            {{- end }}
+          # /healthz answers before any of the interesting wiring, which
+          # is what makes it a liveness probe and not a readiness one: a
+          # hub whose Kubernetes credentials are wrong is still the right
+          # process to send traffic to, because it is the thing that will
+          # explain the failure.
+          readinessProbe:
+            httpGet: {path: /healthz, port: http}
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: {path: /healthz, port: http}
+            periodSeconds: 30
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.hub.resources | nindent 12 }}
+      volumes:
+        - name: state
+          persistentVolumeClaim:
+            claimName: {{ .Values.hub.state.existingClaim | default (printf "%s-state" (include "kubestronaut-sim.fullname" .)) }}
+        {{- if $sessions }}
+        - name: session-pods
+          configMap:
+            name: {{ include "kubestronaut-sim.fullname" . }}-session-pods
+        {{- end }}
+      {{- with .Values.hub.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.hub.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.hub.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/kubestronaut-sim/templates/httproute.yaml
+++ b/deploy/helm/kubestronaut-sim/templates/httproute.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.httpRoute.enabled }}
+{{- if not .Values.httpRoute.parentRefs }}
+{{- fail "kubestronaut-sim: httpRoute.enabled needs at least one httpRoute.parentRefs entry naming the Gateway to attach to" }}
+{{- end }}
+# Offered because it is what this project's own deployment uses. Any
+# other way of getting HTTP to the Service works as well — the hub cares
+# about one thing in front of it, which is that a WebSocket may stay open
+# for hours: the desktop stream is one, and a gateway with a short idle
+# timeout will cut it. websockify pings every 30s from inside the session
+# so the connection is never actually idle, but a hard maximum-lifetime
+# setting will still end it.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "kubestronaut-sim.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubestronaut-sim.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.httpRoute.parentRefs | nindent 4 }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ include "kubestronaut-sim.fullname" . }}
+          port: {{ .Values.hub.service.port }}
+{{- end }}

--- a/deploy/helm/kubestronaut-sim/templates/networkpolicy.yaml
+++ b/deploy/helm/kubestronaut-sim/templates/networkpolicy.yaml
@@ -1,6 +1,7 @@
+{{- if and .Values.sessions.networkPolicy.enabled (or (gt (int .Values.sessions.practical.seats) 0) (gt (int .Values.sessions.mcq.seats) 0)) }}
 # What a hosted session is allowed to talk to.
 #
-# Deploy this WITH the session Pod, not after it. A practical session
+# Installed with the hub, before any session exists. A practical session
 # runs a privileged container and hands a stranger a root shell with a
 # container runtime in it; this is the boundary around that, and the Pod
 # spec on its own does not have one.
@@ -51,22 +52,44 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: session
-  namespace: kubestronaut-sim
+  name: {{ include "kubestronaut-sim.fullname" . }}-session
+  namespace: {{ include "kubestronaut-sim.sessionNamespace" . }}
   labels:
-    app.kubernetes.io/name: kubestronaut-sim
-    app.kubernetes.io/component: session
+    {{- include "kubestronaut-sim.labels" . | nindent 4 }}
 spec:
+  # The labels the hub stamps on every session Pod it creates, in both
+  # flavours. Not the chart's own selector labels: these Pods are not
+  # part of the release, they are created and destroyed by the hub long
+  # after `helm install` returned.
   podSelector:
     matchLabels:
       app.kubernetes.io/name: kubestronaut-sim
       app.kubernetes.io/component: session
-  # Egress only, deliberately. Ingress belongs with the hub, which is
-  # the only thing that should ever reach a session and does not exist
-  # yet; a rule written before there is something to name would either
-  # be guesswork or would have to encode node addressing to keep
-  # `kubectl port-forward` working, and both are worse than saying so.
+  {{- if .Values.sessions.networkPolicy.restrictIngress }}
+  # Ingress as well: the hub is the only thing that should ever reach a
+  # session, and it reaches exactly one port. Off by default because
+  # whether the kubelet's readiness probe is subject to policy depends
+  # on the CNI, and a probe that is refused makes every session boot
+  # time out. `kubectl port-forward` is unaffected either way — it
+  # enters the Pod's network namespace rather than the dataplane.
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "kubestronaut-sim.selectorLabels" . | nindent 14 }}
+          {{- if ne (include "kubestronaut-sim.sessionNamespace" .) .Release.Namespace }}
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+          {{- end }}
+      ports:
+        - {protocol: TCP, port: 8080}
+  {{- else }}
+  # Egress only. The ingress half is sessions.networkPolicy.restrictIngress,
+  # which is off by default for a reason worth reading before turning on.
   policyTypes: [Egress]
+  {{- end }}
   egress:
     # DNS. Named by the Pods that serve it rather than by the Service
     # address, because that address is in a range denied below.
@@ -98,3 +121,4 @@ spec:
               - 100.64.0.0/10     # RFC6598 carrier-grade NAT
               - 169.254.0.0/16    # link-local, incl. cloud metadata
               - 224.0.0.0/4       # multicast
+{{- end }}

--- a/deploy/helm/kubestronaut-sim/templates/pvc.yaml
+++ b/deploy/helm/kubestronaut-sim/templates/pvc.yaml
@@ -1,0 +1,33 @@
+{{- if not .Values.hub.state.existingClaim }}
+# Attempt history: one JSON document per user plus the full results of
+# every graded attempt.
+#
+# It is the only thing in this deployment that is not disposable. A
+# session Pod's own /state dies with the Pod by design — that is what
+# makes a seat reclaimable — so this volume is where "the score you got
+# last Tuesday" actually lives.
+#
+# ReadWriteOnce, and the Deployment is `Recreate` for that reason: two
+# replicas would either fail to schedule or, with a RWX class, race each
+# other writing the same user's document.
+#
+# helm.sh/resource-policy: keep — an uninstall must not take a
+# candidate's history with it. Delete the PVC by hand if you mean it.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "kubestronaut-sim.fullname" . }}-state
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubestronaut-sim.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  accessModes: ["ReadWriteOnce"]
+  {{- with .Values.hub.state.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.hub.state.size | quote }}
+{{- end }}

--- a/deploy/helm/kubestronaut-sim/templates/rbac.yaml
+++ b/deploy/helm/kubestronaut-sim/templates/rbac.yaml
@@ -1,0 +1,40 @@
+{{- if or (gt (int .Values.sessions.practical.seats) 0) (gt (int .Values.sessions.mcq.seats) 0) }}
+# Everything the hub is allowed to do to the cluster.
+#
+# Four verbs on one resource in one namespace, which is the whole of the
+# hub's Kubernetes client: create a session Pod, watch it become ready,
+# delete it, and list them to re-adopt its own sessions after a restart.
+# It reads no Secrets, creates no workloads, and touches nothing outside
+# the session namespace.
+#
+# A Role, not a ClusterRole, deliberately: a session Pod is a privileged
+# container, and the process that creates them should not be able to
+# create one anywhere else in the cluster.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "kubestronaut-sim.fullname" . }}-sessions
+  namespace: {{ include "kubestronaut-sim.sessionNamespace" . }}
+  labels:
+    {{- include "kubestronaut-sim.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "kubestronaut-sim.fullname" . }}-sessions
+  namespace: {{ include "kubestronaut-sim.sessionNamespace" . }}
+  labels:
+    {{- include "kubestronaut-sim.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "kubestronaut-sim.fullname" . }}-sessions
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kubestronaut-sim.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/helm/kubestronaut-sim/templates/secret.yaml
+++ b/deploy/helm/kubestronaut-sim/templates/secret.yaml
@@ -1,0 +1,26 @@
+{{- if include "kubestronaut-sim.createSecret" . }}
+# Created only when the credentials are set inline in values.
+#
+# The other path — hub.existingSecret — is the one a real deployment
+# uses: an ExternalSecret, a sealed secret, or anything else that keeps
+# the values out of a values file. The keys are the same either way,
+# because they are the environment variable names the hub reads.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kubestronaut-sim.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubestronaut-sim.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- with .Values.hub.secret.cookieKey }}
+  COOKIE_KEY: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.hub.secret.githubClientID }}
+  GITHUB_CLIENT_ID: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.hub.secret.githubClientSecret }}
+  GITHUB_CLIENT_SECRET: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/kubestronaut-sim/templates/service.yaml
+++ b/deploy/helm/kubestronaut-sim/templates/service.yaml
@@ -1,0 +1,22 @@
+# The hub's only door. Point your Ingress, Gateway or tunnel here.
+#
+# Session Pods deliberately get no Service: they are addressed by Pod IP
+# by the hub and by nothing else, and a Service in front of them would be
+# a second way to reach a candidate's exam that does not check who is
+# asking.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kubestronaut-sim.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubestronaut-sim.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.hub.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.hub.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "kubestronaut-sim.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/kubestronaut-sim/templates/serviceaccount.yaml
+++ b/deploy/helm/kubestronaut-sim/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kubestronaut-sim.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubestronaut-sim.labels" . | nindent 4 }}

--- a/deploy/helm/kubestronaut-sim/values.yaml
+++ b/deploy/helm/kubestronaut-sim/values.yaml
@@ -1,0 +1,198 @@
+# A hosted kubestronaut-sim.
+#
+# Two things are deployed from here: the hub, which is the only process
+# reachable from the internet, and the Pod manifests it stamps out once
+# per candidate. The manifests are not templated — they are the files in
+# files/, applied as written, with only the handful of fields below
+# rewritten. That is deliberate: they were debugged against a real
+# cluster as concrete YAML and they stay readable as concrete YAML.
+#
+# Everything a deployment is allowed to differ in is on this page.
+
+# -------------------------------------------------------------------
+# Images
+#
+# Every image this chart runs is `<prefix><name>:<tag>` — the seven
+# session images plus the hub, all published by one release workflow, so
+# one prefix and one tag name all eight. Change `prefix` to pull from a
+# mirror or a private registry; the names after it are fixed.
+images:
+  prefix: docker.io/cjoga/kubestronaut-sim-
+  # Empty means Chart.appVersion, which is the release these manifests
+  # were written against. Pin it here to deploy a different one.
+  tag: ""
+  # IfNotPresent because a released tag is immutable and k8s-env is
+  # 2.6 GB — re-checking that on every session boot costs minutes for
+  # nothing. Set Always if you point `tag` at a mutable tag like `dev`.
+  pullPolicy: IfNotPresent
+  # Names of imagePullSecrets, for a private registry.
+  pullSecrets: []
+
+# -------------------------------------------------------------------
+# The hub
+hub:
+  replicas: 1
+
+  # Where a browser reaches the hub, scheme and host, no trailing slash.
+  # REQUIRED: it is the OAuth redirect target and the address session
+  # Pods post their graded attempts back to.
+  baseURL: ""
+
+  auth:
+    # github — the hosted tier: any GitHub account may sign in.
+    # header  — trust a header set by a proxy in front of this. For a
+    #           self-hoster who already has SSO. The hub says at boot
+    #           that it MUST NOT be reachable except through that proxy.
+    # none    — no identity at all. Everyone is the same user.
+    mode: github
+    # Only read when mode is header.
+    header: X-Forwarded-User
+    # How long a login lasts.
+    ttl: 12h
+    # Set false only if you terminate TLS somewhere the cookie cannot
+    # reach — which for an internet-facing deployment means: do not.
+    cookieSecure: true
+
+  # Credentials. Either name a Secret that already exists (an
+  # ExternalSecret, a sealed secret, whatever you use) or set the values
+  # inline and let the chart create one. The keys are the same either
+  # way: COOKIE_KEY, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET.
+  #
+  # COOKIE_KEY signs two things with two different keys derived from it:
+  # login cookies, and the per-Pod tickets a session presents to record a
+  # graded attempt. Rotating it logs everyone out and invalidates
+  # in-flight tickets; losing it does the same. It is not generated here
+  # on purpose — a chart that minted one would rotate it on every
+  # upgrade that missed the old value.
+  existingSecret: ""
+  secret:
+    cookieKey: ""
+    githubClientID: ""
+    githubClientSecret: ""
+
+  # Durable per-user history: one JSON document per user plus the full
+  # results of each attempt. Small — an attempt is tens of KB — but it is
+  # the only thing in this deployment that is not disposable.
+  state:
+    size: 5Gi
+    # Empty uses the cluster default StorageClass.
+    storageClass: ""
+    # Name an existing PVC to keep history across a `helm uninstall`.
+    existingClaim: ""
+
+  service:
+    type: ClusterIP
+    port: 80
+
+  resources:
+    requests: {cpu: 10m, memory: 32Mi}
+    limits: {cpu: 500m, memory: 256Mi}
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+  # Extra environment for the hub, as a plain env list. An escape hatch
+  # for a knob this chart has not grown a value for yet.
+  extraEnv: []
+
+# -------------------------------------------------------------------
+# Sessions
+#
+# The caps. Every number here is a value because the whole scaling story
+# is "more seats on more nodes" — none of it is a code change.
+sessions:
+  # Empty means the release namespace. The hub can only create Pods in a
+  # namespace its Role covers, and the chart writes that Role here.
+  namespace: ""
+
+  # Which flavour POST /api/session/start admits into when the caller
+  # does not say.
+  defaultKind: practical
+
+  # How long a seat may be held before it is taken back, whatever the
+  # candidate is doing. The ticket a Pod records attempts with outlives
+  # this by an hour so a grade in the final minutes still lands.
+  maxAge: 10h
+  # No request from the browser for this long and the seat is reclaimed.
+  idleTimeout: 30m
+  # The head of the queue is offered a hold, not a seat. This is how long
+  # they have to claim it before it passes to the next person — a browser
+  # closed an hour ago must not keep a seat warm.
+  queueHold: 2m
+  # A boot that has not reached ready by now is declared failed. A cold
+  # practical session builds a two-node cluster.
+  bootTimeout: 20m
+  # Pod creations in flight at once, across all flavours. Boot is
+  # CPU-bound: one measured session took a 4-core node to 3090m while
+  # memory stayed at 25%, so two boots on one node do not take turns,
+  # they both crawl. Raise this only with nodes to spread them over.
+  bootConcurrency: 1
+  # Pod names are <prefix>-<flavour>-<short hash of the user>.
+  podPrefix: sim-session
+
+  practical:
+    # 0 seats disables the flavour: no template is loaded and
+    # /api/session/start refuses it.
+    seats: 3
+    bank: ckad-mock-01
+    # A practical session is a privileged Pod that hands a stranger a
+    # root shell with a container runtime in it. Confine it to nodes you
+    # have decided may run that, and label them to match.
+    #
+    # To schedule anywhere instead, set this to `null` and not to `{}` —
+    # Helm merges maps from your values over the defaults rather than
+    # replacing them, so an empty map here leaves the label requirement
+    # below in place and nothing tells you.
+    nodeSelector:
+      kubestronaut-sim/session: "true"
+    tolerations: []
+    # Per-container overrides, merged over what files/session-pod.yaml
+    # declares. The manifest's numbers are measured; change them here
+    # rather than editing it, e.g.
+    #   resources:
+    #     k8s-env:
+    #       limits: {memory: 8Gi}
+    resources: {}
+
+  mcq:
+    # An MCQ session is a facilitator and 128Mi. It needs no cluster, no
+    # shells and no privilege, so it schedules anywhere and the cap is
+    # about a hundred times higher.
+    seats: 30
+    bank: kcna-mock
+    nodeSelector: {}
+    tolerations: []
+    resources: {}
+
+  # What a session Pod may talk to. Not optional in any deployment that
+  # sells seats to strangers: without it a session reaches the cluster's
+  # own API server and every other namespace's Pods.
+  networkPolicy:
+    enabled: true
+    # Also refuse ingress to a session Pod from anything but the hub.
+    #
+    # Off by default because it is the one rule here that can break a
+    # working deployment rather than fail closed: the port a session
+    # serves is reached by the hub in-cluster, but also by the kubelet's
+    # readiness probe, and whether probe traffic is subject to policy
+    # depends on the CNI. `kubectl port-forward` is unaffected either way
+    # — it enters the Pod's network namespace rather than the dataplane.
+    # Turn it on, then confirm sessions still reach ready.
+    restrictIngress: false
+
+# -------------------------------------------------------------------
+# Routing
+#
+# The chart publishes a ClusterIP Service and stops there: point your
+# own Ingress, Gateway or tunnel at it. A Gateway API HTTPRoute is
+# offered because that is what this project's own deployment uses.
+httpRoute:
+  enabled: false
+  # e.g. [{name: my-gateway, namespace: gateway-system, sectionName: https}]
+  parentRefs: []
+  hostnames: []
+  annotations: {}
+
+nameOverride: ""
+fullnameOverride: ""

--- a/deploy/session-networkpolicy.yaml
+++ b/deploy/session-networkpolicy.yaml
@@ -1,0 +1,100 @@
+# What a hosted session is allowed to talk to.
+#
+# Deploy this WITH the session Pod, not after it. A practical session
+# runs a privileged container and hands a stranger a root shell with a
+# container runtime in it; this is the boundary around that, and the Pod
+# spec on its own does not have one.
+#
+# ---------------------------------------------------------------------
+# What this policy does NOT do, so nobody reads it as more than it is
+#
+# It does not restore the documentation allowlist as a network boundary.
+# That is not a gap to be closed later — it cannot be closed in a
+# single-Pod session, and the reason is worth writing down.
+#
+# Under compose the exam has three networks. `desktop` sits only on
+# `examnet`, which runs with masquerade off, so it cannot reach the
+# internet at all and Firefox's only route out is `docs-proxy`. The two
+# instances sit on `examnet` AND `default`, so they have ordinary
+# internet access — measured, not assumed: `curl https://example.com`
+# from instance-1 answers 200 while the same call from the desktop times
+# out. The instances need it, because a question builds an image
+# `FROM alpine:3.21` and podman pulls that from Docker Hub.
+#
+# A Pod is one network namespace shared by every container, and a
+# NetworkPolicy selects Pods, not containers. So the desktop and the
+# instances necessarily get the same egress, and the instances' egress
+# is load-bearing. Splitting `docs-proxy` into its own Pod would not
+# help — the hole is the instances, not the proxy.
+#
+# The practical effect is narrower than it first sounds: the allowlist
+# still governs the browser (Firefox is configured to use the proxy, and
+# a non-allowlisted host returns "blocked by exam docs allowlist"), and
+# a candidate determined to search the web from an instance shell could
+# already do that in the local product. Recorded in docs/follow-ups.md.
+#
+# ---------------------------------------------------------------------
+# What it does do
+#
+# It stops a session reaching the infrastructure hosting it. Measured on
+# an unpoliced session Pod: an instance reached the cluster's API server
+# and got a 401 — rejected for want of a credential, which is not the
+# same as unreachable, and `automountServiceAccountToken: false` is the
+# only reason there was no credential to present. Everything private is
+# denied here instead: the cluster's own API and Services, every other
+# namespace's Pods, the nodes, and the link-local range that cloud
+# metadata services answer on.
+#
+# Addressed by reserved range rather than by this cluster's addressing,
+# so it carries no deployment detail and a self-hoster can apply it
+# unedited.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: session
+  namespace: kubestronaut-sim
+  labels:
+    app.kubernetes.io/name: kubestronaut-sim
+    app.kubernetes.io/component: session
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kubestronaut-sim
+      app.kubernetes.io/component: session
+  # Egress only, deliberately. Ingress belongs with the hub, which is
+  # the only thing that should ever reach a session and does not exist
+  # yet; a rule written before there is something to name would either
+  # be guesswork or would have to encode node addressing to keep
+  # `kubectl port-forward` working, and both are worse than saying so.
+  policyTypes: [Egress]
+  egress:
+    # DNS. Named by the Pods that serve it rather than by the Service
+    # address, because that address is in a range denied below.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - {protocol: UDP, port: 53}
+        - {protocol: TCP, port: 53}
+    # The public internet, and nothing private. The instances need this
+    # for `podman pull`, and k8s-env needs it on a first boot whose
+    # add-on images are not already baked into the image.
+    #
+    # Note what is NOT excepted: 127.0.0.0/8. Every service in this Pod
+    # talks to every other over loopback inside the shared namespace,
+    # which never reaches the dataplane a NetworkPolicy acts on, and the
+    # inner kind cluster's own bridge is inside that namespace too.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8        # cluster Pods and Services
+              - 172.16.0.0/12     # RFC1918
+              - 192.168.0.0/16    # RFC1918
+              - 100.64.0.0/10     # RFC6598 carrier-grade NAT
+              - 169.254.0.0/16    # link-local, incl. cloud metadata
+              - 224.0.0.0/4       # multicast

--- a/deploy/session-pod-mcq.yaml
+++ b/deploy/session-pod-mcq.yaml
@@ -1,0 +1,107 @@
+# One multiple-choice exam session, as a single Pod.
+#
+# The second of the two flavours the hub stamps out. An MCQ attempt needs
+# no Kubernetes cluster, no candidate shells, no desktop and no registry:
+# the questions are answered in the browser. So this is the practical
+# Pod's eight containers minus six — around 128Mi against 4Gi, and it
+# schedules anywhere, unprivileged.
+#
+# It is a separate manifest rather than a toggle inside session-pod.yaml
+# because there is no YAML templating in this repo and no dependency that
+# would add it. Two files that each say plainly what they are beats one
+# that has to be read twice.
+#
+# The conductor is here and the desktop is not, which looks arbitrary
+# until you look at what answers GET /api/catalog: the facilitator, from
+# a server-side call to the conductor's bank list. Drop the conductor and
+# the exam picker has nothing to show. It is 32Mi.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sim-session-mcq
+  namespace: kubestronaut-sim
+  labels:
+    app.kubernetes.io/name: kubestronaut-sim
+    app.kubernetes.io/component: session
+    kubestronaut-sim/kind: mcq
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  enableServiceLinks: false
+  terminationGracePeriodSeconds: 10
+
+  # Same reason as the practical Pod: compose service names are used as
+  # hostnames in the code, and a Pod is one network namespace.
+  hostAliases:
+    - ip: "127.0.0.1"
+      hostnames: [facilitator, conductor]
+
+  initContainers:
+    - name: banks
+      image: cjoga/kubestronaut-sim-banks:dev
+      imagePullPolicy: Always
+      # /shared/ready is the authority on whether the environment is
+      # usable — every service gates on it, and bootstate treats its
+      # absence as "still booting" no matter what else it reads. Nothing
+      # boots here, so it is written once, now. Without it the
+      # facilitator would serve a permanent boot screen over a session
+      # that was ready before it started.
+      command: ["sh", "-c", "cp -a /src/. /banks/ && touch /shared/ready"]
+      volumeMounts:
+        - {name: banks, mountPath: /banks}
+        - {name: shared, mountPath: /shared}
+      resources:
+        requests: {memory: "32Mi", cpu: "10m"}
+        limits: {memory: "128Mi", cpu: "200m"}
+
+  containers:
+    - name: conductor
+      image: cjoga/kubestronaut-sim-conductor:dev
+      imagePullPolicy: Always
+      env:
+        - {name: BANK, value: "kcna-mock"}
+        # No cluster and no instances to exec into. The ssh engine
+        # refuses a restart up front rather than part-way through, which
+        # is what keeps a switch from wiping state it cannot rebuild —
+        # and here the hub replaces the whole Pod anyway.
+        - {name: ENGINE, value: "ssh"}
+        - {name: INSTANCES, value: ""}
+        - {name: FACILITATOR_URL, value: "http://127.0.0.1:8080"}
+      volumeMounts:
+        - {name: banks, mountPath: /banks, readOnly: true}
+        - {name: shared, mountPath: /shared}
+      resources:
+        requests: {memory: "32Mi", cpu: "10m"}
+        limits: {memory: "128Mi", cpu: "200m"}
+
+    - name: facilitator
+      image: cjoga/kubestronaut-sim-facilitator:dev
+      imagePullPolicy: Always
+      ports:
+        - {name: http, containerPort: 8080}
+      env:
+        - {name: BANK, value: "kcna-mock"}
+        - {name: CONDUCTOR_ADDR, value: "127.0.0.1:9000"}
+        # No desktop container exists, so the proxy has nowhere to send
+        # /desktop/*. An MCQ bank never asks for one.
+        - {name: DESKTOP_ADDR, value: ""}
+      volumeMounts:
+        - {name: banks, mountPath: /banks, readOnly: true}
+        - {name: shared, mountPath: /shared, readOnly: true}
+        - {name: session, mountPath: /session}
+        # Ephemeral here as it is in the practical Pod: the hub owns
+        # durable history, and this is the local cache the webhook drains.
+        - {name: state, mountPath: /state}
+      readinessProbe:
+        httpGet: {path: /healthz, port: http}
+        periodSeconds: 5
+        failureThreshold: 24
+      resources:
+        requests: {memory: "64Mi", cpu: "10m"}
+        limits: {memory: "256Mi", cpu: "300m"}
+
+  volumes:
+    - {name: banks, emptyDir: {sizeLimit: 512Mi}}
+    - {name: shared, emptyDir: {sizeLimit: 16Mi}}
+    - {name: session, emptyDir: {sizeLimit: 64Mi}}
+    - {name: state, emptyDir: {sizeLimit: 64Mi}}

--- a/deploy/session-pod-mcq.yaml
+++ b/deploy/session-pod-mcq.yaml
@@ -60,6 +60,13 @@ spec:
       imagePullPolicy: Always
       env:
         - {name: BANK, value: "kcna-mock"}
+        # Same socket as the practical Pod, for uniformity rather than
+        # for a hole this flavour has: an MCQ session ships no shell and
+        # no desktop, so there is nothing here to reach :9000 from. One
+        # rule — the conductor never listens on TCP inside a Pod — is
+        # easier to keep true than one with an exemption, and this Pod
+        # is the one most likely to grow a container later.
+        - {name: LISTEN, value: "unix:/run/control/conductor.sock"}
         # No cluster and no instances to exec into. The ssh engine
         # refuses a restart up front rather than part-way through, which
         # is what keeps a switch from wiping state it cannot rebuild —
@@ -70,6 +77,7 @@ spec:
       volumeMounts:
         - {name: banks, mountPath: /banks, readOnly: true}
         - {name: shared, mountPath: /shared}
+        - {name: control, mountPath: /run/control}
       resources:
         requests: {memory: "32Mi", cpu: "10m"}
         limits: {memory: "128Mi", cpu: "200m"}
@@ -81,13 +89,14 @@ spec:
         - {name: http, containerPort: 8080}
       env:
         - {name: BANK, value: "kcna-mock"}
-        - {name: CONDUCTOR_ADDR, value: "127.0.0.1:9000"}
+        - {name: CONDUCTOR_ADDR, value: "unix:/run/control/conductor.sock"}
         # No desktop container exists, so the proxy has nowhere to send
         # /desktop/*. An MCQ bank never asks for one.
         - {name: DESKTOP_ADDR, value: ""}
       volumeMounts:
         - {name: banks, mountPath: /banks, readOnly: true}
         - {name: shared, mountPath: /shared, readOnly: true}
+        - {name: control, mountPath: /run/control}
         - {name: session, mountPath: /session}
         # Ephemeral here as it is in the practical Pod: the hub owns
         # durable history, and this is the local cache the webhook drains.
@@ -103,5 +112,8 @@ spec:
   volumes:
     - {name: banks, emptyDir: {sizeLimit: 512Mi}}
     - {name: shared, emptyDir: {sizeLimit: 16Mi}}
+    # One socket, and mounted into the conductor and the facilitator
+    # only. See the LISTEN comment above.
+    - {name: control, emptyDir: {sizeLimit: 1Mi}}
     - {name: session, emptyDir: {sizeLimit: 64Mi}}
     - {name: state, emptyDir: {sizeLimit: 64Mi}}

--- a/deploy/session-pod-mcq.yaml
+++ b/deploy/session-pod-mcq.yaml
@@ -93,6 +93,10 @@ spec:
         # No desktop container exists, so the proxy has nowhere to send
         # /desktop/*. An MCQ bank never asks for one.
         - {name: DESKTOP_ADDR, value: ""}
+        # Filled per session by the hub. See the practical Pod for what
+        # the ticket is and why it lives in the spec.
+        - {name: HISTORY_WEBHOOK_URL, value: ""}
+        - {name: HISTORY_WEBHOOK_TOKEN, value: ""}
       volumeMounts:
         - {name: banks, mountPath: /banks, readOnly: true}
         - {name: shared, mountPath: /shared, readOnly: true}

--- a/deploy/session-pod.yaml
+++ b/deploy/session-pod.yaml
@@ -243,6 +243,20 @@ spec:
         - {name: BANK, value: "ckad-mock-01"}
         - {name: CONDUCTOR_ADDR, value: "unix:/run/control/conductor.sock"}
         - {name: DESKTOP_ADDR, value: "127.0.0.1:6080"}
+        # Declared empty and filled per session by the hub, the same way
+        # BANK is. This Pod's /state dies with it, so the copy posted
+        # here is the one the candidate still has tomorrow.
+        #
+        # The token is a ticket naming one user, minted at Pod creation
+        # and good for appending to that user's history and nothing
+        # else. It is in the Pod spec rather than a Secret because that
+        # is one fewer object to create, delete and grant the hub RBAC
+        # over, and reading it needs Pod-read in this namespace — which
+        # is already inside the accepted threat model for a Pod that
+        # runs a privileged container. Unset under compose, where
+        # nothing is collecting attempts.
+        - {name: HISTORY_WEBHOOK_URL, value: ""}
+        - {name: HISTORY_WEBHOOK_TOKEN, value: ""}
       volumeMounts:
         - {name: banks, mountPath: /banks, readOnly: true}
         - {name: shared, mountPath: /shared, readOnly: true}

--- a/deploy/session-pod.yaml
+++ b/deploy/session-pod.yaml
@@ -210,6 +210,14 @@ spec:
       image: cjoga/kubestronaut-sim-conductor:dev
       imagePullPolicy: Always
       env:
+        # A unix socket, not :9000. Compose keeps the conductor off the
+        # exam network entirely (`controlnet: internal: true`); one Pod
+        # is one network namespace, so the same TCP port would sit on
+        # the candidate's own loopback and let a shell on an instance
+        # reset their cluster. The control volume below is mounted into
+        # this container and the facilitator, and nowhere else — that
+        # mount is the boundary compose drew with a network.
+        - {name: LISTEN, value: "unix:/run/control/conductor.sock"}
         # No Docker socket in a Pod. Reset and switch are the hub's job
         # (it recycles this Pod); ssh covers training-mode reseed, which
         # is the only live exec left.
@@ -219,6 +227,7 @@ spec:
       volumeMounts:
         - {name: banks, mountPath: /banks, readOnly: true}
         - {name: shared, mountPath: /shared}
+        - {name: control, mountPath: /run/control}
       resources:
         requests: {memory: "32Mi", cpu: "10m"}
         limits: {memory: "128Mi", cpu: "200m"}
@@ -232,11 +241,13 @@ spec:
         - {name: http, containerPort: 8080}
       env:
         - {name: BANK, value: "ckad-mock-01"}
-        - {name: CONDUCTOR_ADDR, value: "127.0.0.1:9000"}
+        - {name: CONDUCTOR_ADDR, value: "unix:/run/control/conductor.sock"}
         - {name: DESKTOP_ADDR, value: "127.0.0.1:6080"}
       volumeMounts:
         - {name: banks, mountPath: /banks, readOnly: true}
         - {name: shared, mountPath: /shared, readOnly: true}
+        # The only other container that may reach the control API.
+        - {name: control, mountPath: /run/control}
         - {name: session, mountPath: /session}
         # Separate from /session deliberately: /session is one attempt's
         # scratch, /state is every graded attempt. Under compose their
@@ -255,6 +266,11 @@ spec:
   volumes:
     - {name: banks, emptyDir: {sizeLimit: 512Mi}}
     - {name: shared, emptyDir: {sizeLimit: 256Mi}}
+    # Holds one socket and must stay that way. It is mounted into the
+    # conductor and the facilitator only; anything else mounted here
+    # gets the control API, which is the thing this volume exists to
+    # keep away from the candidate's shell.
+    - {name: control, emptyDir: {sizeLimit: 1Mi}}
     # The inner dockerd: kind node images plus whatever the candidate
     # builds. The single largest consumer of node disk.
     - {name: dind, emptyDir: {sizeLimit: 20Gi}}

--- a/deploy/session-pod.yaml
+++ b/deploy/session-pod.yaml
@@ -1,0 +1,269 @@
+# One practical exam session, as a single Pod.
+#
+# This is the compose stack translated container-for-container. It is kept
+# as a concrete manifest rather than a chart template so it can be applied
+# and debugged directly; the Helm chart wraps this once it boots clean.
+#
+# Three things differ from docker-compose.yaml, and only three:
+#
+#   1. hostAliases. Compose gives every service a DNS name on a user
+#      network. A Pod is one network namespace, so those names resolve
+#      nowhere — and they are not only internal: banks/ckad-mock-01/q09
+#      has the candidate type `podman push registry:5000/...`. Every
+#      service name is aliased to 127.0.0.1 so bank content, the ssh
+#      targets and every hardcoded address keep working untouched.
+#
+#   2. /banks. Compose bind-mounts ./banks from the host into five
+#      services. There is no host here, so the banks ship as their own
+#      image and an init container stages them into a shared volume.
+#
+#   3. The conductor has no Docker socket. It is the only container that
+#      mounts one under compose, and a Pod cannot provide it. ENGINE=ssh
+#      replaces the three Engine calls; reset and switch are the hub's
+#      job here, so only training-mode reseed still needs the conductor.
+#
+# imagePullPolicy: Always on every first-party image, because :dev is a
+# mutable tag — without it the node serves its cached copy and a rebuild
+# never reaches the Pod. Upstream pinned tags (registry:2) keep the
+# default IfNotPresent on purpose.
+#
+# The privilege story: k8s-env is privileged because it runs dockerd and
+# `kind create cluster`. The instances are NOT — they carry exactly the
+# five capabilities compose gives them, and BUILDAH_ISOLATION=chroot in
+# their image is what makes a build work without the host cgroup
+# namespace. See docs/follow-ups.md.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sim-session
+  namespace: kubestronaut-sim
+  labels:
+    app.kubernetes.io/name: kubestronaut-sim
+    app.kubernetes.io/component: session
+    kubestronaut-sim/kind: practical
+spec:
+  restartPolicy: Never
+  # Nothing in this Pod talks to the Kubernetes API. The cluster the
+  # candidate works against is the kind cluster inside k8s-env.
+  automountServiceAccountToken: false
+  enableServiceLinks: false
+  nodeSelector:
+    kubestronaut-sim/session: "true"
+  terminationGracePeriodSeconds: 30
+
+  # Every compose service name, resolved inside the namespace they share.
+  #
+  # The instances get their own loopback addresses rather than sharing
+  # .1: both run sshd on 22 and only one can bind it per namespace. All
+  # of 127.0.0.0/8 is loopback, so giving each its own address keeps the
+  # port free — `ssh instance-1` from the desktop and the facilitator's
+  # sshArgs both work unchanged, with no ssh_config and no -p anywhere.
+  hostAliases:
+    - ip: "127.0.0.1"
+      hostnames: [k8s-env, registry, docs-proxy, desktop, conductor, facilitator]
+    - ip: "127.0.0.2"
+      hostnames: [instance-1]
+    - ip: "127.0.0.3"
+      hostnames: [instance-2]
+
+  initContainers:
+    # Banks are content, not code, and they are read by five containers
+    # built from three different Docker contexts. Staging them once from
+    # their own image keeps a single source of truth and lets a bank
+    # update ship without rebuilding the facilitator.
+    - name: banks
+      image: cjoga/kubestronaut-sim-banks:dev
+      imagePullPolicy: Always
+      command: ["sh", "-c", "cp -a /src/. /banks/"]
+      volumeMounts:
+        - {name: banks, mountPath: /banks}
+      resources:
+        requests: {memory: "32Mi", cpu: "10m"}
+        limits: {memory: "128Mi", cpu: "200m"}
+
+  containers:
+    # ---------------------------------------------------------------
+    - name: k8s-env
+      image: cjoga/kubestronaut-sim-k8s-env:dev
+      imagePullPolicy: Always
+      # dockerd + kind. This is the one container that genuinely needs it.
+      securityContext:
+        privileged: true
+      env:
+        - {name: BANK, value: "ckad-mock-01"}
+        # Lets the conductor reach this container over ssh (ENGINE=ssh).
+        # Explicit address because the instances hold :22 on .2 and .3;
+        # binding 0.0.0.0 here would lock them out.
+        - {name: SSHD_LISTEN, value: "127.0.0.1"}
+      volumeMounts:
+        - {name: shared, mountPath: /shared}
+        - {name: dind, mountPath: /var/lib/docker}
+        - {name: banks, mountPath: /banks, readOnly: true}
+      startupProbe:
+        # bootstrap.sh traps its own errors into /shared/boot.json, which
+        # the UI reads, so this is a liveness gate and not the failure
+        # detector. Generous for the same reason the compose healthcheck
+        # is: a cold first boot builds a two-node cluster.
+        exec: {command: ["test", "-f", "/shared/ready"]}
+        periodSeconds: 10
+        failureThreshold: 180
+      resources:
+        requests: {memory: "2Gi", cpu: "300m"}
+        limits: {memory: "6Gi", cpu: "2000m"}
+
+    # ---------------------------------------------------------------
+    # The two candidate shells. Identical but for their course and
+    # container-storage volumes.
+    - name: instance-1
+      image: cjoga/kubestronaut-sim-instance:dev
+      imagePullPolicy: Always
+      securityContext:
+        capabilities:
+          # Measured one failure at a time; see docker-compose.yaml.
+          add: [SYS_ADMIN, SYS_CHROOT, MKNOD, SETFCAP, SYS_RESOURCE]
+        seccompProfile: {type: Unconfined}
+        appArmorProfile: {type: Unconfined}
+      env:
+        - {name: BANK, value: "ckad-mock-01"}
+        # Matches this instance's hostAlias; see the note there.
+        - {name: SSHD_LISTEN, value: "127.0.0.2"}
+        # Every container in a Pod shares one UTS namespace, so without
+        # this the prompt here is the Pod's name — identical to the one
+        # the candidate typed `ssh instance-1` at. See the entrypoint.
+        - {name: SIM_HOSTNAME, value: "instance-1"}
+      volumeMounts:
+        - {name: shared, mountPath: /shared, readOnly: true}
+        - {name: banks, mountPath: /banks, readOnly: true}
+        - {name: course-1, mountPath: /opt/course}
+        - {name: containers-1, mountPath: /var/lib/containers}
+      resources:
+        requests: {memory: "512Mi", cpu: "50m"}
+        limits: {memory: "1536Mi", cpu: "500m"}
+
+    - name: instance-2
+      image: cjoga/kubestronaut-sim-instance:dev
+      imagePullPolicy: Always
+      securityContext:
+        capabilities:
+          add: [SYS_ADMIN, SYS_CHROOT, MKNOD, SETFCAP, SYS_RESOURCE]
+        seccompProfile: {type: Unconfined}
+        appArmorProfile: {type: Unconfined}
+      env:
+        - {name: BANK, value: "ckad-mock-01"}
+        - {name: SSHD_LISTEN, value: "127.0.0.3"}
+        - {name: SIM_HOSTNAME, value: "instance-2"}
+      volumeMounts:
+        - {name: shared, mountPath: /shared, readOnly: true}
+        - {name: banks, mountPath: /banks, readOnly: true}
+        - {name: course-2, mountPath: /opt/course}
+        - {name: containers-2, mountPath: /var/lib/containers}
+      resources:
+        requests: {memory: "512Mi", cpu: "50m"}
+        limits: {memory: "1536Mi", cpu: "500m"}
+
+    # ---------------------------------------------------------------
+    # Push target for the image-building questions. Plain HTTP, no auth —
+    # it exists so `podman push` from an instance has somewhere to go.
+    - name: registry
+      image: registry:2
+      env:
+        - {name: REGISTRY_STORAGE_DELETE_ENABLED, value: "true"}
+      volumeMounts:
+        - {name: registry-data, mountPath: /var/lib/registry}
+      resources:
+        requests: {memory: "64Mi", cpu: "10m"}
+        limits: {memory: "256Mi", cpu: "200m"}
+
+    # ---------------------------------------------------------------
+    # The docs allowlist. Under compose, examnet's masquerade-off is what
+    # forced traffic through here; one netns cannot express that, so this
+    # is now enforced by Firefox's proxy policy alone. Recorded as a
+    # hosted-mode divergence — a NetworkPolicy still bounds the Pod.
+    - name: docs-proxy
+      image: cjoga/kubestronaut-sim-docs-proxy:dev
+      imagePullPolicy: Always
+      env:
+        - {name: BANK, value: "ckad-mock-01"}
+      volumeMounts:
+        - {name: banks, mountPath: /banks, readOnly: true}
+        - {name: shared, mountPath: /shared, readOnly: true}
+      resources:
+        requests: {memory: "32Mi", cpu: "10m"}
+        limits: {memory: "128Mi", cpu: "200m"}
+
+    # ---------------------------------------------------------------
+    - name: desktop
+      image: cjoga/kubestronaut-sim-desktop:dev
+      imagePullPolicy: Always
+      volumeMounts:
+        - {name: shared, mountPath: /shared, readOnly: true}
+      readinessProbe:
+        httpGet: {path: /vnc.html, port: 6080}
+        periodSeconds: 10
+        failureThreshold: 30
+      resources:
+        requests: {memory: "768Mi", cpu: "100m"}
+        limits: {memory: "2Gi", cpu: "500m"}
+
+    # ---------------------------------------------------------------
+    - name: conductor
+      image: cjoga/kubestronaut-sim-conductor:dev
+      imagePullPolicy: Always
+      env:
+        # No Docker socket in a Pod. Reset and switch are the hub's job
+        # (it recycles this Pod); ssh covers training-mode reseed, which
+        # is the only live exec left.
+        - {name: ENGINE, value: "ssh"}
+        - {name: INSTANCES, value: "instance-1,instance-2"}
+        - {name: FACILITATOR_URL, value: "http://127.0.0.1:8080"}
+      volumeMounts:
+        - {name: banks, mountPath: /banks, readOnly: true}
+        - {name: shared, mountPath: /shared}
+      resources:
+        requests: {memory: "32Mi", cpu: "10m"}
+        limits: {memory: "128Mi", cpu: "200m"}
+
+    # ---------------------------------------------------------------
+    # The only container the hub proxies traffic to.
+    - name: facilitator
+      image: cjoga/kubestronaut-sim-facilitator:dev
+      imagePullPolicy: Always
+      ports:
+        - {name: http, containerPort: 8080}
+      env:
+        - {name: BANK, value: "ckad-mock-01"}
+        - {name: CONDUCTOR_ADDR, value: "127.0.0.1:9000"}
+        - {name: DESKTOP_ADDR, value: "127.0.0.1:6080"}
+      volumeMounts:
+        - {name: banks, mountPath: /banks, readOnly: true}
+        - {name: shared, mountPath: /shared, readOnly: true}
+        - {name: session, mountPath: /session}
+        # Separate from /session deliberately: /session is one attempt's
+        # scratch, /state is every graded attempt. Under compose their
+        # durability requirements are opposite. Here both are ephemeral —
+        # the hub owns durable history, so /state is a local cache the
+        # history webhook drains.
+        - {name: state, mountPath: /state}
+      readinessProbe:
+        httpGet: {path: /healthz, port: http}
+        periodSeconds: 10
+        failureThreshold: 30
+      resources:
+        requests: {memory: "64Mi", cpu: "10m"}
+        limits: {memory: "256Mi", cpu: "300m"}
+
+  volumes:
+    - {name: banks, emptyDir: {sizeLimit: 512Mi}}
+    - {name: shared, emptyDir: {sizeLimit: 256Mi}}
+    # The inner dockerd: kind node images plus whatever the candidate
+    # builds. The single largest consumer of node disk.
+    - {name: dind, emptyDir: {sizeLimit: 20Gi}}
+    - {name: course-1, emptyDir: {sizeLimit: 1Gi}}
+    - {name: course-2, emptyDir: {sizeLimit: 1Gi}}
+    # vfs copies whole layers rather than stacking them, so this is
+    # deliberately roomier than the images it holds would suggest.
+    - {name: containers-1, emptyDir: {sizeLimit: 4Gi}}
+    - {name: containers-2, emptyDir: {sizeLimit: 4Gi}}
+    - {name: registry-data, emptyDir: {sizeLimit: 2Gi}}
+    - {name: session, emptyDir: {sizeLimit: 64Mi}}
+    - {name: state, emptyDir: {sizeLimit: 64Mi}}

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,9 @@ pages are for changing the thing.
   enforces, and what CI structurally cannot.
 - [TROUBLESHOOTING.md](TROUBLESHOOTING.md) — symptoms and fixes, from
   the preflight through boot, an attempt, and grading.
+- [hosting.md](hosting.md) — running it for other people: the Helm
+  chart, every cap it takes as a value, and the handful of things a
+  hosted session does differently from `./sim up`.
 - [../site/README.md](../site/README.md) — the GitHub Pages landing
   page: which of its files are generated mirrors, and what
   `site/build.sh --check` does and does not catch.
@@ -26,7 +29,7 @@ pages are for changing the thing.
 
 - [cli.md](cli.md) — every `./sim` subcommand, environment variable,
   and published port.
-- [api.md](api.md) — the facilitator and conductor HTTP APIs.
+- [api.md](api.md) — the facilitator, conductor and hub HTTP APIs.
 - [bank-spec.md](bank-spec.md) — the question bank format and the
   validator contract.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,9 +6,13 @@ port has every capability the exam UI has. See
 
 Two services. The facilitator serves the whole browser-facing surface
 on port 8080 — the API, the embedded UI, the desktop proxy, and a
-reverse proxy to the conductor. The conductor listens on `:9000` on an
-`internal: true` network with no host port, and is reachable only
-through that proxy (`facilitator/cmd/facilitator/main.go:203-207`).
+reverse proxy to the conductor. The conductor is reachable only through
+that proxy: under compose it listens on `:9000` on an `internal: true`
+network with no host port, and in a hosted Pod — one network namespace,
+so an internal network is not available — it listens on a unix socket
+in a volume mounted into the facilitator and nothing else. One value
+per side describes either shape (`LISTEN` and `CONDUCTOR_ADDR`, a
+`host:port` or a `unix:/path`; `facilitator/cmd/facilitator/conductor.go`).
 Host ports are in [cli.md](cli.md).
 
 Errors are `{"error":"..."}` as `application/json`

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,10 +1,14 @@
 # HTTP API
 
-There is no authentication on any endpoint: anyone who can reach the
-port has every capability the exam UI has. See
-[SECURITY.md](../SECURITY.md).
+There is no authentication on any endpoint of the simulator: anyone who
+can reach the port has every capability the exam UI has. See
+[SECURITY.md](../SECURITY.md). That property survives a hosted
+deployment rather than being weakened by it — the hub documented at the
+end of this page is a separate process in front, and the facilitator is
+never reachable except through it.
 
-Two services. The facilitator serves the whole browser-facing surface
+Two services in the simulator, and a third only in a hosted deployment
+([hosting.md](hosting.md)). The facilitator serves the whole browser-facing surface
 on port 8080 — the API, the embedded UI, the desktop proxy, and a
 reverse proxy to the conductor. The conductor is reachable only through
 that proxy: under compose it listens on `:9000` on an `internal: true`
@@ -1201,3 +1205,148 @@ instances (`conductor/internal/control/control.go:275-330`).
 | 400 | The body has no non-empty `bank` (`conductor/internal/api/api.go:85-87`), or the bank is unknown, malformed or not runnable (`conductor/internal/api/api.go:107-108`). |
 | 409 | An attempt is running — end it first (`conductor/internal/api/api.go:105-106`) — or another control operation is in flight (`conductor/internal/api/api.go:103-104`). |
 | 500 | Switching is not configured on this conductor (`conductor/internal/control/control.go:247-249`). |
+
+## Hub
+
+Only in a hosted deployment. `./sim up` never runs this process, and the
+SPA finds out which product it is talking to by asking for one route:
+a facilitator JSON-404s `GET /api/me`, and that 404 is the whole
+detection mechanism (`hub/internal/api/api.go`).
+
+The route table is deliberately small. The hub **answers** identity,
+history, admission and the control operations that replace a Pod —
+everything whose truth outlives one session — and **proxies** everything
+else to the candidate's own session Pod, where the facilitator described
+above is unchanged and unaware any of this exists.
+
+Every route below except `/healthz`, `GET /api/me` and the OAuth pair
+requires a signed session cookie and answers `401 {"error":"not signed
+in"}` without one.
+
+### The catch-all proxy
+
+| Code | When |
+|---|---|
+| — | Proxied to the candidate's Pod, unchanged. `X-Forwarded-*` is deliberately NOT set: the facilitator trusts its inputs, and a header the hub uses for auth must not be one a candidate can set. |
+| 404 | The candidate has no session. Not 502 — nothing is wrong, they have not started one. |
+| 503 | Their Pod exists and is not ready. Carries `Retry-After: 5` and `{"state": "..."}`. |
+| 502 | The Pod is unreachable. |
+
+The upgrade to the desktop's WebSocket is carried by the same proxy
+(`httputil.ReverseProxy` hijacks on a 101), with `FlushInterval: -1` so
+a stream is never buffered.
+
+### GET /api/me
+
+The hosted-mode probe, and the SPA's whole view of its own state.
+Answers 200 whether or not anyone is signed in — a 401 would conflate
+"hosted, logged out" with "not hosted at all".
+
+```json
+{
+  "authenticated": true,
+  "authMode": "github",
+  "user": {"id": "583231", "login": "octocat"},
+  "session": {
+    "kind": "practical", "pod": "sim-session-practical-583231",
+    "state": "starting", "startedAt": "...", "expiresAt": "...",
+    "lastSeen": "..."
+  },
+  "seats": {"practical": {"used": 1, "total": 3}, "mcq": {"used": 0, "total": 30}}
+}
+```
+
+`session` is absent when the candidate has none, `queue` (`{"position":
+2}`) is present only while they are in one, and `loginURL` replaces
+`user` when they are not signed in. `seats` is reported to signed-out
+callers too: someone deciding whether to sign in is entitled to know
+whether there is anywhere to sit.
+
+`state` is `pending` (a seat is held, someone else is booting first),
+`starting` (their own Pod is building), `ready`, or `failed` — which
+keeps the seat so they can read why before it is reaped.
+
+### POST /api/session/start
+
+Admission first, then the facilitator's own start. The two are separate
+events minutes apart, and the same path does both in that order.
+
+| Code | When |
+|---|---|
+| 202 | A seat was granted and a Pod is being built. `{"starting": true, "state": "..."}` with `Retry-After: 5`. |
+| 409 | Every seat of that flavour is taken. `{"queued": true, "position": 2, "seats": {...}, "kind": "practical"}`. |
+| 400 | The body names a `kind` that is not `practical` or `mcq`. |
+| 502 | The Pod failed to boot; the body carries the reason. |
+| — | Once the Pod is ready, the request is forwarded to it unchanged and the facilitator's own answer is returned. |
+
+The body is `{"kind": "practical"}` for admission and the facilitator's
+own `StartOptions` for an attempt. The SPA never sends the first form to
+a ready session: on the ready path this is the facilitator's endpoint,
+and a body naming a kind and no mode would start an unconfigured
+attempt.
+
+### POST /hub/session/end
+
+Gives up the seat and destroys the Pod. 204, or 204 if there was nothing
+to end. A queued candidate with no session is dequeued by the same call.
+
+Deliberately not `POST /api/session/end`, which is the facilitator's and
+ends the **attempt** — grading it and writing its record while the
+environment stays up so the candidate can read their score. Ending the
+seat is a different act, and a candidate who confused the two would lose
+their results to a misclick.
+
+### POST /api/control/reset, POST /api/control/switch
+
+A hosted reset or switch replaces the Pod rather than rebuilding in
+place: the conductor cannot restart a container it reaches over ssh, and
+a Pod has no per-container restart under `restartPolicy: Never`. Both
+answer in the conductor's own 202-plus-job shape, and
+`GET /api/control/status` and `/api/control/log` answer from the hub's
+job store rather than the conductor's — the Pod they describe may not
+exist while they run.
+
+### Attempt history
+
+`GET /api/history` returns the same shape the facilitator's does —
+attempts most recent first, with the cross-attempt rollup beside them —
+so the dashboard needs no hosted branch. It is the hub's store, never
+the Pod's: a route answered there would answer from the copy that is
+about to be destroyed.
+
+| Route | Behaviour |
+|---|---|
+| `GET /api/history` | `{"attempts": [...], "summary": {...}}`, newest first |
+| `GET /api/history/{attempt}` | The full graded-results document. Scoped to the caller's own user directory, so someone else's attempt id is simply not found. Hosted only — a local facilitator keeps the summary row and lets the next attempt overwrite the results. |
+| `GET /api/history/export` | The interchange document (`{"version":1,"attempts":[...]}`, oldest first). Importable by a local `./sim`. |
+| `DELETE /api/history` | Erases the user's directory: every attempt and every results blob. |
+| `POST /api/history/import` | 501, with the reason. |
+| `GET /api/history/summary` | 501 — the CLI's route, and answering it wrongly would be worse than not answering. |
+
+### POST /hub/ingest/history
+
+How a graded attempt reaches the store. The session Pod's facilitator
+posts `{"record": {...}, "results": {...}}` with a bearer ticket; the
+hub reads the user out of the ticket and never out of the body, because
+a Pod that could name its own user could write into anyone's history.
+
+The ticket is signed with a key derived from `COOKIE_KEY` — `HMAC-SHA256(key,
+"history-ingest")` — so it can never be spent as that candidate's login,
+and the login cookie can never be spent as a ticket.
+
+Under `/hub/`, not `/api/`, and deliberately: `/api/` is the candidate's
+surface, and this is the Pod talking to the hub about them.
+
+| Code | When |
+|---|---|
+| 200 | `{"recorded": true}`, or `false` if that attempt id was already stored — a retried delivery records nothing twice. |
+| 400 | No record in the body. |
+| 401 | The ticket is missing, forged, or expired. Expiry is logged separately and answered identically. |
+
+### /hub/auth/*
+
+`GET /hub/auth/login` redirects to GitHub with a CSRF state cookie
+scoped to `/hub/auth`; `GET /hub/auth/callback` checks that state before
+anything else and redirects to `/` on success; `POST /hub/auth/logout`
+clears the cookie and answers 204. All three answer 404 in
+`AUTH_MODE=header` and `none`, where there is nothing to log in to.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,15 @@
 # Architecture
 
-kubestronaut-sim is eight containers, three Go modules that share no
+kubestronaut-sim is eight containers, four Go modules that share no
 code, and one kind cluster. Read this before changing any of them.
+
+Seven containers and three of the modules are the simulator, which is
+what `./sim up` runs and what almost all of this page describes. The
+fourth module, `hub/`, exists only in a hosted deployment: it runs in
+front of the simulator rather than inside it, and it is the reason the
+simulator itself did not have to change to be hosted. Where that
+distinction matters below it is called out; [hosting.md](hosting.md)
+covers the rest.
 
 Commands live in [cli.md](cli.md), HTTP endpoints in [api.md](api.md),
 bank file layout in [bank-spec.md](bank-spec.md), and the threat model in
@@ -148,21 +156,28 @@ service's container, exec inside it, restart it
 docker CLI out of the image: the narrower the client, the less a
 socket-holding container can be talked into doing.
 
-## The three Go modules
+## The four Go modules
 
-| Directory | Module path | Binary | Built from |
-|---|---|---|---|
-| `conductor/` | `kubestronaut-sim/conductor` | `/conductor` | `conductor/` |
-| `facilitator/` | `kubestronaut-sim/facilitator` | `/facilitator` | repo root |
-| `proxy/` | `kubestronaut-sim/proxy` | `/docs-proxy` | `proxy/` |
+| Directory | Module path | Binary | Built from | Runs |
+|---|---|---|---|---|
+| `conductor/` | `kubestronaut-sim/conductor` | `/conductor` | `conductor/` | always |
+| `facilitator/` | `kubestronaut-sim/facilitator` | `/facilitator` | repo root | always |
+| `proxy/` | `kubestronaut-sim/proxy` | `/docs-proxy` | `proxy/` | always |
+| `hub/` | `kubestronaut-sim/hub` | `/hub` | `hub/` | hosted only |
 
-All three declare Go 1.24 and have **zero external dependencies**. No
+All four declare Go 1.24 and have **zero external dependencies**. No
 `go.sum` exists anywhere in the repo, and none should: a stdlib-only
 build is what lets every image compile from a bare `golang:1.24-alpine`
-stage with no module download and nothing to pin.
+stage with no module download and nothing to pin. The hub keeps the rule
+in the place it is most tempting to break: it talks to the Kubernetes API
+with a hand-written REST client for four calls rather than vendoring
+client-go, exactly as the conductor hand-rolls the Docker Engine API for
+three.
 
-The three communicate over HTTP and never by import. No module's code
-appears in another module's build.
+The four communicate over HTTP and never by import. No module's code
+appears in another module's build — which is also why the hub
+re-implements the facilitator's attempt rollup instead of sharing it
+(docs/follow-ups.md records the reasoning and the risk).
 
 None of them parses YAML either. Each image's entrypoint shells out to
 `yq` to pre-convert the bank files to JSON and hands the Go binary a path

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,7 +128,7 @@ one network namespace and `controlnet` has no equivalent: a TCP port
 would sit on the candidate's own loopback. The conductor listens on a
 unix socket in a volume mounted into itself and the facilitator, and
 into no other container — the mount is the boundary the network used to
-be (`deploy/session-pod.yaml`, gated in CI).
+be (`deploy/helm/kubestronaut-sim/files/session-pod.yaml`, gated in CI).
 
 This is defence in depth rather than a hole being closed. Every
 state-changing endpoint is already refused there on its own merits: a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -123,6 +123,24 @@ candidate can legitimately drive the control API, and a candidate
 resetting their own exam is a feature. [SECURITY.md](../SECURITY.md) owns
 the rest of the threat model.
 
+In a hosted session that boundary has to be redrawn, because a Pod is
+one network namespace and `controlnet` has no equivalent: a TCP port
+would sit on the candidate's own loopback. The conductor listens on a
+unix socket in a volume mounted into itself and the facilitator, and
+into no other container — the mount is the boundary the network used to
+be (`deploy/session-pod.yaml`, gated in CI).
+
+This is defence in depth rather than a hole being closed. Every
+state-changing endpoint is already refused there on its own merits: a
+Pod cannot restart a container under `restartPolicy: Never`, so reset
+and switch return 501 before touching anything
+(`conductor/internal/control/control.go:192,299`); re-seeding is Training
+mode only and the conductor asks the facilitator, not the caller
+(`reseed.go`); and `seed` fires only for a pooled bank, of which the tree
+has none. The socket is what keeps that list from having to stay
+complete — an endpoint added later without its own gate is not
+reachable in the first place.
+
 The conductor speaks the Docker Engine API directly over the socket
 through a hand-written stdlib client with three calls: find a compose
 service's container, exec inside it, restart it

--- a/docs/follow-ups.md
+++ b/docs/follow-ups.md
@@ -110,6 +110,31 @@ Known, chosen, and not currently worth the cost of changing.
   because the failure worth retrying is a hub mid-redeploy; a rejected
   ticket is not retried, because retrying sends identical bytes to an
   identical answer.
+- **The hosted lease countdown is not shown during a running exam.** The
+  header chip carries it, and the header is not rendered over the exam
+  screen — that screen has its own topbar with its own clock, and a
+  second countdown beside it would be read as the exam's. Two
+  consequences, one good and one not. The good one: there is no way to
+  destroy an environment mid-attempt by misclick, because the End
+  session control is on the same chip. The cost: a session whose hard
+  cap falls inside an attempt ends it with no warning on screen. Narrow
+  in practice — the cap defaults to ten hours against a two-hour exam —
+  and the honest fix is a lease indicator in the exam's own topbar
+  rather than a second header, which is a change to two exam screens
+  rather than to the chip.
+- **The hub mirrors the facilitator's cross-attempt rollup rather than
+  sharing it.** `hub/internal/store/rollup.go` recomputes what
+  `facilitator/internal/history` already computes: which attempts count,
+  which certifications the Kubestronaut path holds, and the weakest
+  domains across every graded attempt. Sharing it is not available —
+  the hub is a separate module, every module here is stdlib-only with no
+  `go.sum`, and `history` is an internal package, which Go scopes to its
+  own module's tree whatever the `go.mod` says. Lifting it out of
+  `internal` would couple the hub's build to the facilitator's for one
+  function, and the hub's image copies `hub/` alone. So it is a copy,
+  narrowly: only the fields the rollup reads are decoded out of each
+  record and the rest stays raw bytes. If the two drift, the symptom is
+  a hosted dashboard whose numbers differ from a local one.
 - **The session Pod's history ticket is an env var in the Pod spec, not
   a Secret.** It names one user and authorises appending to that user's
   history and nothing else, it is minted per Pod and expires an hour

--- a/docs/follow-ups.md
+++ b/docs/follow-ups.md
@@ -60,7 +60,7 @@ Known, chosen, and not currently worth the cost of changing.
   a candidate willing to search the web from an instance shell can
   already do that in the local product. Local behaviour is unchanged and
   remains the stricter of the two.
-  `deploy/session-networkpolicy.yaml` addresses the part that *is*
+  The chart's `networkpolicy.yaml` addresses the part that *is*
   fixable — a session reaching the infrastructure hosting it — and says
   the same thing at more length.
 - **In a hosted session, containers other than the two instances report

--- a/docs/follow-ups.md
+++ b/docs/follow-ups.md
@@ -99,6 +99,26 @@ Known, chosen, and not currently worth the cost of changing.
   the durable copy, and accepting an arbitrary attempt document would
   only let a record that survives on purpose hold entries that were never
   graded.
+- **A hosted attempt is recorded twice, and only one copy is meant to
+  last.** The facilitator writes `/state/history.json` exactly as it
+  always has — that is what `./sim up` relies on and it does not change
+  — and additionally posts the record and the full results document to
+  the hub, which keeps it per user on a volume that outlives the Pod.
+  The two can disagree for one attempt: a hub that is down when an
+  exam is graded costs the durable copy, and the facilitator says so in
+  its log rather than failing the grade. Three deliveries are attempted
+  because the failure worth retrying is a hub mid-redeploy; a rejected
+  ticket is not retried, because retrying sends identical bytes to an
+  identical answer.
+- **The session Pod's history ticket is an env var in the Pod spec, not
+  a Secret.** It names one user and authorises appending to that user's
+  history and nothing else, it is minted per Pod and expires an hour
+  after the hard session cap, and it is signed with a key derived from
+  `COOKIE_KEY` so it can never be spent as that candidate's login.
+  Reading it needs Pod-read in the session namespace, which is already
+  well inside the accepted threat model for a namespace whose Pods run
+  a privileged container. A Secret would be a second object to create,
+  delete and grant RBAC over for no change in who can read it.
 - **ingress-nginx image digests are stripped** at build time so the
   preloaded tags resolve offline.
 - **The ingress `ValidatingWebhookConfiguration` is left in place.** It

--- a/docs/follow-ups.md
+++ b/docs/follow-ups.md
@@ -26,6 +26,79 @@ Known, chosen, and not currently worth the cost of changing.
 - **Podman on the instances runs with the `vfs` storage driver.** Slower
   and more disk-hungry than overlay, but it works without granting the
   instances more than the five capabilities they already hold.
+- **A build's `RUN` steps use chroot isolation, not a container.**
+  `BUILDAH_ISOLATION=chroot`, set in `images/instance/Dockerfile` three
+  ways — as an `ENV`, in `/etc/environment`, and via a sudoers
+  `env_keep`. Under compose the instances get the host's cgroup namespace
+  and crun works; under Kubernetes an unprivileged container gets a
+  private one, where crun cannot enable cgroup controllers or attach its
+  device-control eBPF program. Granting `privileged` would fix it and
+  would make the candidate's own shell the most privileged container in
+  the pod, so the isolation of the build step was traded away instead. A
+  `RUN` step gets no namespaces of its own; the images the questions build
+  are tiny and the candidate is already root there, so nothing current
+  notices. One image behaves identically in both places, which is the
+  point. The three mechanisms are not redundancy: `ENV` alone never
+  reaches a candidate, because sshd sanitises login sessions and sudo
+  resets the environment again — and q09 requires sudo.
+- **In a hosted session the exam desktop can reach the open web, and no
+  NetworkPolicy can change that.** Under compose the desktop sits only on
+  `examnet`, which runs with masquerade off, so its only route out is
+  `docs-proxy` — `tests/smoke.sh` asserts a plain
+  `curl https://example.com` from the desktop fails. A Pod is one network
+  namespace and the same call succeeds.
+  This is architectural, not a deferred fix. The two instances are on
+  `default` as well as `examnet`, so they have ordinary internet access
+  even locally (measured: 200 from instance-1, timeout from the desktop),
+  and they need it — a question builds an image `FROM alpine:3.21`, which
+  podman pulls from Docker Hub. A NetworkPolicy selects Pods, not
+  containers, so the desktop and the instances necessarily share one
+  egress and the instances' egress is load-bearing. Splitting
+  `docs-proxy` out would not help; the instances are the hole.
+  What survives is narrower than it sounds: the allowlist still governs
+  the browser, which is where candidates actually read documentation, and
+  a candidate willing to search the web from an instance shell can
+  already do that in the local product. Local behaviour is unchanged and
+  remains the stricter of the two.
+  `deploy/session-networkpolicy.yaml` addresses the part that *is*
+  fixable — a session reaching the infrastructure hosting it — and says
+  the same thing at more length.
+- **In a hosted session, containers other than the two instances report
+  the Pod's hostname.** Pod containers share a UTS namespace. The
+  instances take one of their own (`unshare --uts`, using CAP_SYS_ADMIN
+  they already hold for image builds), because the prompt is the
+  candidate's only confirmation that `ssh instance-1` landed and it
+  otherwise looks identical before and after. The desktop and the four
+  service containers keep the Pod's name: the desktop cannot unshare
+  without being granted a capability it has no other use for, and its
+  prompt is now unambiguous anyway — it is the one that is *not*
+  `instance-1` or `instance-2`. Nothing reads a hostname anywhere.
+- **In a hosted session, reset and switch replace the Pod rather than
+  rebuilding in place.** The conductor cannot restart a container it
+  reaches over ssh — a Pod has no per-container restart under
+  `restartPolicy: Never` — so `hub/internal/session` deletes the Pod and
+  creates a new one, reporting progress in the conductor's own job shape
+  so the UI needs no hosted branch. Two consequences, both accepted: the
+  phases differ from a local reset's (there is no cluster to rebuild in
+  place), and a hosted reset costs a full boot rather than a partial one.
+- **In a hosted session, seeding a pooled bank would report no
+  progress.** The hub answers `/api/control/status` and `/api/control/log`
+  from its own job store, because reset and switch are its operations and
+  the Pod they describe may not exist while they run. The conductor's one
+  remaining job type, `seed`, is triggered by the facilitator
+  server-to-server and would therefore be invisible to the browser. No
+  hands-on bank in the tree is pooled — `exam.Pooled()` is false for
+  every one — so nothing is currently affected. Recorded rather than
+  guessed at, because the first pooled hands-on bank will need this.
+- **Hosted history cannot be imported into, and reports no summary.**
+  Both are refused with 501 and an explanation rather than proxied. The
+  Pod's own `/state` is ephemeral by design, so a history route answered
+  there would answer from the copy that is about to be destroyed — "clear
+  my history" would succeed against nothing that lasts. Import exists
+  locally because local history is genuinely fragile; hosted history is
+  the durable copy, and accepting an arbitrary attempt document would
+  only let a record that survives on purpose hold entries that were never
+  graded.
 - **ingress-nginx image digests are stripped** at build time so the
   preloaded tags resolve offline.
 - **The ingress `ValidatingWebhookConfiguration` is left in place.** It
@@ -43,9 +116,17 @@ Known, chosen, and not currently worth the cost of changing.
 
 Recorded because each has been proposed at least once and is settled.
 
-- **No authentication, permanently.** See [../SECURITY.md](../SECURITY.md).
-  Notes elsewhere of the form "needs auth once hosted" describe a
-  scenario that is not planned.
+- ~~**No authentication, permanently.**~~ **Still true of the
+  simulator, no longer true of the product.** The facilitator has no
+  authentication of any kind and gains none: `./sim up` is unchanged,
+  with no accounts and no new required configuration. What changed is
+  that a hosted deployment puts `hub/` in front of it — GitHub login,
+  capped seats, durable per-user history — and the facilitator is simply
+  never reachable except through it. That is the whole reason the
+  property survives: the hub was built *around* the simulator rather
+  than into it. Struck through rather than deleted, because this entry
+  was cited as settled and a reader who remembers it needs to find out
+  what it became.
 - ~~**No attempt history and no cross-attempt analytics.**~~ **Overturned,
   deliberately.** This was a durable constraint until the design brief
   made cross-attempt progress a product goal, and it is now built: every

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -1,0 +1,218 @@
+# Hosting
+
+Everything in this repository runs on one machine with `./sim up`, and
+that stays true. This page is about the other shape: running it for
+people who have not got 9GB and forty minutes to spare, with sign-in, a
+capped pool of concurrent sessions, and attempt history that outlives
+the environment it was made in.
+
+The local product is the reference. It is uncapped, has no accounts, and
+needs no configuration; a hosted deployment is the same simulator with a
+door in front of it. If you want the uncapped one, clone this and run it.
+
+## What is actually deployed
+
+Two things, and the second is created and destroyed on demand:
+
+- **The hub** — one Deployment, one Service, one PersistentVolumeClaim.
+  It is the only process reachable from the internet. It does identity,
+  seats, the queue, durable history, and a reverse proxy to each
+  candidate's own environment.
+- **A session Pod, per candidate** — the whole `./sim up` stack as a
+  single Pod. Two flavours: `practical` (eight containers, a real
+  two-node cluster) and `mcq` (a facilitator and 128Mi, no cluster).
+
+The facilitator inside a session has no authentication of any kind and
+gains none. It is simply never reachable except through the hub, which
+is the property that lets the local product stay untouched: the hub was
+built *around* the simulator rather than into it.
+
+## Before you deploy one
+
+**A practical session runs a privileged container.** It builds a real
+Kubernetes cluster inside itself with a container runtime, hands a
+stranger a root shell next to it, and there is no way to do that
+unprivileged — user namespaces are explicitly incompatible with
+`privileged`, and the sandboxed runtimes either cannot host a nested
+container runtime or need nested virtualization. Treat the nodes that
+run these as disposable: deploy on hardware you are willing to rebuild,
+keep them out of any node pool that runs something you care about, and
+label only the nodes you have made that decision about.
+
+Only one container in the Pod is privileged, and the manifest says which
+and why. The two candidate shells carry exactly the five capabilities
+`docker-compose.yaml` gives them locally.
+
+The chart ships a NetworkPolicy that stops a session reaching the
+cluster hosting it — the API server, other namespaces, the nodes, and
+the link-local range cloud metadata answers on. It is on by default.
+Turning it off is not a supported configuration; it is the boundary that
+makes the paragraph above an accepted risk rather than an open one.
+
+MCQ sessions are unprivileged and tiny. If you only want to host the
+multiple-choice exams, set `sessions.practical.seats: 0` and none of the
+above applies.
+
+## Install
+
+```bash
+helm install kubestronaut-sim deploy/helm/kubestronaut-sim \
+  --namespace kubestronaut-sim --create-namespace \
+  --values my-values.yaml
+```
+
+The chart refuses at render time rather than at boot for the four
+configurations that cannot work — GitHub mode with no credentials,
+GitHub mode with no base URL, an auth mode that does not exist, and an
+HTTPRoute attached to no Gateway. A hub that CrashLoopBackOffs on a
+missing client ID has already replaced the working one.
+
+A minimal `my-values.yaml`:
+
+```yaml
+hub:
+  baseURL: https://sim.example.com
+  # A Secret carrying COOKIE_KEY, GITHUB_CLIENT_ID and
+  # GITHUB_CLIENT_SECRET. Create it however you create secrets.
+  existingSecret: kubestronaut-sim-hub
+
+sessions:
+  practical:
+    seats: 3
+  mcq:
+    seats: 30
+```
+
+Then point something at the Service. The chart publishes a ClusterIP and
+stops there; an `httpRoute` block is offered because Gateway API is what
+this project's own deployment uses, and any Ingress or tunnel works as
+well.
+
+**One requirement of whatever sits in front:** a WebSocket may stay open
+for hours. The desktop stream is one. websockify pings every 30 seconds
+from inside the session so the connection is never idle, but a proxy
+with a hard maximum-lifetime setting will still cut it, and the
+candidate sees their desktop drop mid-question.
+
+## Credentials
+
+`COOKIE_KEY` signs two different things with two keys derived from it:
+login cookies, and the per-Pod ticket a session presents when it records
+a graded attempt. They are derived rather than shared so a ticket read
+out of a Pod spec can never be spent as that candidate's login.
+
+Rotating it signs everyone out and invalidates tickets in flight; losing
+it does the same. The chart does not generate one, deliberately — a
+chart that minted a key would rotate it on every upgrade that forgot to
+pass the old one.
+
+The GitHub OAuth app needs one callback URL: `<baseURL>/hub/auth/callback`.
+No scopes are requested beyond the default, and the only thing read from
+the account is its numeric id and login.
+
+## Seats, and what a seat is
+
+A seat is held from admission to teardown, not from readiness. Counting
+only ready sessions would admit a second candidate while the first is
+still booting and hand both of them a half-built cluster.
+
+| Value | Default | What it governs |
+|---|---|---|
+| `sessions.practical.seats` | 3 | Concurrent hands-on environments |
+| `sessions.mcq.seats` | 30 | Concurrent multiple-choice sessions |
+| `sessions.maxAge` | `10h` | The hard cap. A seat is taken back at it |
+| `sessions.idleTimeout` | `30m` | No request from the browser for this long and the seat goes back |
+| `sessions.queueHold` | `2m` | How long the head of the queue has to claim a seat |
+| `sessions.bootTimeout` | `20m` | A boot that has not reached ready by now is failed |
+| `sessions.bootConcurrency` | 1 | Pod creations in flight at once |
+
+`bootConcurrency` is the one to leave alone without a reason. Boot is
+CPU-bound — one measured session took a four-core node to 3090m while
+memory stayed at 25% — so two boots on one node do not take turns, they
+both crawl. Raise it only when you have nodes to spread them over.
+
+Going from three seats to five is a values change. Going beyond what
+your nodes hold is labelling another node. Neither is a code change.
+
+## Sizing
+
+Per practical session, summed across its eight containers as the
+manifest declares them: **3.9Gi / 540m requested, 11.8Gi / 4400m
+limit**. The per-container numbers are measured and live in
+`deploy/helm/kubestronaut-sim/files/session-pod.yaml`; override them
+through `sessions.practical.resources` rather than editing that file.
+
+The limits are deliberately far above the requests, which means seats
+are overcommitted: three sessions request 11.8Gi and could in principle
+demand 35Gi. If several peak at once a node can OOM mid-exam. Serialised
+boots are most of the mitigation — the peak is the boot — and
+`emptyDir.sizeLimit` is the rest, which stops a runaway build filling
+node disk instead of just its own session.
+
+Node disk is the figure most likely to surprise: the emptyDir volumes
+declare **32.9GiB** of `sizeLimit` between them, and 20GiB of that is
+the inner Docker daemon's. It is a ceiling rather than a reservation —
+a session that never builds an image uses a fraction of it — but three
+seats on one node can legitimately ask for 99GiB.
+
+Steady state is cheap. The expensive part is the first three to six
+minutes, which is `kind create cluster` plus a CNI, an ingress
+controller and every question's setup script.
+
+An MCQ session is about 128Mi and schedules anywhere.
+
+## History
+
+Attempts are the reason to sign in. Every graded attempt in a recorded
+mode is posted to the hub as it happens and kept per user on the hub's
+volume, which is the only thing in the deployment that is not
+disposable — a session Pod's own state dies with the Pod by design, and
+that is what makes a seat reclaimable.
+
+Two consequences worth knowing before you run this for other people:
+
+- **A hub that is down when an exam is graded costs the durable copy of
+  that attempt.** The session says so in its log rather than failing the
+  grade, and retries three times. The candidate still sees their score.
+- **Hosted history cannot be imported into.** It is the durable copy
+  rather than the fragile one, and accepting an arbitrary attempt
+  document would let a record that survives on purpose hold entries that
+  were never graded. Export works, and an export from here imports into
+  a local `./sim`.
+
+Set `hub.state.existingClaim` if you want the record to survive a
+`helm uninstall`. The chart's own PVC is annotated
+`helm.sh/resource-policy: keep` for the same reason, so an uninstall
+does not take a candidate's history with it.
+
+## Self-hosting behind your own identity
+
+`hub.auth.mode: header` trusts a header set by whatever proxy is in
+front — for a deployment that already has SSO. The hub says so at boot,
+loudly, because the failure is silent: reachable directly in that mode,
+anyone can claim any identity by setting one header.
+
+Set `COOKIE_KEY` in that mode too. It is what turns durable history on,
+not what turns login on, and a deployment with seats and a proxy and
+silently no history would be missing the one thing a hosted tier is for.
+
+`hub.auth.mode: none` has no identity at all: everyone is the same user
+and shares one history. It is for trying the chart, not for people.
+
+## What hosted mode does differently
+
+Not a shorter list than it looks. Each of these is a consequence of a
+Pod being one network namespace and one disposable unit, and each is
+recorded with its reasoning in [follow-ups.md](follow-ups.md):
+
+- The documentation allowlist governs the browser, not the network. A
+  Pod is one network namespace, so the desktop and the candidate's
+  shells necessarily share one egress and the shells' egress is
+  load-bearing (a question builds an image `FROM alpine:3.21`).
+  Local behaviour is unchanged and remains the stricter of the two.
+- Reset and switch replace the Pod rather than rebuilding in place, so a
+  hosted reset costs a full boot and reports different phases.
+- Every container except the two candidate shells reports the Pod's
+  hostname, because a Pod shares one UTS namespace.
+- History import and the CLI's summary route are refused with an
+  explanation rather than proxied.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -69,6 +69,7 @@ cd facilitator && go test ./... && go vet ./...
 | `facilitator/` | The HTTP API, the session state machine, grading, and the embedded UI |
 | `conductor/` | The Docker-socket sidecar that rebuilds the cluster and switches banks |
 | `proxy/` | The documentation allowlist proxy the exam desktop browses through |
+| `hub/` | Identity, seats, the queue, durable history and the session proxy. Hosted deployments only ([hosting.md](hosting.md)) |
 
 Without a host Go toolchain, run the same commands in a container:
 
@@ -188,7 +189,7 @@ machine.
 
 ## What CI runs
 
-`.github/workflows/ci.yml` runs five jobs on push to every branch, on
+`.github/workflows/ci.yml` runs six jobs on push to every branch, on
 every pull request, and on manual dispatch. It is the only workflow that
 gates anything — `.github/workflows/site.yml` deploys `site/` to GitHub
 Pages on a push to `main` and tests nothing (see
@@ -197,10 +198,20 @@ Pages on a push to `main` and tests nothing (see
 | Job | What it runs |
 |---|---|
 | `banks` | The five offline gates, then `site/build.sh --check` |
-| `go` | `go test ./...` then `go vet ./...` for `facilitator`, `conductor` and `proxy`, in a matrix with `fail-fast: false` |
+| `go` | `go test ./...` then `go vet ./...` for `facilitator`, `conductor`, `proxy` and `hub`, in a matrix with `fail-fast: false` |
 | `ui` | `npm ci`, `npx tsc --noEmit`, `npm run lint`, `npm test`, all with `working-directory: ui` |
 | `images` | Builds all six Dockerfiles with `PRELOAD=none`, then `docker compose config -q` |
 | `shell` | `bash -n` over `sim`, `tests/*.sh`, image entrypoints, `banks/_lib/*.sh`, every `setup.sh` and `validate.d/*.sh`, and every solution script |
+| `chart` | `helm lint`, four negative controls that must each be refused at render time, then `helm template` and the hub's own `render()` run over the result |
+
+The `chart` job is the only place the Pod manifests and the hub meet.
+They meet as bytes — helm turns YAML into JSON, the hub parses that JSON
+and stamps out a Pod — and checking each half alone proves nothing about
+the join: a manifest that stops declaring an env var the hub must fill
+renders perfectly and then fails at the first candidate to press start.
+It is gated by `TestTheChartRendersSomethingThisPackageCanStampOut`,
+which skips when `SESSION_POD_JSON` is unset so `go test ./...` needs no
+helm.
 
 `PRELOAD=none` skips baking ~2GB of image archives. The job proves the
 Dockerfiles parse and build; only a real boot proves the archives are
@@ -212,7 +223,7 @@ right, and that is the smoke suite's job.
 only: npm in `/ui`, with development dependencies grouped into one PR and
 major vitest bumps ignored, and GitHub Actions in `/`.
 
-There is deliberately no `gomod` entry — all three Go modules are
+There is deliberately no `gomod` entry — all four Go modules are
 stdlib-only, so no `go.sum` exists and there is nothing to bump. There is
 no `docker` entry either: base image tags are hand-pinned, and a bump
 needs a cold-cache smoke run to prove the preloaded images still resolve

--- a/facilitator/cmd/facilitator/conductor.go
+++ b/facilitator/cmd/facilitator/conductor.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// unixPrefix marks a CONDUCTOR_ADDR value as a filesystem socket rather
+// than a host:port. It matches the conductor's own LISTEN convention
+// (conductor/cmd/conductor/main.go), so one value describes both ends.
+const unixPrefix = "unix:"
+
+// socketHost is the host every socket-dialed request carries.
+//
+// A URL needs one and net/http will not send a request without it, but
+// nothing resolves it: the transport below ignores the address it is
+// handed and dials the path instead. Named rather than "localhost" so a
+// log line or a proxy header says where the request really went.
+const socketHost = "conductor"
+
+// conductorEndpoint resolves CONDUCTOR_ADDR into the base URL every
+// conductor client is built from, and the RoundTripper that reaches it.
+//
+// Two transports because there are two deployments. Under compose the
+// conductor is on `controlnet`, an `internal: true` network the exam
+// containers are not attached to, and plain TCP is already private. In
+// a hosted session the whole stack is one Pod: one network namespace,
+// shared loopback, and a candidate with a shell on an instance could
+// curl the control API directly. A unix socket cannot be reached across
+// a namespace it is not mounted into, which is the property TCP lost.
+//
+// A nil RoundTripper means http.DefaultTransport, which is what the TCP
+// case wants and what every test gets.
+func conductorEndpoint(addr string) (*url.URL, http.RoundTripper, error) {
+	path, isSocket := strings.CutPrefix(addr, unixPrefix)
+	if !isSocket {
+		u, err := url.Parse("http://" + addr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("parse CONDUCTOR_ADDR: %w", err)
+		}
+		return u, nil, nil
+	}
+	if path == "" {
+		return nil, nil, fmt.Errorf("parse CONDUCTOR_ADDR: %q has no socket path", addr)
+	}
+	var d net.Dialer
+	return &url.URL{Scheme: "http", Host: socketHost}, &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return d.DialContext(ctx, "unix", path)
+		},
+	}, nil
+}

--- a/facilitator/cmd/facilitator/conductor_test.go
+++ b/facilitator/cmd/facilitator/conductor_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestConductorEndpointOverTCPIsUnchanged(t *testing.T) {
+	u, rt, err := conductorEndpoint("conductor:9000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := u.String(); got != "http://conductor:9000" {
+		t.Errorf("base URL = %q", got)
+	}
+	// nil, not a custom transport: compose's conductor is an ordinary
+	// host:port and must keep using http.DefaultTransport, connection
+	// pooling and all.
+	if rt != nil {
+		t.Errorf("TCP endpoint built a transport: %T", rt)
+	}
+}
+
+// The one that matters. A socket the facilitator cannot actually reach
+// would fail at the first control operation, minutes into a hosted
+// session, so this speaks HTTP over a real unix listener rather than
+// asserting the transport's shape.
+func TestConductorEndpointOverASocketReachesTheConductor(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "c.sock")
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var gotHost, gotPath string
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHost, gotPath = r.Host, r.URL.Path
+		w.Write([]byte(`[{"id":"ckad-mock-01"}]`))
+	}))
+	srv.Listener.Close()
+	srv.Listener = ln
+	srv.Start()
+	defer srv.Close()
+
+	base, rt, err := conductorEndpoint(unixPrefix + path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := newBanksFetcher(base, rt)(t.Context())
+	if err != nil {
+		t.Fatalf("bank list over the socket: %v", err)
+	}
+	if string(body) != `[{"id":"ckad-mock-01"}]` {
+		t.Errorf("body = %s", body)
+	}
+	if gotPath != "/api/control/banks" {
+		t.Errorf("path = %q", gotPath)
+	}
+	// The placeholder host has to survive to the conductor: net/http
+	// will not send a request without one, and a blank Host header is a
+	// 400 from the server, not a routing detail.
+	if gotHost != socketHost {
+		t.Errorf("Host = %q, want %q", gotHost, socketHost)
+	}
+}
+
+func TestConductorEndpointRejectsASocketWithNoPath(t *testing.T) {
+	_, _, err := conductorEndpoint(unixPrefix)
+	if err == nil || !strings.Contains(err.Error(), "no socket path") {
+		t.Errorf("err = %v", err)
+	}
+}

--- a/facilitator/cmd/facilitator/history.go
+++ b/facilitator/cmd/facilitator/history.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -38,8 +39,15 @@ const maxBanksBytes = 1 << 20
 // with the hints and the solution open; counting it would make every
 // "best score" meaningless, and session.Recorded is the one place that
 // rule is defined — the mode screen advertises the same predicate.
-func recordAttempt(store *history.Store, ex *exam.Exam, token string, snap session.Snapshot, res *evaluate.Results) error {
-	if store == nil || res == nil {
+//
+// Two destinations, one record. mir is nil under compose and in every
+// test, which is the whole of the local behaviour. Where it is not nil,
+// it is the copy that survives the Pod, so its failure is reported
+// alongside the local one rather than instead of it — and neither
+// suppresses the other, because a hub that is down must not also cost
+// the candidate the record on their own disk.
+func recordAttempt(store *history.Store, mir *mirror, ex *exam.Exam, token string, snap session.Snapshot, res *evaluate.Results) error {
+	if res == nil || (store == nil && mir == nil) {
 		return nil
 	}
 	if !session.Recorded(snap.Mode) {
@@ -80,10 +88,18 @@ func recordAttempt(store *history.Store, ex *exam.Exam, token string, snap sessi
 		Domains:         toHistoryDomains(res.Domains),
 	}
 
-	if _, err := store.Add(rec); err != nil {
-		return err
+	var errs []error
+	if store != nil {
+		if _, err := store.Add(rec); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	return nil
+	if mir != nil {
+		if err := mir.post(context.Background(), rec, res); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // declaredLength is the bank's declared exam length: ExamLength for a

--- a/facilitator/cmd/facilitator/history.go
+++ b/facilitator/cmd/facilitator/history.go
@@ -124,8 +124,8 @@ func toHistoryDomains(in []evaluate.DomainResult) []history.DomainResult {
 // risk of starting work — the conductor's other endpoints rebuild
 // clusters — so this reaches for exactly one route and cannot be talked
 // into another.
-func newBanksFetcher(base *url.URL) api.BanksFetcher {
-	client := &http.Client{Timeout: banksTimeout}
+func newBanksFetcher(base *url.URL, rt http.RoundTripper) api.BanksFetcher {
+	client := &http.Client{Timeout: banksTimeout, Transport: rt}
 	endpoint := base.JoinPath("/api/control/banks").String()
 
 	return func(ctx context.Context) ([]byte, error) {

--- a/facilitator/cmd/facilitator/history_test.go
+++ b/facilitator/cmd/facilitator/history_test.go
@@ -243,7 +243,7 @@ func TestNewBanksFetcher(t *testing.T) {
 	defer srv.Close()
 
 	base := mustParseURL(t, srv.URL)
-	raw, err := newBanksFetcher(base)(t.Context())
+	raw, err := newBanksFetcher(base, nil)(t.Context())
 	if err != nil {
 		t.Fatalf("fetch: %v", err)
 	}
@@ -258,7 +258,7 @@ func TestNewBanksFetcher(t *testing.T) {
 		http.Error(w, "nope", http.StatusInternalServerError)
 	}))
 	defer bad.Close()
-	if _, err := newBanksFetcher(mustParseURL(t, bad.URL))(t.Context()); err == nil {
+	if _, err := newBanksFetcher(mustParseURL(t, bad.URL), nil)(t.Context()); err == nil {
 		t.Error("a 500 from the conductor was not reported as an error")
 	}
 }

--- a/facilitator/cmd/facilitator/history_test.go
+++ b/facilitator/cmd/facilitator/history_test.go
@@ -66,7 +66,7 @@ func TestRecordAttemptCopiesTheBankIn(t *testing.T) {
 	ex := recorderExam()
 	snap := session.Snapshot{State: "ended", Mode: session.ModeExam, StartedAt: time.Date(2026, 3, 1, 9, 0, 0, 0, time.UTC)}
 
-	if err := recordAttempt(store, ex, "tok-1", snap, gradedResults()); err != nil {
+	if err := recordAttempt(store, nil, ex, "tok-1", snap, gradedResults()); err != nil {
 		t.Fatalf("recordAttempt: %v", err)
 	}
 
@@ -107,7 +107,7 @@ func TestRecordAttemptSkipsTraining(t *testing.T) {
 	res := gradedResults()
 	res.Mode = session.ModeTraining
 
-	if err := recordAttempt(store, recorderExam(), "tok-1", snap, res); err != nil {
+	if err := recordAttempt(store, nil, recorderExam(), "tok-1", snap, res); err != nil {
 		t.Fatalf("recordAttempt: %v", err)
 	}
 	if got := len(store.All()); got != 0 {
@@ -124,7 +124,7 @@ func TestRecordAttemptMarksAFilteredDrawUncounted(t *testing.T) {
 	res.Percent = 100
 	res.Passed = true
 
-	if err := recordAttempt(store, recorderExam(), "tok-1", snap, res); err != nil {
+	if err := recordAttempt(store, nil, recorderExam(), "tok-1", snap, res); err != nil {
 		t.Fatalf("recordAttempt: %v", err)
 	}
 	got := store.All()
@@ -145,7 +145,7 @@ func TestRecordAttemptIsIdempotent(t *testing.T) {
 	store := newTestStore(t)
 	snap := session.Snapshot{State: "ended", Mode: session.ModeExam}
 	for i := 0; i < 3; i++ {
-		if err := recordAttempt(store, recorderExam(), "tok-1", snap, gradedResults()); err != nil {
+		if err := recordAttempt(store, nil, recorderExam(), "tok-1", snap, gradedResults()); err != nil {
 			t.Fatalf("recordAttempt %d: %v", i, err)
 		}
 	}
@@ -157,7 +157,7 @@ func TestRecordAttemptIsIdempotent(t *testing.T) {
 func TestRecordAttemptWithoutATokenRefuses(t *testing.T) {
 	store := newTestStore(t)
 	snap := session.Snapshot{State: "ended", Mode: session.ModeExam}
-	if err := recordAttempt(store, recorderExam(), "", snap, gradedResults()); err == nil {
+	if err := recordAttempt(store, nil, recorderExam(), "", snap, gradedResults()); err == nil {
 		t.Fatal("recordAttempt with no token returned nil; an id-less record cannot be de-duplicated")
 	}
 	if got := len(store.All()); got != 0 {
@@ -169,7 +169,7 @@ func TestRecordAttemptWithoutATokenRefuses(t *testing.T) {
 // still runs, it just keeps no record.
 func TestRecordAttemptWithNoStore(t *testing.T) {
 	snap := session.Snapshot{State: "ended", Mode: session.ModeExam}
-	if err := recordAttempt(nil, recorderExam(), "tok-1", snap, gradedResults()); err != nil {
+	if err := recordAttempt(nil, nil, recorderExam(), "tok-1", snap, gradedResults()); err != nil {
 		t.Fatalf("recordAttempt with a nil store: %v", err)
 	}
 }
@@ -183,7 +183,7 @@ func TestGradeRecordsTheAttempt(t *testing.T) {
 
 	g := newGrader(ex, mgr, &countingRunner{}, time.Second)
 	g.record = func(token string, snap session.Snapshot, res *evaluate.Results) error {
-		return recordAttempt(store, ex, token, snap, res)
+		return recordAttempt(store, nil, ex, token, snap, res)
 	}
 	g.Grade()
 

--- a/facilitator/cmd/facilitator/main.go
+++ b/facilitator/cmd/facilitator/main.go
@@ -174,10 +174,18 @@ func runServer() error {
 		hist = nil
 	}
 
+	// Default-off, and the only thing in this process that knows a world
+	// outside the Pod exists. Unset under compose, which is every local
+	// run: no mirror, no request, no behaviour change.
+	mir := newMirror(os.Getenv("HISTORY_WEBHOOK_URL"), os.Getenv("HISTORY_WEBHOOK_TOKEN"), log.Printf)
+	if mir != nil {
+		log.Printf("attempts will also be posted to %s", os.Getenv("HISTORY_WEBHOOK_URL"))
+	}
+
 	runner := evaluate.NewSSHRunner(cfg.sshKey)
 	g := newGrader(ex, mgr, runner, checkTimeout)
 	g.record = func(token string, snap session.Snapshot, res *evaluate.Results) error {
-		return recordAttempt(hist, ex, token, snap, res)
+		return recordAttempt(hist, mir, ex, token, snap, res)
 	}
 	gradeFn := g.Grade
 	onExpire.Store(&gradeFn)

--- a/facilitator/cmd/facilitator/main.go
+++ b/facilitator/cmd/facilitator/main.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"net/http"
 	"net/http/httputil"
-	"net/url"
 	"os"
 	"sync/atomic"
 	"time"
@@ -199,12 +198,14 @@ func runServer() error {
 
 	// Reverse proxy for the conductor's control API: the browser only
 	// ever talks to :8080, and the conductor is only reachable from this
-	// container (they share the internal control network).
-	conductorURL, err := url.Parse("http://" + envOr("CONDUCTOR_ADDR", "conductor:9000"))
+	// container — over the internal control network under compose, over
+	// a unix socket in a hosted Pod. See conductorEndpoint.
+	conductorURL, conductorTransport, err := conductorEndpoint(envOr("CONDUCTOR_ADDR", "conductor:9000"))
 	if err != nil {
-		return fmt.Errorf("parse CONDUCTOR_ADDR: %w", err)
+		return err
 	}
 	controlProxy := httputil.NewSingleHostReverseProxy(conductorURL)
+	controlProxy.Transport = conductorTransport
 
 	boot := bootstate.New(
 		envOr("BOOT_FILE", "/shared/boot.json"),
@@ -223,8 +224,8 @@ func runServer() error {
 	// exam.Pooled, and no bank in the tree opts in yet.
 	handler := api.New(ex, cfg.bankDir, mgr, g.Grade, desktopHandler, controlProxy, web.FS(), boot, g.PracticeGrade,
 		api.WithHistory(hist),
-		api.WithBanks(newBanksFetcher(conductorURL)),
-		api.WithSeeder(newConductorSeeder(conductorURL)),
+		api.WithBanks(newBanksFetcher(conductorURL, conductorTransport)),
+		api.WithSeeder(newConductorSeeder(conductorURL, conductorTransport)),
 	)
 
 	srv := &http.Server{

--- a/facilitator/cmd/facilitator/mirror.go
+++ b/facilitator/cmd/facilitator/mirror.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"kubestronaut-sim/facilitator/internal/evaluate"
+	"kubestronaut-sim/facilitator/internal/history"
+)
+
+// mirrorTimeout bounds one delivery attempt.
+//
+// Generous because the body is the whole graded-results document, not
+// because the hub is slow — and because this runs after the candidate
+// already has their score, so nothing is waiting on it.
+const mirrorTimeout = 15 * time.Second
+
+// mirrorAttempts is how many times one attempt is offered before it is
+// given up on, and mirrorBackoff the pause after the first failure
+// (doubled for the second).
+//
+// Retried at all because in a hosted session this is the ONLY copy that
+// survives: the Pod's own /state dies with the Pod, usually within the
+// hour. Bounded at three because the failure that is worth retrying is
+// a hub mid-redeploy, which is seconds, and the one that is not is a
+// hub that is gone, which no number of attempts fixes.
+const (
+	mirrorAttempts = 3
+	mirrorBackoff  = time.Second
+)
+
+// mirror posts each graded attempt to a store that outlives this Pod.
+//
+// It is the hosted tier's whole reason for the facilitator to know
+// anything about the outside world, and it is default-off: with
+// HISTORY_WEBHOOK_URL unset there is no mirror, no request and no
+// behaviour change, which is what `./sim up` runs and must keep
+// running. The local history write is untouched either way — this is a
+// copy, not a replacement, and a hub that is down must never cost a
+// candidate the record on their own disk.
+//
+// The facilitator still has no idea who the candidate is. It presents
+// the ticket it was started with; the hub reads the identity out of
+// that. Nothing here can name a user, which is what keeps one session
+// from writing into another's history.
+type mirror struct {
+	url    string
+	token  string
+	client *http.Client
+	logf   func(string, ...any)
+	// sleep is overridable so the retry can be tested without waiting.
+	sleep func(time.Duration)
+}
+
+// newMirror returns nil when HISTORY_WEBHOOK_URL is unset, which is the
+// only configuration `./sim up` has ever had.
+func newMirror(rawURL, token string, logf func(string, ...any)) *mirror {
+	if rawURL == "" {
+		return nil
+	}
+	return &mirror{
+		url:    rawURL,
+		token:  token,
+		client: &http.Client{Timeout: mirrorTimeout},
+		logf:   logf,
+		sleep:  time.Sleep,
+	}
+}
+
+// post delivers one attempt, record and full results together.
+//
+// The results document is sent whole rather than summarised because it
+// is what the review screen renders: the per-check artifacts carry the
+// actual, the expected and the why, and a summary would leave a hosted
+// candidate with a score and no explanation of it.
+func (m *mirror) post(ctx context.Context, rec history.Record, res *evaluate.Results) error {
+	body, err := json.Marshal(struct {
+		Record  history.Record    `json:"record"`
+		Results *evaluate.Results `json:"results"`
+	}{rec, res})
+	if err != nil {
+		return fmt.Errorf("history mirror: encode: %w", err)
+	}
+
+	var last error
+	for attempt := 1; attempt <= mirrorAttempts; attempt++ {
+		if attempt > 1 {
+			m.sleep(mirrorBackoff << (attempt - 2))
+		}
+		last = m.deliver(ctx, body)
+		if last == nil {
+			return nil
+		}
+		if errors.Is(last, errMirrorRefused) {
+			// A 4xx is this build disagreeing with that hub about the
+			// request — a bad ticket, a body it will not take. Retrying
+			// sends the identical bytes to the identical answer.
+			break
+		}
+		m.logf("history mirror: attempt %d/%d: %v", attempt, mirrorAttempts, last)
+	}
+	return last
+}
+
+// errMirrorRefused marks a failure that a retry cannot change.
+var errMirrorRefused = errors.New("refused")
+
+func (m *mirror) deliver(ctx context.Context, body []byte) error {
+	ctx, cancel := context.WithTimeout(ctx, mirrorTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, m.url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("history mirror: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+m.token)
+
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("history mirror: %w", err)
+	}
+	defer resp.Body.Close()
+	// Drained so the connection can be reused, and capped because the
+	// only use for what comes back is putting it in a log line.
+	detail, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+
+	switch {
+	case resp.StatusCode < 300:
+		return nil
+	case resp.StatusCode < 500:
+		return fmt.Errorf("history mirror: %w: %s: %s", errMirrorRefused, resp.Status, bytes.TrimSpace(detail))
+	default:
+		return fmt.Errorf("history mirror: %s: %s", resp.Status, bytes.TrimSpace(detail))
+	}
+}

--- a/facilitator/cmd/facilitator/mirror_test.go
+++ b/facilitator/cmd/facilitator/mirror_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"kubestronaut-sim/facilitator/internal/history"
+	"kubestronaut-sim/facilitator/internal/session"
+)
+
+// quietMirror is a mirror pointed at url with the retry pause removed,
+// so a test of three attempts costs no seconds.
+func quietMirror(t *testing.T, url, token string) *mirror {
+	t.Helper()
+	m := newMirror(url, token, func(string, ...any) {})
+	m.sleep = func(time.Duration) {}
+	return m
+}
+
+func historyRecord() history.Record {
+	return history.Record{ID: "tok-1", Bank: "ckad-mock-01", Mode: session.ModeExam}
+}
+
+// The whole point of the mirror: the hub receives the record AND the
+// full results document. A record alone would give a hosted candidate a
+// score in their history with nothing behind it, because the review
+// screen renders from the results' per-check artifacts.
+func TestMirrorPostsTheRecordAndTheFullResults(t *testing.T) {
+	var gotAuth, gotType string
+	var body struct {
+		Record  map[string]any `json:"record"`
+		Results map[string]any `json:"results"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth, gotType = r.Header.Get("Authorization"), r.Header.Get("Content-Type")
+		json.NewDecoder(r.Body).Decode(&body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	store := newTestStore(t)
+	snap := session.Snapshot{State: "ended", Mode: session.ModeExam}
+	if err := recordAttempt(store, quietMirror(t, srv.URL, "tok"), recorderExam(), "tok-1", snap, gradedResults()); err != nil {
+		t.Fatalf("recordAttempt: %v", err)
+	}
+
+	if gotAuth != "Bearer tok" {
+		t.Errorf("Authorization = %q", gotAuth)
+	}
+	if gotType != "application/json" {
+		t.Errorf("Content-Type = %q", gotType)
+	}
+	if body.Record["id"] != "tok-1" {
+		t.Errorf("record id = %v", body.Record["id"])
+	}
+	if body.Results == nil {
+		t.Fatal("the results document was not sent; a hosted attempt would have no review")
+	}
+	if _, ok := body.Results["questions"]; !ok {
+		t.Errorf("results carry no questions: %v", body.Results)
+	}
+	// Nothing in the body names a user. The ticket does, and only the
+	// ticket may — a Pod that could name its own user could write into
+	// anyone's history.
+	raw, _ := json.Marshal(body)
+	for _, forbidden := range []string{"user", "uid", "login"} {
+		if strings.Contains(strings.ToLower(string(raw)), `"`+forbidden+`"`) {
+			t.Errorf("the posted body names a %q; identity must come from the ticket alone", forbidden)
+		}
+	}
+}
+
+// A hub that is down must not also cost the candidate the copy on their
+// own disk. The local write comes first and its success is not
+// conditional on the remote one.
+func TestMirrorFailureStillLeavesTheLocalRecord(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "down", http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	store := newTestStore(t)
+	snap := session.Snapshot{State: "ended", Mode: session.ModeExam}
+	err := recordAttempt(store, quietMirror(t, srv.URL, "tok"), recorderExam(), "tok-1", snap, gradedResults())
+	if err == nil {
+		t.Fatal("a failed mirror must be reported, not swallowed")
+	}
+	if got := len(store.All()); got != 1 {
+		t.Fatalf("local history has %d attempts, want 1", got)
+	}
+}
+
+func TestMirrorRetriesAServerErrorAndGivesUp(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, "restarting", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	if err := quietMirror(t, srv.URL, "tok").post(t.Context(), historyRecord(), gradedResults()); err == nil {
+		t.Fatal("post returned nil after every attempt failed")
+	}
+	if got := calls.Load(); got != mirrorAttempts {
+		t.Errorf("delivered %d times, want %d", got, mirrorAttempts)
+	}
+}
+
+func TestMirrorRetryRecoversFromARestartingHub(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			http.Error(w, "restarting", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if err := quietMirror(t, srv.URL, "tok").post(t.Context(), historyRecord(), gradedResults()); err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("delivered %d times, want 2", got)
+	}
+}
+
+// A rejected ticket is this build disagreeing with that hub. Retrying
+// sends identical bytes to an identical answer, and in a hosted session
+// that is three times the delay before the candidate's own log says
+// what is wrong.
+func TestMirrorDoesNotRetryARejectedTicket(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, "that ticket is not valid", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	err := quietMirror(t, srv.URL, "bad").post(t.Context(), historyRecord(), gradedResults())
+	if err == nil {
+		t.Fatal("a rejected ticket returned nil")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("delivered %d times, want 1", got)
+	}
+}
+
+// Unset is what `./sim up` runs, and it must produce no mirror at all —
+// not a mirror that posts nowhere.
+func TestNoWebhookURLMeansNoMirror(t *testing.T) {
+	if m := newMirror("", "tok", nil); m != nil {
+		t.Errorf("newMirror with no URL returned %+v", m)
+	}
+}

--- a/facilitator/cmd/facilitator/seeder.go
+++ b/facilitator/cmd/facilitator/seeder.go
@@ -33,9 +33,9 @@ type conductorSeeder struct {
 	statusURL string
 }
 
-func newConductorSeeder(base *url.URL) api.Seeder {
+func newConductorSeeder(base *url.URL, rt http.RoundTripper) api.Seeder {
 	return &conductorSeeder{
-		client:    &http.Client{Timeout: seedTimeout},
+		client:    &http.Client{Timeout: seedTimeout, Transport: rt},
 		seedURL:   base.JoinPath("/api/control/seed").String(),
 		statusURL: base.JoinPath("/api/control/status").String(),
 	}

--- a/facilitator/cmd/facilitator/seeder_test.go
+++ b/facilitator/cmd/facilitator/seeder_test.go
@@ -23,7 +23,7 @@ func TestConductorSeederStart(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s := newConductorSeeder(mustParseURL(t, srv.URL))
+	s := newConductorSeeder(mustParseURL(t, srv.URL), nil)
 	id, err := s.Start(t.Context(), []string{"q03", "q01"})
 	if err != nil {
 		t.Fatalf("Start: %v", err)
@@ -48,7 +48,7 @@ func TestConductorSeederStartSurfacesTheConductorsReason(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s := newConductorSeeder(mustParseURL(t, srv.URL))
+	s := newConductorSeeder(mustParseURL(t, srv.URL), nil)
 	_, err := s.Start(t.Context(), []string{"q01"})
 	if err == nil {
 		t.Fatal("Start accepted a 409")
@@ -85,7 +85,7 @@ func TestConductorSeederStatus(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			s := newConductorSeeder(mustParseURL(t, srv.URL))
+			s := newConductorSeeder(mustParseURL(t, srv.URL), nil)
 			got, err := s.Status(t.Context(), "job-4")
 			if err != nil {
 				t.Fatalf("Status: %v", err)

--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -1,0 +1,31 @@
+FROM golang:1.24-alpine AS build
+WORKDIR /src
+COPY go.mod ./
+COPY cmd ./cmd
+COPY internal ./internal
+RUN CGO_ENABLED=0 go build -o /hub ./cmd/hub
+# STATE_DIR's default, created here because a scratch image has no shell
+# to create it with and the hub runs as 65532. Without it the process
+# dies at start with "mkdir /state: permission denied" — a Pod with a
+# real volume mounted there never sees this, which is exactly why it
+# would be found by whoever first ran the image on its own.
+RUN mkdir -p /state && chown 65532:65532 /state
+
+# scratch, not alpine, and it is the only image in this repo that can be.
+# The hub speaks HTTP to two places — the Kubernetes API and each session
+# Pod — and shells out to nothing, so it needs no yq, no ssh, no busybox.
+# It is also the only process here that is reachable from the internet,
+# which makes "there is no shell in this image" worth having.
+FROM scratch
+# The Kubernetes API server is TLS and the hub verifies it against the
+# ServiceAccount's own CA bundle, which the kubelet projects into the
+# Pod. This is here for the OTHER TLS client in the process: the GitHub
+# OAuth exchange, which needs public roots.
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /hub /hub
+COPY --from=build --chown=65532:65532 /state /state
+# Non-root by default. Nothing here writes outside /state, which is a
+# volume the chart owns.
+USER 65532:65532
+EXPOSE 8080
+ENTRYPOINT ["/hub"]

--- a/hub/cmd/hub/main.go
+++ b/hub/cmd/hub/main.go
@@ -1,0 +1,287 @@
+// Command hub is the front door of the hosted tier: identity, attempt
+// history, seats, and the proxy to each candidate's own session Pod.
+//
+// It exists so the simulator does not have to change. The facilitator
+// still has no authentication of any kind — it is simply never reachable
+// except through this process. That is what keeps `./sim up`
+// byte-identical, with no accounts and no new required configuration.
+//
+// Two ways to run it:
+//
+//	AUTH_MODE=github  ... SESSION_POD_TEMPLATE=/etc/hub/session-pod.json
+//	AUTH_MODE=none    ... SESSION_UPSTREAM=127.0.0.1:8080
+//
+// The second needs no Kubernetes at all: it puts the whole hub —
+// admission, seats, the queue, the recycle protocol, the proxy — in
+// front of a local `./sim up`, which is the only place the whole
+// simulator runs without a cluster. What it cannot do is rebuild
+// anything, so a reset there completes the protocol over the same
+// facilitator rather than a fresh one.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"kubestronaut-sim/hub/internal/api"
+	"kubestronaut-sim/hub/internal/auth"
+	"kubestronaut-sim/hub/internal/kube"
+	"kubestronaut-sim/hub/internal/session"
+	"kubestronaut-sim/hub/internal/store"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatalf("hub: %v", err)
+	}
+}
+
+func run() error {
+	addr := envOr("ADDR", ":8080")
+	stateDir := envOr("STATE_DIR", "/state")
+
+	mode, err := auth.ParseMode(envOr("AUTH_MODE", string(auth.ModeGitHub)))
+	if err != nil {
+		return err
+	}
+	secure := envOr("COOKIE_SECURE", "true") != "false"
+	ttl, err := time.ParseDuration(envOr("SESSION_TTL", "12h"))
+	if err != nil {
+		return fmt.Errorf("SESSION_TTL: %w", err)
+	}
+
+	a := &auth.Authenticator{
+		Mode:       mode,
+		HeaderName: envOr("AUTH_HEADER", "X-Forwarded-User"),
+		Secure:     secure,
+		TTL:        ttl,
+	}
+
+	// Configuration is validated before anything is created. Both a
+	// missing client secret and an unwritable state directory stop the
+	// process, but only one of them is reported first, and the useful
+	// one to report is the configuration: a hub run with no environment
+	// at all should say what it needs, not what it could not mkdir.
+	baseURL := strings.TrimSuffix(os.Getenv("HUB_BASE_URL"), "/")
+	if mode == auth.ModeGitHub {
+		// Every one of these is required, and a hub that starts without
+		// them would look healthy and fail at the first login. Checked
+		// here, once, with a message that names what is missing.
+		key := os.Getenv("COOKIE_KEY")
+		id, secret := os.Getenv("GITHUB_CLIENT_ID"), os.Getenv("GITHUB_CLIENT_SECRET")
+		var missing []string
+		for name, v := range map[string]string{
+			"COOKIE_KEY": key, "GITHUB_CLIENT_ID": id,
+			"GITHUB_CLIENT_SECRET": secret, "HUB_BASE_URL": baseURL,
+		} {
+			if v == "" {
+				missing = append(missing, name)
+			}
+		}
+		if len(missing) > 0 {
+			sort.Strings(missing)
+			return fmt.Errorf("AUTH_MODE=github needs %s", strings.Join(missing, ", "))
+		}
+		signer, err := auth.NewSigner([]byte(key))
+		if err != nil {
+			return err
+		}
+		a.Signer = signer
+		a.GitHub = auth.NewGitHub(id, secret, baseURL+"/hub/auth/callback")
+	}
+
+	if mode == auth.ModeHeader {
+		// Said out loud at boot because the failure is silent: a hub
+		// reachable directly in this mode lets anyone claim any identity
+		// by setting one header.
+		log.Printf("hub: AUTH_MODE=header trusts %q — this process MUST NOT be reachable except through the proxy that sets it", a.HeaderName)
+	}
+
+	st, err := store.New(stateDir)
+	if err != nil {
+		return err
+	}
+	srv := &api.Server{Auth: a, Store: st, BaseURL: baseURL}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	mgr, err := buildManager()
+	if err != nil {
+		return err
+	}
+	if mgr != nil {
+		srv.Sessions = mgr
+		srv.DefaultKind, err = session.ParseKind(envOr("DEFAULT_KIND", string(session.Practical)))
+		if err != nil {
+			return err
+		}
+		// Adopt before serving: a hub redeployed mid-exam that forgot its
+		// sessions would put every candidate behind a queue for seats
+		// that are already taken, with their own Pods running.
+		if err := mgr.Adopt(ctx); err != nil {
+			log.Printf("hub: %v (starting anyway with no adopted sessions)", err)
+		}
+		go mgr.Run(ctx, envDuration("REAP_INTERVAL", 30*time.Second))
+	}
+
+	log.Printf("hub listening on %s (auth %s, state %s, sessions %v)", addr, mode, stateDir, mgr != nil)
+	// Timeouts, because this is an internet-facing process. No write
+	// timeout: the session proxy carries the desktop's WebSocket, which
+	// is long-lived by design.
+	s := &http.Server{
+		Addr:              addr,
+		Handler:           srv.Handler(),
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		BaseContext:       func(net.Listener) context.Context { return ctx },
+	}
+	go func() {
+		<-ctx.Done()
+		shutdown, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		s.Shutdown(shutdown)
+	}()
+	if err := s.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}
+
+// buildManager returns nil when this deployment serves identity and
+// history only — which is a real configuration, not a degraded one: it
+// is what the auth and store halves can be run and proved with before a
+// cluster exists.
+func buildManager() (*session.Manager, error) {
+	upstream := os.Getenv("SESSION_UPSTREAM")
+	practical := os.Getenv("SESSION_POD_TEMPLATE")
+	mcq := os.Getenv("SESSION_POD_TEMPLATE_MCQ")
+	if upstream == "" && practical == "" && mcq == "" {
+		log.Print("hub: no SESSION_UPSTREAM or SESSION_POD_TEMPLATE — serving identity and history only")
+		return nil, nil
+	}
+
+	readyContainer := envOr("READY_CONTAINER", "facilitator")
+	cfg := session.Config{
+		Flavours:        map[session.Kind]session.Flavour{},
+		HoldFor:         envDuration("QUEUE_HOLD", 2*time.Minute),
+		IdleAfter:       envDuration("IDLE_TIMEOUT", 30*time.Minute),
+		MaxAge:          envDuration("SESSION_MAX_AGE", 10*time.Hour),
+		BootTimeout:     envDuration("BOOT_TIMEOUT", 20*time.Minute),
+		BootConcurrency: envInt("BOOT_CONCURRENCY", 1),
+		ReadyContainer:  readyContainer,
+		Port:            envInt("SESSION_PORT", 8080),
+		PodPrefix:       envOr("POD_PREFIX", "sim-session"),
+		Labels: map[string]string{
+			"app.kubernetes.io/name":      "kubestronaut-sim",
+			"app.kubernetes.io/component": "session",
+		},
+		Logf: log.Printf,
+	}
+
+	var pods session.Pods
+	if upstream != "" {
+		// The local path. One fixed address, a real Pod lifecycle on top
+		// of it, and no cluster.
+		host, port, err := net.SplitHostPort(upstream)
+		if err != nil {
+			return nil, fmt.Errorf("SESSION_UPSTREAM must be host:port: %w", err)
+		}
+		p, err := strconv.Atoi(port)
+		if err != nil {
+			return nil, fmt.Errorf("SESSION_UPSTREAM port: %w", err)
+		}
+		cfg.Port = p
+		pods = &session.Static{Host: host}
+		log.Printf("hub: SESSION_UPSTREAM=%s — every session proxies to this one address", upstream)
+	} else {
+		client, err := kube.InCluster()
+		if err != nil {
+			return nil, err
+		}
+		if ns := os.Getenv("SESSION_NAMESPACE"); ns != "" {
+			client.Namespace = ns
+		}
+		pods = &session.KubePods{Client: client, ReadyContainer: readyContainer}
+		log.Printf("hub: creating session Pods in namespace %s", client.Namespace)
+	}
+
+	for kind, spec := range map[session.Kind]struct{ path, seats, bank string }{
+		session.Practical: {practical, "PRACTICAL_SEATS", "PRACTICAL_BANK"},
+		session.MCQ:       {mcq, "MCQ_SEATS", "MCQ_BANK"},
+	} {
+		seats := envInt(spec.seats, 0)
+		if spec.path == "" && upstream == "" {
+			continue
+		}
+		if seats <= 0 {
+			continue
+		}
+		var tmpl session.Template
+		if spec.path != "" {
+			b, err := os.ReadFile(spec.path)
+			if err != nil {
+				return nil, fmt.Errorf("read %s: %w", spec.path, err)
+			}
+			tmpl = b
+		} else {
+			// SESSION_UPSTREAM has no Pod to create, but the manager
+			// still renders a manifest to name and label the thing it is
+			// tracking. A minimal one keeps that path identical to the
+			// real one rather than special-cased.
+			tmpl = session.Template(`{"kind":"Pod","metadata":{},"spec":{"containers":[{"name":"facilitator","env":[{"name":"BANK","value":""}]}]}}`)
+		}
+		cfg.Flavours[kind] = session.Flavour{
+			Seats: seats, Template: tmpl, Bank: os.Getenv(spec.bank),
+		}
+		log.Printf("hub: %s sessions: %d seat(s)", kind, seats)
+	}
+	if len(cfg.Flavours) == 0 {
+		return nil, errors.New("hub: sessions are configured but no flavour has seats — set PRACTICAL_SEATS and/or MCQ_SEATS")
+	}
+	return session.New(pods, cfg), nil
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func envInt(key string, fallback int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		log.Printf("hub: %s=%q is not a number; using %d", key, v, fallback)
+		return fallback
+	}
+	return n
+}
+
+func envDuration(key string, fallback time.Duration) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		log.Printf("hub: %s=%q is not a duration; using %s", key, v, fallback)
+		return fallback
+	}
+	return d
+}

--- a/hub/cmd/hub/main.go
+++ b/hub/cmd/hub/main.go
@@ -74,6 +74,7 @@ func run() error {
 	// one to report is the configuration: a hub run with no environment
 	// at all should say what it needs, not what it could not mkdir.
 	baseURL := strings.TrimSuffix(os.Getenv("HUB_BASE_URL"), "/")
+	var ingest *auth.Signer
 	if mode == auth.ModeGitHub {
 		// Every one of these is required, and a hub that starts without
 		// them would look healthy and fail at the first login. Checked
@@ -101,6 +102,23 @@ func run() error {
 		a.GitHub = auth.NewGitHub(id, secret, baseURL+"/hub/auth/callback")
 	}
 
+	// Follows COOKIE_KEY rather than the auth mode, deliberately.
+	//
+	// AUTH_MODE=header issues no cookie and so needs no key of its own —
+	// but it is the self-hosting path, and a deployment there with seats
+	// and a proxy and silently no durable history would be the one thing
+	// a hosted tier is for, missing. Setting COOKIE_KEY is what turns
+	// attempt collection on; github mode requires it anyway.
+	//
+	// Derived, not the same key: see auth.Derive. A ticket read out of a
+	// Pod spec must not be spendable as that candidate's login.
+	if key := os.Getenv("COOKIE_KEY"); key != "" {
+		ingest, err = auth.NewSigner(auth.Derive([]byte(key), auth.PurposeIngest))
+		if err != nil {
+			return err
+		}
+	}
+
 	if mode == auth.ModeHeader {
 		// Said out loud at boot because the failure is silent: a hub
 		// reachable directly in this mode lets anyone claim any identity
@@ -112,12 +130,12 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	srv := &api.Server{Auth: a, Store: st, BaseURL: baseURL}
+	srv := &api.Server{Auth: a, Store: st, BaseURL: baseURL, Ingest: ingest}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	mgr, err := buildManager()
+	mgr, err := buildManager(newTicketer(ingest, baseURL, envDuration("SESSION_MAX_AGE", 10*time.Hour)))
 	if err != nil {
 		return err
 	}
@@ -159,11 +177,42 @@ func run() error {
 	return nil
 }
 
+// ticketGrace is how long a Pod's history ticket stays good past the
+// hard session cap.
+//
+// It is not a second lease. The Pod is already gone by then; this only
+// covers an attempt graded in the last minutes of a session whose POST
+// is retrying while the hub restarts. A ticket that expired exactly at
+// the cap would lose precisely the attempt that ran the full length.
+const ticketGrace = time.Hour
+
+// newTicketer returns the session.Config.Webhook for this deployment,
+// or nil when nothing here can collect attempts — no signer (so no
+// AUTH_MODE=github) or no base URL for the Pod to post back to. Nil is
+// not a failure: it is a hub keeping seats and a proxy without a
+// durable history, which is exactly what AUTH_MODE=none is.
+func newTicketer(signer *auth.Signer, baseURL string, maxAge time.Duration) func(string) (string, string, error) {
+	if signer == nil || baseURL == "" {
+		return nil
+	}
+	endpoint := baseURL + "/hub/ingest/history"
+	return func(user string) (string, string, error) {
+		tok, err := signer.Encode(auth.Session{
+			UserID:  user,
+			Expires: time.Now().Add(maxAge + ticketGrace).Unix(),
+		})
+		if err != nil {
+			return "", "", err
+		}
+		return endpoint, tok, nil
+	}
+}
+
 // buildManager returns nil when this deployment serves identity and
 // history only — which is a real configuration, not a degraded one: it
 // is what the auth and store halves can be run and proved with before a
 // cluster exists.
-func buildManager() (*session.Manager, error) {
+func buildManager(webhook func(string) (string, string, error)) (*session.Manager, error) {
 	upstream := os.Getenv("SESSION_UPSTREAM")
 	practical := os.Getenv("SESSION_POD_TEMPLATE")
 	mcq := os.Getenv("SESSION_POD_TEMPLATE_MCQ")
@@ -187,7 +236,8 @@ func buildManager() (*session.Manager, error) {
 			"app.kubernetes.io/name":      "kubestronaut-sim",
 			"app.kubernetes.io/component": "session",
 		},
-		Logf: log.Printf,
+		Webhook: webhook,
+		Logf:    log.Printf,
 	}
 
 	var pods session.Pods
@@ -239,8 +289,15 @@ func buildManager() (*session.Manager, error) {
 			// SESSION_UPSTREAM has no Pod to create, but the manager
 			// still renders a manifest to name and label the thing it is
 			// tracking. A minimal one keeps that path identical to the
-			// real one rather than special-cased.
-			tmpl = session.Template(`{"kind":"Pod","metadata":{},"spec":{"containers":[{"name":"facilitator","env":[{"name":"BANK","value":""}]}]}}`)
+			// real one rather than special-cased — including declaring
+			// the webhook vars, so a render that would fail against the
+			// real template fails here too rather than only in the
+			// cluster. Nothing reads them: the upstream is a `./sim up`
+			// this process did not start and cannot configure.
+			tmpl = session.Template(`{"kind":"Pod","metadata":{},"spec":{"containers":[{"name":"facilitator","env":[` +
+				`{"name":"BANK","value":""},` +
+				`{"name":"HISTORY_WEBHOOK_URL","value":""},` +
+				`{"name":"HISTORY_WEBHOOK_TOKEN","value":""}]}]}}`)
 		}
 		cfg.Flavours[kind] = session.Flavour{
 			Seats: seats, Template: tmpl, Bank: os.Getenv(spec.bank),

--- a/hub/go.mod
+++ b/hub/go.mod
@@ -1,0 +1,3 @@
+module kubestronaut-sim/hub
+
+go 1.24

--- a/hub/internal/api/api.go
+++ b/hub/internal/api/api.go
@@ -193,20 +193,26 @@ func (s *Server) seats() map[string]seat {
 }
 
 // handleHistory serves the user's attempts in the exact shape the
-// facilitator's own /api/history returns, so Progress.tsx needs no
+// facilitator's own /api/history returns — most recent first, with the
+// cross-attempt rollup beside them — so Progress.tsx needs no
 // hosted-mode branch.
+//
+// Not store.Document: that is the interchange format an export writes,
+// and it is oldest-first with no summary. The dashboard reads
+// `summary.weakDomains` unconditionally, so serving the document here
+// gives a blank screen rather than a wrong one.
 func (s *Server) handleHistory(w http.ResponseWriter, r *http.Request) {
 	sess, ok := s.requireUser(w, r)
 	if !ok {
 		return
 	}
-	doc, err := s.Store.Document(sess.UserID)
+	hist, err := s.Store.History(sess.UserID)
 	if err != nil {
 		s.logf("hub: history for %s: %v", sess.UserID, err)
 		writeError(w, http.StatusInternalServerError, "could not read your history")
 		return
 	}
-	writeJSON(w, http.StatusOK, doc)
+	writeJSON(w, http.StatusOK, hist)
 }
 
 func (s *Server) handleAttempt(w http.ResponseWriter, r *http.Request) {

--- a/hub/internal/api/api.go
+++ b/hub/internal/api/api.go
@@ -1,0 +1,314 @@
+// Package api is the hub's HTTP surface: the handful of routes it
+// answers itself. Everything it does not answer belongs to the user's
+// session Pod and is proxied there.
+//
+// The route table is deliberately small, and GET /api/me is the reason.
+// A local facilitator JSON-404s any /api/* it does not know, so the SPA
+// can ask once and learn which product it is talking to — no build flag,
+// no separate bundle, and `./sim up` stays byte-identical.
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"time"
+
+	"kubestronaut-sim/hub/internal/auth"
+	"kubestronaut-sim/hub/internal/session"
+	"kubestronaut-sim/hub/internal/store"
+)
+
+// stateCookie carries the OAuth CSRF token between the redirect to
+// GitHub and the callback. Short-lived and its own cookie so it cannot
+// be confused with a session.
+const stateCookie = "kubestronaut_oauth_state"
+
+// Server wires the hub's dependencies into a handler.
+type Server struct {
+	Auth  *auth.Authenticator
+	Store *store.Store
+	// Sessions is nil in the identity-only deployment the store and auth
+	// packages can be exercised without: no seats, no proxy, no
+	// catch-all. Every session route checks for it.
+	Sessions *session.Manager
+	// DefaultKind is the flavour /api/session/start admits into when the
+	// request does not say.
+	DefaultKind session.Kind
+	// BaseURL is where a browser reaches the hub, used to build the
+	// OAuth redirect back to it.
+	BaseURL string
+	Logf    func(string, ...any)
+
+	proxy *httputil.ReverseProxy
+}
+
+func (s *Server) logf(format string, args ...any) {
+	if s.Logf != nil {
+		s.Logf(format, args...)
+		return
+	}
+	log.Printf(format, args...)
+}
+
+// Handler returns the hub's routes.
+//
+// Two kinds of route live here and the distinction is the whole design.
+// The hub ANSWERS identity, history, admission and the control
+// operations that replace a Pod — everything whose truth outlives a
+// session. It PROXIES the rest to the candidate's own Pod, where the
+// facilitator is unchanged and unaware any of this exists.
+//
+// Go's mux resolves most-specific-first, so registering "/" as the
+// catch-all does not shadow anything above it.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.Write([]byte("ok"))
+	})
+
+	mux.HandleFunc("GET /api/me", s.handleMe)
+
+	// Every /api/history route is answered here, none are proxied. A
+	// split — some from the hub's store, some from the Pod's ephemeral
+	// one — would give two different answers to the same question
+	// depending on the path, and the Pod's answer is always the one that
+	// is about to be destroyed.
+	mux.HandleFunc("GET /api/history", s.handleHistory)
+	mux.HandleFunc("DELETE /api/history", s.handleHistoryDelete)
+	mux.HandleFunc("GET /api/history/export", s.handleHistoryExport)
+	mux.HandleFunc("POST /api/history/import", s.handleHistoryImport)
+	mux.HandleFunc("GET /api/history/summary", s.handleHistorySummary)
+	mux.HandleFunc("GET /api/history/{attempt}", s.handleAttempt)
+
+	mux.HandleFunc("GET /hub/auth/login", s.handleLogin)
+	mux.HandleFunc("GET /hub/auth/callback", s.handleCallback)
+	mux.HandleFunc("POST /hub/auth/logout", s.handleLogout)
+
+	if s.Sessions != nil {
+		s.proxy = s.newProxy()
+
+		// Admission. The facilitator's own POST /api/session/start still
+		// runs — it is what actually begins an attempt — but only after
+		// this has granted a seat and the Pod is up, and the request is
+		// then forwarded there unchanged.
+		mux.HandleFunc("POST /api/session/start", s.handleSessionStart)
+		mux.HandleFunc("POST /hub/session/end", s.handleSessionEnd)
+
+		// Reset and switch are Pod replacement here, not in-place
+		// rebuilds, so the hub owns them and the job they report.
+		mux.HandleFunc("POST /api/control/reset", s.handleReset)
+		mux.HandleFunc("POST /api/control/switch", s.handleSwitch)
+		mux.HandleFunc("GET /api/control/status", s.handleControlStatus)
+		mux.HandleFunc("GET /api/control/log", s.handleControlLog)
+
+		mux.HandleFunc("/", s.handleProxy)
+	}
+
+	return mux
+}
+
+// me is the hosted-mode probe. It answers 200 whether or not anyone is
+// logged in, on purpose: the SPA is asking "am I talking to a hub?", and
+// a 401 would conflate "hosted, logged out" with "not hosted at all".
+type me struct {
+	Authenticated bool    `json:"authenticated"`
+	AuthMode      string  `json:"authMode"`
+	User          *meUser `json:"user,omitempty"`
+	LoginURL      string  `json:"loginURL,omitempty"`
+
+	// Session and Queue are what the header chip and the queue dialog
+	// render. Both omitted when there is nothing to say, so the SPA can
+	// treat their presence as the question's answer.
+	Session *session.Session `json:"session,omitempty"`
+	Queue   *queueState      `json:"queue,omitempty"`
+	Seats   map[string]seat  `json:"seats,omitempty"`
+}
+
+type meUser struct {
+	ID    string `json:"id"`
+	Login string `json:"login"`
+}
+
+type queueState struct {
+	Position int `json:"position"`
+}
+
+type seat struct {
+	Used  int `json:"used"`
+	Total int `json:"total"`
+}
+
+func (s *Server) handleMe(w http.ResponseWriter, r *http.Request) {
+	body := me{AuthMode: string(s.Auth.Mode)}
+	sess, err := s.Auth.Current(r)
+	if err != nil {
+		body.LoginURL = "/hub/auth/login"
+		// Seat counts before login on purpose: someone deciding whether
+		// to sign in is entitled to know whether there is anywhere to
+		// sit. It is a capacity number, not a fact about anyone.
+		body.Seats = s.seats()
+		writeJSON(w, http.StatusOK, body)
+		return
+	}
+	body.Authenticated = true
+	body.User = &meUser{ID: sess.UserID, Login: sess.Login}
+	body.Seats = s.seats()
+	if s.Sessions != nil {
+		if live, err := s.Sessions.Get(sess.UserID); err == nil {
+			body.Session = &live
+		} else if pos := s.Sessions.Position(sess.UserID); pos > 0 {
+			body.Queue = &queueState{Position: pos}
+		}
+	}
+	writeJSON(w, http.StatusOK, body)
+}
+
+func (s *Server) seats() map[string]seat {
+	if s.Sessions == nil {
+		return nil
+	}
+	out := map[string]seat{}
+	for kind, counts := range s.Sessions.Seats() {
+		out[string(kind)] = seat{Used: counts[0], Total: counts[1]}
+	}
+	return out
+}
+
+// handleHistory serves the user's attempts in the exact shape the
+// facilitator's own /api/history returns, so Progress.tsx needs no
+// hosted-mode branch.
+func (s *Server) handleHistory(w http.ResponseWriter, r *http.Request) {
+	sess, ok := s.requireUser(w, r)
+	if !ok {
+		return
+	}
+	doc, err := s.Store.Document(sess.UserID)
+	if err != nil {
+		s.logf("hub: history for %s: %v", sess.UserID, err)
+		writeError(w, http.StatusInternalServerError, "could not read your history")
+		return
+	}
+	writeJSON(w, http.StatusOK, doc)
+}
+
+func (s *Server) handleAttempt(w http.ResponseWriter, r *http.Request) {
+	sess, ok := s.requireUser(w, r)
+	if !ok {
+		return
+	}
+	// Scoped to the caller's own user directory, so an attempt ID
+	// belonging to someone else is simply not found rather than served.
+	results, err := s.Store.Results(sess.UserID, r.PathValue("attempt"))
+	switch {
+	case errors.Is(err, store.ErrNotFound), errors.Is(err, store.ErrBadName):
+		writeError(w, http.StatusNotFound, "no such attempt")
+		return
+	case err != nil:
+		s.logf("hub: results for %s: %v", sess.UserID, err)
+		writeError(w, http.StatusInternalServerError, "could not read that attempt")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	w.Write(results)
+}
+
+func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
+	if s.Auth.Mode != auth.ModeGitHub {
+		// In header and none modes there is nothing to log in to; saying
+		// so beats redirecting to an OAuth app that does not exist.
+		writeError(w, http.StatusNotFound, "this deployment does not use GitHub login")
+		return
+	}
+	state, err := auth.NewState()
+	if err != nil {
+		s.logf("hub: %v", err)
+		writeError(w, http.StatusInternalServerError, "could not start login")
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     stateCookie,
+		Value:    state,
+		Path:     "/hub/auth",
+		HttpOnly: true,
+		Secure:   s.Auth.Secure,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   int((10 * time.Minute).Seconds()),
+	})
+	http.Redirect(w, r, s.Auth.GitHub.AuthCodeURL(state), http.StatusFound)
+}
+
+func (s *Server) handleCallback(w http.ResponseWriter, r *http.Request) {
+	if s.Auth.Mode != auth.ModeGitHub {
+		writeError(w, http.StatusNotFound, "this deployment does not use GitHub login")
+		return
+	}
+	// The state check is the CSRF defence, and it comes first: without
+	// it an attacker can complete a login flow in someone else's browser
+	// and have them signed in as the attacker.
+	c, err := r.Cookie(stateCookie)
+	if err != nil || c.Value == "" || c.Value != r.URL.Query().Get("state") {
+		writeError(w, http.StatusBadRequest, "login state did not match — start again")
+		return
+	}
+	// Spent, whatever happens next.
+	http.SetCookie(w, &http.Cookie{
+		Name: stateCookie, Value: "", Path: "/hub/auth",
+		HttpOnly: true, Secure: s.Auth.Secure, SameSite: http.SameSiteLaxMode, MaxAge: -1,
+	})
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		writeError(w, http.StatusBadRequest, "no authorization code")
+		return
+	}
+	token, err := s.Auth.GitHub.Exchange(r.Context(), code)
+	if err != nil {
+		s.logf("hub: %v", err)
+		writeError(w, http.StatusBadGateway, "GitHub refused the login")
+		return
+	}
+	sess, err := s.Auth.GitHub.User(r.Context(), token)
+	if err != nil {
+		s.logf("hub: %v", err)
+		writeError(w, http.StatusBadGateway, "could not read your GitHub account")
+		return
+	}
+	if err := s.Auth.Issue(w, sess); err != nil {
+		s.logf("hub: %v", err)
+		writeError(w, http.StatusInternalServerError, "could not start your session")
+		return
+	}
+	s.logf("hub: %s (%s) logged in", sess.Login, sess.UserID)
+	http.Redirect(w, r, "/", http.StatusFound)
+}
+
+func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
+	s.Auth.Clear(w)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// requireUser writes a 401 and reports false when nobody is logged in.
+func (s *Server) requireUser(w http.ResponseWriter, r *http.Request) (auth.Session, bool) {
+	sess, err := s.Auth.Current(r)
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "not signed in")
+		return auth.Session{}, false
+	}
+	return sess, true
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(body)
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}

--- a/hub/internal/api/api.go
+++ b/hub/internal/api/api.go
@@ -40,7 +40,12 @@ type Server struct {
 	// BaseURL is where a browser reaches the hub, used to build the
 	// OAuth redirect back to it.
 	BaseURL string
-	Logf    func(string, ...any)
+	// Ingest verifies the tickets session Pods post graded attempts
+	// with. A DIFFERENT signer from Auth's, over a derived key, so a
+	// ticket lifted from a Pod spec is not a login — see auth.Derive.
+	// Nil leaves the route unregistered.
+	Ingest *auth.Signer
+	Logf   func(string, ...any)
 
 	proxy *httputil.ReverseProxy
 }
@@ -88,6 +93,14 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /hub/auth/login", s.handleLogin)
 	mux.HandleFunc("GET /hub/auth/callback", s.handleCallback)
 	mux.HandleFunc("POST /hub/auth/logout", s.handleLogout)
+
+	// Under /hub/, not /api/, and deliberately: /api/ is the candidate's
+	// surface and everything under it is proxied or answered on their
+	// behalf. This is the session Pod talking to the hub about them, and
+	// it authenticates as the Pod, not as them.
+	if s.Ingest != nil {
+		mux.HandleFunc("POST /hub/ingest/history", s.handleIngestHistory)
+	}
 
 	if s.Sessions != nil {
 		s.proxy = s.newProxy()

--- a/hub/internal/api/api_test.go
+++ b/hub/internal/api/api_test.go
@@ -1,0 +1,299 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"kubestronaut-sim/hub/internal/auth"
+	"kubestronaut-sim/hub/internal/store"
+)
+
+func newServer(t *testing.T, mode auth.Mode) (*Server, *store.Store) {
+	t.Helper()
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := auth.NewSigner([]byte(strings.Repeat("k", 32)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &Server{
+		Auth: &auth.Authenticator{
+			Mode: mode, Signer: signer, Secure: true, TTL: time.Hour,
+			HeaderName: "X-Forwarded-User",
+		},
+		Store:   st,
+		BaseURL: "https://hub.example",
+		Logf:    func(string, ...any) {},
+	}
+	return s, st
+}
+
+func login(t *testing.T, s *Server, userID, name string) *http.Cookie {
+	t.Helper()
+	w := httptest.NewRecorder()
+	if err := s.Auth.Issue(w, auth.Session{UserID: userID, Login: name}); err != nil {
+		t.Fatal(err)
+	}
+	return w.Result().Cookies()[0]
+}
+
+func do(s *Server, r *http.Request) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	return w
+}
+
+// /api/me answers 200 even when nobody is logged in. That is the whole
+// mechanism the SPA uses to tell a hub from a local facilitator, which
+// JSON-404s any /api/* it does not know — a 401 here would conflate
+// "hosted, logged out" with "not hosted".
+func TestMeAnswers200WhenLoggedOut(t *testing.T) {
+	s, _ := newServer(t, auth.ModeGitHub)
+
+	w := do(s, httptest.NewRequest(http.MethodGet, "/api/me", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var body me
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Authenticated {
+		t.Error("authenticated = true with no cookie")
+	}
+	if body.LoginURL == "" {
+		t.Error("no loginURL offered to a logged-out user")
+	}
+	if body.AuthMode != "github" {
+		t.Errorf("authMode = %q, want github", body.AuthMode)
+	}
+}
+
+func TestMeIdentifiesALoggedInUser(t *testing.T) {
+	s, _ := newServer(t, auth.ModeGitHub)
+	r := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	r.AddCookie(login(t, s, "583231", "octocat"))
+
+	w := do(s, r)
+	var body me
+	json.Unmarshal(w.Body.Bytes(), &body)
+	if !body.Authenticated || body.User == nil {
+		t.Fatalf("body = %+v, want an authenticated user", body)
+	}
+	if body.User.ID != "583231" || body.User.Login != "octocat" {
+		t.Errorf("user = %+v", body.User)
+	}
+}
+
+func TestHistoryRequiresASession(t *testing.T) {
+	s, _ := newServer(t, auth.ModeGitHub)
+	if w := do(s, httptest.NewRequest(http.MethodGet, "/api/history", nil)); w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+// The stored record comes back byte-identical, because the UI renders it
+// with the same components it uses against a local facilitator.
+func TestHistoryReturnsTheStoredRecordUnchanged(t *testing.T) {
+	s, st := newServer(t, auth.ModeGitHub)
+	rec := json.RawMessage(`{"id":"a1","gradedAt":"2026-08-03T10:00:00Z","earned":170,"total":180,"aNewField":true}`)
+	if _, err := st.Add("583231", rec, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/api/history", nil)
+	r.AddCookie(login(t, s, "583231", "octocat"))
+	w := do(s, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var doc store.Document
+	if err := json.Unmarshal(w.Body.Bytes(), &doc); err != nil {
+		t.Fatal(err)
+	}
+	if len(doc.Attempts) != 1 {
+		t.Fatalf("attempts = %d, want 1", len(doc.Attempts))
+	}
+	if !strings.Contains(string(doc.Attempts[0]), `"aNewField":true`) {
+		t.Errorf("record lost a field in transit: %s", doc.Attempts[0])
+	}
+}
+
+// The sharpest property in this package: one user must never be able to
+// read another's attempt, even knowing its ID exactly.
+func TestOneUserCannotReadAnothersAttempt(t *testing.T) {
+	s, st := newServer(t, auth.ModeGitHub)
+	rec := json.RawMessage(`{"id":"secret1","gradedAt":"2026-08-03T10:00:00Z"}`)
+	results := json.RawMessage(`{"checks":[{"id":"q01","passed":true}]}`)
+	if _, err := st.Add("583231", rec, results); err != nil {
+		t.Fatal(err)
+	}
+
+	// The owner can read it.
+	own := httptest.NewRequest(http.MethodGet, "/api/history/secret1", nil)
+	own.AddCookie(login(t, s, "583231", "octocat"))
+	if w := do(s, own); w.Code != http.StatusOK {
+		t.Fatalf("owner got %d, want 200", w.Code)
+	}
+
+	// Someone else, with the exact ID, does not.
+	other := httptest.NewRequest(http.MethodGet, "/api/history/secret1", nil)
+	other.AddCookie(login(t, s, "999999", "attacker"))
+	w := do(s, other)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("another user got %d for someone else's attempt, want 404", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "passed") {
+		t.Error("another user's results leaked into the response body")
+	}
+}
+
+func TestAttemptWithATraversingIDIsNotFound(t *testing.T) {
+	s, _ := newServer(t, auth.ModeGitHub)
+	r := httptest.NewRequest(http.MethodGet, "/api/history/"+url.PathEscape("../../etc/passwd"), nil)
+	r.AddCookie(login(t, s, "583231", "octocat"))
+	if w := do(s, r); w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestLoginSetsStateAndRedirectsToGitHub(t *testing.T) {
+	s, _ := newServer(t, auth.ModeGitHub)
+	s.Auth.GitHub = auth.NewGitHub("cid", "csecret", "https://hub.example/hub/auth/callback")
+
+	w := do(s, httptest.NewRequest(http.MethodGet, "/hub/auth/login", nil))
+	if w.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302", w.Code)
+	}
+	loc, err := url.Parse(w.Header().Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := loc.Query().Get("state")
+	if state == "" {
+		t.Fatal("redirect carried no state")
+	}
+	var found *http.Cookie
+	for _, c := range w.Result().Cookies() {
+		if c.Name == stateCookie {
+			found = c
+		}
+	}
+	if found == nil {
+		t.Fatal("no state cookie was set")
+	}
+	if found.Value != state {
+		t.Errorf("state cookie %q does not match redirect state %q", found.Value, state)
+	}
+	if !found.HttpOnly {
+		t.Error("state cookie is not HttpOnly")
+	}
+}
+
+// Without this check an attacker can complete a login flow in someone
+// else's browser and leave them signed in as the attacker.
+func TestCallbackRejectsAMismatchedState(t *testing.T) {
+	s, _ := newServer(t, auth.ModeGitHub)
+	s.Auth.GitHub = auth.NewGitHub("cid", "csecret", "https://hub.example/hub/auth/callback")
+
+	for name, setup := range map[string]func(*http.Request){
+		"no cookie at all": func(r *http.Request) {},
+		"cookie differs": func(r *http.Request) {
+			r.AddCookie(&http.Cookie{Name: stateCookie, Value: "someone-elses"})
+		},
+		"empty cookie": func(r *http.Request) {
+			r.AddCookie(&http.Cookie{Name: stateCookie, Value: ""})
+		},
+	} {
+		r := httptest.NewRequest(http.MethodGet, "/hub/auth/callback?code=c1&state=mine", nil)
+		setup(r)
+		if w := do(s, r); w.Code != http.StatusBadRequest {
+			t.Errorf("%s: status = %d, want 400", name, w.Code)
+		}
+	}
+}
+
+func TestCallbackCompletesTheLogin(t *testing.T) {
+	s, _ := newServer(t, auth.ModeGitHub)
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/token":
+			w.Write([]byte(`{"access_token":"tok-123"}`))
+		case "/user":
+			w.Write([]byte(`{"login":"octocat","id":583231}`))
+		}
+	}))
+	defer gh.Close()
+	s.Auth.GitHub = auth.NewGitHub("cid", "csecret", "https://hub.example/hub/auth/callback")
+	s.Auth.GitHub.TokenURL = gh.URL + "/token"
+	s.Auth.GitHub.UserURL = gh.URL + "/user"
+
+	r := httptest.NewRequest(http.MethodGet, "/hub/auth/callback?code=c1&state=st1", nil)
+	r.AddCookie(&http.Cookie{Name: stateCookie, Value: "st1"})
+	w := do(s, r)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302; body=%s", w.Code, w.Body)
+	}
+	var session *http.Cookie
+	for _, c := range w.Result().Cookies() {
+		if strings.Contains(c.Name, "kubestronaut_session") {
+			session = c
+		}
+	}
+	if session == nil {
+		t.Fatal("callback issued no session cookie")
+	}
+	// And that cookie really identifies the GitHub user.
+	check := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	check.AddCookie(session)
+	var body me
+	json.Unmarshal(do(s, check).Body.Bytes(), &body)
+	if body.User == nil || body.User.ID != "583231" {
+		t.Errorf("session identifies %+v, want GitHub id 583231", body.User)
+	}
+}
+
+// Header mode is for a deployment that already terminates auth upstream;
+// GitHub's routes must not pretend to work there.
+func TestLoginRoutesAreAbsentOutsideGitHubMode(t *testing.T) {
+	s, _ := newServer(t, auth.ModeHeader)
+	for _, path := range []string{"/hub/auth/login", "/hub/auth/callback"} {
+		if w := do(s, httptest.NewRequest(http.MethodGet, path, nil)); w.Code != http.StatusNotFound {
+			t.Errorf("%s status = %d, want 404 in header mode", path, w.Code)
+		}
+	}
+}
+
+func TestHeaderModeIdentifiesFromTheHeader(t *testing.T) {
+	s, _ := newServer(t, auth.ModeHeader)
+	r := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	r.Header.Set("X-Forwarded-User", "1234")
+
+	var body me
+	json.Unmarshal(do(s, r).Body.Bytes(), &body)
+	if !body.Authenticated || body.User.ID != "1234" {
+		t.Errorf("body = %+v, want the header's user", body)
+	}
+}
+
+func TestLogoutClearsTheSession(t *testing.T) {
+	s, _ := newServer(t, auth.ModeGitHub)
+	w := do(s, httptest.NewRequest(http.MethodPost, "/hub/auth/logout", nil))
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", w.Code)
+	}
+	for _, c := range w.Result().Cookies() {
+		if strings.Contains(c.Name, "kubestronaut_session") && c.MaxAge >= 0 {
+			t.Errorf("session cookie MaxAge = %d, want negative", c.MaxAge)
+		}
+	}
+}

--- a/hub/internal/api/api_test.go
+++ b/hub/internal/api/api_test.go
@@ -114,7 +114,7 @@ func TestHistoryReturnsTheStoredRecordUnchanged(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d", w.Code)
 	}
-	var doc store.Document
+	var doc store.History
 	if err := json.Unmarshal(w.Body.Bytes(), &doc); err != nil {
 		t.Fatal(err)
 	}
@@ -123,6 +123,81 @@ func TestHistoryReturnsTheStoredRecordUnchanged(t *testing.T) {
 	}
 	if !strings.Contains(string(doc.Attempts[0]), `"aNewField":true`) {
 		t.Errorf("record lost a field in transit: %s", doc.Attempts[0])
+	}
+}
+
+// The dashboard shape, not the interchange one.
+//
+// Progress.tsx reads `summary.weakDomains` without checking and lists
+// attempts newest first. Serving store.Document here — versioned,
+// oldest first, no summary — renders a blank dashboard rather than a
+// visibly wrong one, which is the failure mode worth a test.
+func TestHistoryIsTheDashboardShapeNotTheExportShape(t *testing.T) {
+	s, st := newServer(t, auth.ModeGitHub)
+	for _, rec := range []string{
+		`{"id":"older","certification":"CKAD","mode":"exam","counted":true,"passed":true,
+		  "gradedAt":"2026-08-01T10:00:00Z","percent":75,
+		  "domains":[{"domain":"Observability","earned":2,"total":10}]}`,
+		`{"id":"newer","certification":"KCNA","mode":"exam","counted":true,"passed":true,
+		  "gradedAt":"2026-08-04T10:00:00Z","percent":90,
+		  "domains":[{"domain":"Fundamentals","earned":9,"total":10}]}`,
+	} {
+		if _, err := st.Add("583231", json.RawMessage(rec), nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/api/history", nil)
+	r.AddCookie(login(t, s, "583231", "octocat"))
+	w := do(s, r)
+
+	var body struct {
+		Version  *int              `json:"version"`
+		Attempts []json.RawMessage `json:"attempts"`
+		Summary  struct {
+			Attempts    int `json:"attempts"`
+			PassedCount int `json:"passedCount"`
+			TrackCount  int `json:"trackCount"`
+			WeakDomains []struct {
+				Domain string `json:"domain"`
+			} `json:"weakDomains"`
+		} `json:"summary"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Version != nil {
+		t.Error("the dashboard response carries an interchange version field")
+	}
+	if len(body.Attempts) != 2 || !strings.Contains(string(body.Attempts[0]), `"newer"`) {
+		t.Errorf("attempts are not newest first: %s", w.Body.String())
+	}
+	if body.Summary.Attempts != 2 || body.Summary.PassedCount != 2 || body.Summary.TrackCount != 5 {
+		t.Errorf("summary = %+v", body.Summary)
+	}
+	if len(body.Summary.WeakDomains) != 2 || body.Summary.WeakDomains[0].Domain != "Observability" {
+		t.Errorf("weak domains = %+v, want Observability first", body.Summary.WeakDomains)
+	}
+}
+
+// Export stays the interchange document: versioned, oldest first, and
+// importable by a local `./sim`. That is the whole reason hosted export
+// exists while hosted import is refused.
+func TestExportIsStillTheInterchangeDocument(t *testing.T) {
+	s, st := newServer(t, auth.ModeGitHub)
+	if _, err := st.Add("583231", json.RawMessage(`{"id":"a1","gradedAt":"2026-08-03T10:00:00Z"}`), nil); err != nil {
+		t.Fatal(err)
+	}
+	r := httptest.NewRequest(http.MethodGet, "/api/history/export", nil)
+	r.AddCookie(login(t, s, "583231", "octocat"))
+	w := do(s, r)
+
+	var doc store.Document
+	if err := json.Unmarshal(w.Body.Bytes(), &doc); err != nil {
+		t.Fatal(err)
+	}
+	if doc.Version == 0 {
+		t.Error("export lost its version, so a local import cannot check it")
 	}
 }
 

--- a/hub/internal/api/history.go
+++ b/hub/internal/api/history.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"net/http"
+)
+
+// The history routes the facilitator owns locally and the hub owns here.
+//
+// All of them, including the ones it refuses. A route left to the
+// catch-all would reach the Pod's own facilitator and answer from a
+// /state volume that dies with the Pod — so "clear my history" would
+// clear a copy, report success, and leave every attempt in place.
+
+func (s *Server) handleHistoryDelete(w http.ResponseWriter, r *http.Request) {
+	sess, ok := s.requireUser(w, r)
+	if !ok {
+		return
+	}
+	if err := s.Store.Clear(sess.UserID); err != nil {
+		s.logf("hub: clear history for %s: %v", sess.UserID, err)
+		writeError(w, http.StatusInternalServerError, "could not clear your history")
+		return
+	}
+	s.logf("hub: %s cleared their history", sess.UserID)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleHistoryExport serves the same document GET /api/history returns,
+// as a download. Same shape by construction: it is the same call.
+func (s *Server) handleHistoryExport(w http.ResponseWriter, r *http.Request) {
+	sess, ok := s.requireUser(w, r)
+	if !ok {
+		return
+	}
+	doc, err := s.Store.Document(sess.UserID)
+	if err != nil {
+		s.logf("hub: export for %s: %v", sess.UserID, err)
+		writeError(w, http.StatusInternalServerError, "could not read your history")
+		return
+	}
+	w.Header().Set("Content-Disposition", `attachment; filename="kubestronaut-history.json"`)
+	writeJSON(w, http.StatusOK, doc)
+}
+
+// handleHistoryImport refuses, and says why.
+//
+// Import exists locally because local history is genuinely fragile — it
+// lives in a volume that `./sim down -v` erases, so exporting before a
+// wipe and importing after is the supported way to keep a record.
+// Hosted history has the opposite property: it is the durable copy, kept
+// outside every Pod the hub destroys. There is nothing to restore it
+// from, and accepting an arbitrary attempt document would only make a
+// record that survives on purpose accept entries that were never graded.
+func (s *Server) handleHistoryImport(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireUser(w, r); !ok {
+		return
+	}
+	writeError(w, http.StatusNotImplemented,
+		"hosted history is kept for you and cannot be imported into — every attempt here was graded here")
+}
+
+// handleHistorySummary is the CLI's route, and the hub does not
+// reimplement its aggregation. Answering it wrongly would be worse than
+// not answering: the numbers would look right.
+func (s *Server) handleHistorySummary(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireUser(w, r); !ok {
+		return
+	}
+	writeError(w, http.StatusNotImplemented,
+		"summary is not available in hosted mode — GET /api/history returns every attempt")
+}

--- a/hub/internal/api/ingest.go
+++ b/hub/internal/api/ingest.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"kubestronaut-sim/hub/internal/auth"
+)
+
+// maxIngestBody bounds one posted attempt.
+//
+// The record is a few hundred bytes; the results document is the large
+// half — 22 questions, each with its checks and their actual/expected
+// artifacts. 4 MiB is far above anything the graders produce and far
+// below anything that threatens the hub.
+const maxIngestBody = 4 << 20
+
+// handleIngestHistory is how a graded attempt outlives the Pod that
+// produced it.
+//
+// The session Pod posts here, server to server, as the facilitator
+// records the attempt locally. It cannot present the candidate's cookie
+// — it has never seen one, and the whole design keeps the facilitator
+// ignorant of identity — so it carries a ticket the hub minted for that
+// user when it created the Pod. The ticket names the user; the request
+// body does not, and must not: a Pod that could name its own user could
+// write into anyone's history.
+func (s *Server) handleIngestHistory(w http.ResponseWriter, r *http.Request) {
+	tok, ok := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
+	if !ok || tok == "" {
+		writeError(w, http.StatusUnauthorized, "this endpoint needs a session ticket")
+		return
+	}
+	sess, err := s.Ingest.Decode(tok)
+	if err != nil {
+		// Logged apart from a forgery, though answered the same: an
+		// expired ticket means a Pod outlived the window it was minted
+		// for and its candidate has just lost an attempt, which is worth
+		// being able to find. Decode reveals nothing about an expired
+		// ticket's user, so there is no id to name here.
+		if errors.Is(err, auth.ErrExpired) {
+			s.logf("hub: an ingest ticket has expired; that attempt was not recorded")
+		}
+		writeError(w, http.StatusUnauthorized, "that ticket is not valid")
+		return
+	}
+
+	var body struct {
+		Record  json.RawMessage `json:"record"`
+		Results json.RawMessage `json:"results"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxIngestBody)).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "body must be JSON with a \"record\"")
+		return
+	}
+	if len(body.Record) == 0 {
+		writeError(w, http.StatusBadRequest, "body has no \"record\"")
+		return
+	}
+
+	// Add is idempotent on the attempt id, so a retried delivery — which
+	// is the normal way this arrives when the hub was briefly redeployed
+	// — records nothing twice and reports which it was.
+	added, err := s.Store.Add(sess.UserID, body.Record, body.Results)
+	if err != nil {
+		s.logf("hub: ingest for %s: %v", sess.UserID, err)
+		writeError(w, http.StatusInternalServerError, "could not record that attempt")
+		return
+	}
+	if added {
+		s.logf("hub: recorded an attempt for %s", sess.UserID)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"recorded": added})
+}

--- a/hub/internal/api/ingest_test.go
+++ b/hub/internal/api/ingest_test.go
@@ -1,0 +1,188 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"kubestronaut-sim/hub/internal/auth"
+)
+
+// cookieKey is the same secret newServer signs cookies with. The ingest
+// signer is derived from it, which is the property several of these
+// tests are about.
+const cookieKey = "kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk"
+
+func withIngest(t *testing.T, s *Server) *auth.Signer {
+	t.Helper()
+	signer, err := auth.NewSigner(auth.Derive([]byte(cookieKey), auth.PurposeIngest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Ingest = signer
+	return signer
+}
+
+func ticket(t *testing.T, signer *auth.Signer, user string, expires time.Time) string {
+	t.Helper()
+	tok, err := signer.Encode(auth.Session{UserID: user, Expires: expires.Unix()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tok
+}
+
+func ingest(s *Server, tok, body string) *httptest.ResponseRecorder {
+	r := httptest.NewRequest(http.MethodPost, "/hub/ingest/history", strings.NewReader(body))
+	if tok != "" {
+		r.Header.Set("Authorization", "Bearer "+tok)
+	}
+	return do(s, r)
+}
+
+const oneAttempt = `{"record":{"id":"att-1","gradedAt":"2026-08-01T10:00:00Z","percent":72},` +
+	`"results":{"bank":"ckad-mock-01","questions":[{"id":"q01"}]}}`
+
+func TestIngestStoresTheAttemptAgainstTheTicketsUser(t *testing.T) {
+	s, st := newServer(t, auth.ModeGitHub)
+	signer := withIngest(t, s)
+
+	w := ingest(s, ticket(t, signer, "583231", time.Now().Add(time.Hour)), oneAttempt)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", w.Code, w.Body)
+	}
+
+	doc, err := st.Document("583231")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doc.Attempts) != 1 {
+		t.Fatalf("stored %d attempts, want 1", len(doc.Attempts))
+	}
+	// The hub does not model the facilitator's record — it has no struct
+	// for it — so a field this build has never heard of has to survive
+	// the round trip. `percent` stands in for all of them.
+	var stored map[string]any
+	if err := json.Unmarshal(doc.Attempts[0], &stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored["percent"] != float64(72) {
+		t.Errorf("attempt lost fields: %s", doc.Attempts[0])
+	}
+	res, err := st.Results("583231", "att-1")
+	if err != nil {
+		t.Fatalf("results were not stored: %v", err)
+	}
+	if !strings.Contains(string(res), "q01") {
+		t.Errorf("results = %s", res)
+	}
+}
+
+// The one that must never regress. A session Pod holds a ticket for one
+// user; if the body could name a different one, any candidate could
+// write into anyone's history — and in a hosted tier the history is the
+// product.
+func TestIngestIgnoresAUserNamedInTheBody(t *testing.T) {
+	s, st := newServer(t, auth.ModeGitHub)
+	signer := withIngest(t, s)
+
+	body := `{"user":"999","uid":"999","record":{"id":"att-1","gradedAt":"2026-08-01T10:00:00Z"}}`
+	if w := ingest(s, ticket(t, signer, "583231", time.Now().Add(time.Hour)), body); w.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", w.Code, w.Body)
+	}
+
+	doc, err := st.Document("999")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doc.Attempts) != 0 {
+		t.Fatal("a body field chose the user; a Pod can write into anyone's history")
+	}
+	doc, _ = st.Document("583231")
+	if len(doc.Attempts) != 1 {
+		t.Fatalf("the ticket's user got %d attempts, want 1", len(doc.Attempts))
+	}
+}
+
+// A ticket lifted out of a Pod spec must not be a login, and a stolen
+// cookie must not be able to post attempts. Both directions, because
+// domain separation that only works one way is not separation.
+func TestATicketIsNotACookieAndACookieIsNotATicket(t *testing.T) {
+	s, _ := newServer(t, auth.ModeGitHub)
+	signer := withIngest(t, s)
+
+	tok := ticket(t, signer, "583231", time.Now().Add(time.Hour))
+	r := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	r.AddCookie(&http.Cookie{Name: "hub_session", Value: tok})
+	w := do(s, r)
+	var body me
+	json.Unmarshal(w.Body.Bytes(), &body)
+	if body.Authenticated {
+		t.Error("an ingest ticket logged in as its user")
+	}
+
+	cookie := login(t, s, "583231", "octocat")
+	if w := ingest(s, cookie.Value, oneAttempt); w.Code != http.StatusUnauthorized {
+		t.Errorf("a session cookie posted an attempt: status = %d", w.Code)
+	}
+}
+
+func TestIngestRefusesWhatItCannotTrust(t *testing.T) {
+	s, _ := newServer(t, auth.ModeGitHub)
+	signer := withIngest(t, s)
+	good := ticket(t, signer, "583231", time.Now().Add(time.Hour))
+
+	for name, tc := range map[string]struct {
+		tok, body string
+		want      int
+	}{
+		"no ticket":      {"", oneAttempt, http.StatusUnauthorized},
+		"forged ticket":  {"nonsense.nonsense", oneAttempt, http.StatusUnauthorized},
+		"expired ticket": {ticket(t, signer, "583231", time.Now().Add(-time.Minute)), oneAttempt, http.StatusUnauthorized},
+		"not json":       {good, "nope", http.StatusBadRequest},
+		"no record":      {good, `{"results":{}}`, http.StatusBadRequest},
+	} {
+		if w := ingest(s, tc.tok, tc.body); w.Code != tc.want {
+			t.Errorf("%s: status = %d, want %d (%s)", name, w.Code, tc.want, w.Body)
+		}
+	}
+}
+
+// Idempotent, because the facilitator retries: a hub restarting between
+// the write and the response gets the same attempt twice.
+func TestIngestIsIdempotentOnTheAttemptID(t *testing.T) {
+	s, st := newServer(t, auth.ModeGitHub)
+	signer := withIngest(t, s)
+	tok := ticket(t, signer, "583231", time.Now().Add(time.Hour))
+
+	for i, want := range []bool{true, false} {
+		w := ingest(s, tok, oneAttempt)
+		if w.Code != http.StatusOK {
+			t.Fatalf("delivery %d: status = %d", i, w.Code)
+		}
+		var body struct {
+			Recorded bool `json:"recorded"`
+		}
+		json.Unmarshal(w.Body.Bytes(), &body)
+		if body.Recorded != want {
+			t.Errorf("delivery %d: recorded = %v, want %v", i, body.Recorded, want)
+		}
+	}
+	doc, _ := st.Document("583231")
+	if len(doc.Attempts) != 1 {
+		t.Fatalf("a retried delivery stored %d attempts", len(doc.Attempts))
+	}
+}
+
+// No signer, no route. A hub with nothing minting tickets must not
+// answer here at all rather than answer 401 — an unregistered route is
+// the difference between "no" and "not here".
+func TestIngestIsNotRegisteredWithoutASigner(t *testing.T) {
+	s, _ := newServer(t, auth.ModeGitHub)
+	if w := ingest(s, "anything", oneAttempt); w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}

--- a/hub/internal/api/proxy.go
+++ b/hub/internal/api/proxy.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+
+	"kubestronaut-sim/hub/internal/session"
+)
+
+// newProxy builds the reverse proxy that carries everything the hub does
+// not answer itself: the SPA, every /api/* route the facilitator owns,
+// and the desktop's WebSocket.
+//
+// httputil.ReverseProxy handles the upgrade correctly — on a 101 it
+// hijacks and splices the two connections — which is why this is a
+// ReverseProxy and not a hand-written pipe. FlushInterval matters
+// separately: the facilitator streams, and buffering a stream until it
+// ends is indistinguishable from a hang.
+func (s *Server) newProxy() *httputil.ReverseProxy {
+	return &httputil.ReverseProxy{
+		Rewrite: func(r *httputil.ProxyRequest) {
+			// The target is per-request because it is per-user: each
+			// candidate's traffic goes to their own Pod, resolved from
+			// their cookie by the handler below.
+			target := r.In.Context().Value(targetKey{}).(*url.URL)
+			r.Out.URL.Scheme = target.Scheme
+			r.Out.URL.Host = target.Host
+			r.Out.Host = target.Host
+			// Deliberately NOT SetXForwarded: the facilitator has no
+			// notion of a forwarded identity, and sending X-Forwarded-*
+			// into a process that trusts its inputs is how a header the
+			// hub uses for auth becomes one a candidate can set.
+		},
+		// -1 flushes immediately. A WebSocket is bidirectional and
+		// message-paced; any buffering at all makes the desktop feel
+		// broken.
+		FlushInterval: -1,
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			s.logf("hub: proxy %s: %v", r.URL.Path, err)
+			writeError(w, http.StatusBadGateway, "your exam environment is not reachable right now")
+		},
+		Transport: &http.Transport{
+			// No idle timeout on the desktop stream, but a bound on how
+			// long a Pod may take to answer at all.
+			ResponseHeaderTimeout: 60 * time.Second,
+			MaxIdleConnsPerHost:   8,
+		},
+	}
+}
+
+// targetKey carries the resolved upstream from the handler to Rewrite.
+type targetKey struct{}
+
+// handleProxy is the catch-all: anything the hub's own mux did not
+// claim belongs to the candidate's session.
+func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
+	sess, ok := s.requireUser(w, r)
+	if !ok {
+		return
+	}
+	live, err := s.Sessions.Get(sess.UserID)
+	if errors.Is(err, session.ErrNoSession) {
+		// 404, not 502: there is nothing wrong, the candidate simply has
+		// no session yet. The SPA's own shell is served by the hub, so
+		// this is only reached for API calls made before starting.
+		writeError(w, http.StatusNotFound, "you have no session running — start one first")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "could not find your session")
+		return
+	}
+	if live.Addr() == "" {
+		// 503 with Retry-After, because the answer really is "ask again":
+		// the Pod is booting and the SPA polls.
+		w.Header().Set("Retry-After", "5")
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error": "your exam environment is still starting",
+			"state": live.State,
+		})
+		return
+	}
+
+	s.Sessions.Touch(sess.UserID)
+	target := &url.URL{Scheme: "http", Host: live.Addr()}
+	s.proxy.ServeHTTP(w, r.WithContext(withTarget(r, target)))
+}

--- a/hub/internal/api/session.go
+++ b/hub/internal/api/session.go
@@ -1,0 +1,205 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+
+	"kubestronaut-sim/hub/internal/session"
+)
+
+// maxBody bounds a control request body. These are a few dozen bytes of
+// JSON; anything larger is not a client this hub has.
+const maxBody = 1 << 20
+
+func withTarget(r *http.Request, target *url.URL) context.Context {
+	return context.WithValue(r.Context(), targetKey{}, target)
+}
+
+// handleSessionStart is admission, and then the facilitator's own start.
+//
+// The two are separate events separated by minutes: admission grants a
+// seat and begins a Pod boot, and only once that Pod answers can the
+// attempt itself begin. The SPA already polls this endpoint, so the
+// intermediate answers are 202 (yours is starting) and 409 (nobody's
+// is), and the final one is whatever the facilitator says.
+func (s *Server) handleSessionStart(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireUser(w, r)
+	if !ok {
+		return
+	}
+	// Read it before doing anything else: on the ready path this exact
+	// body has to reach the facilitator, and a proxied request whose
+	// body was already consumed starts an attempt with no options set.
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxBody))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "could not read the request body")
+		return
+	}
+
+	var wanted struct {
+		Kind string `json:"kind"`
+	}
+	// A body is optional here, exactly as it is for the facilitator.
+	_ = json.Unmarshal(body, &wanted)
+	kind := s.DefaultKind
+	if wanted.Kind != "" {
+		k, err := session.ParseKind(wanted.Kind)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		kind = k
+	}
+
+	live, err := s.Sessions.Start(r.Context(), user.UserID, kind)
+	var queued *session.Queued
+	switch {
+	case errors.As(err, &queued):
+		writeJSON(w, http.StatusConflict, map[string]any{
+			"error":    queued.Error(),
+			"queued":   true,
+			"position": queued.Position,
+			"seats":    queued.Seats,
+			"kind":     string(queued.Kind),
+		})
+		return
+	case errors.Is(err, session.ErrNoSuchKind):
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	case err != nil:
+		s.logf("hub: start for %s: %v", user.UserID, err)
+		writeError(w, http.StatusInternalServerError, "could not start a session")
+		return
+	}
+
+	if live.State == session.Failed {
+		writeJSON(w, http.StatusBadGateway, map[string]any{
+			"error": "your exam environment failed to start",
+			"state": live.State,
+			"detail": live.Error,
+		})
+		return
+	}
+	if live.Addr() == "" {
+		w.Header().Set("Retry-After", "5")
+		writeJSON(w, http.StatusAccepted, map[string]any{
+			"starting": true,
+			"state":    live.State,
+			"kind":     string(live.Kind),
+		})
+		return
+	}
+
+	s.Sessions.Touch(user.UserID)
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.ContentLength = int64(len(body))
+	s.proxy.ServeHTTP(w, r.WithContext(withTarget(r, &url.URL{Scheme: "http", Host: live.Addr()})))
+}
+
+// handleSessionEnd gives up the seat and the Pod.
+//
+// Deliberately not POST /api/session/end: that is the facilitator's, and
+// it ends the *attempt* — grading it, writing its history — while the
+// environment stays up so the candidate can read their score. Ending the
+// seat is a different act and gets a different path, or the two would be
+// impossible to tell apart and a candidate would lose their results by
+// clicking the wrong one.
+func (s *Server) handleSessionEnd(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireUser(w, r)
+	if !ok {
+		return
+	}
+	err := s.Sessions.End(r.Context(), user.UserID)
+	if err != nil && !errors.Is(err, session.ErrNoSession) {
+		s.logf("hub: end for %s: %v", user.UserID, err)
+		writeError(w, http.StatusInternalServerError, "could not end your session")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleReset(w http.ResponseWriter, r *http.Request) {
+	s.recycle(w, r, "")
+}
+
+func (s *Server) handleSwitch(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Bank string `json:"bank"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxBody)).Decode(&body); err != nil || body.Bank == "" {
+		writeError(w, http.StatusBadRequest, "body must be JSON with a non-empty \"bank\"")
+		return
+	}
+	s.recycle(w, r, body.Bank)
+}
+
+// recycle answers reset and switch in the conductor's 202-plus-job
+// shape, which is what lets ControlProgress render hosted and local
+// alike with no branch.
+func (s *Server) recycle(w http.ResponseWriter, r *http.Request, bank string) {
+	user, ok := s.requireUser(w, r)
+	if !ok {
+		return
+	}
+	job, err := s.Sessions.Recycle(user.UserID, bank)
+	switch {
+	case errors.Is(err, session.ErrNoSession):
+		writeError(w, http.StatusNotFound, "you have no session to reset")
+		return
+	case errors.Is(err, session.ErrBusy):
+		writeError(w, http.StatusConflict, "another control operation is already running")
+		return
+	case err != nil:
+		s.logf("hub: recycle for %s: %v", user.UserID, err)
+		writeError(w, http.StatusInternalServerError, "could not start that operation")
+		return
+	}
+	writeJSON(w, http.StatusAccepted, map[string]any{"job": job})
+}
+
+// handleControlStatus and handleControlLog answer for the hub's own
+// jobs, never the conductor's.
+//
+// In a session Pod the conductor produces no jobs of its own: reset and
+// switch are the hub's, and reseed answers synchronously. The one
+// exception is seeding a pooled bank, which the facilitator triggers
+// server-to-server and whose progress would therefore be invisible here.
+// No bank in the product is pooled on the hands-on side, so nothing is
+// currently affected; it is recorded in docs/follow-ups.md rather than
+// guessed at.
+func (s *Server) handleControlStatus(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireUser(w, r)
+	if !ok {
+		return
+	}
+	snap, err := s.Sessions.Status(user.UserID)
+	if errors.Is(err, session.ErrNoSession) {
+		// Not 404: the SPA polls this to decide whether a control
+		// operation is in flight, and "you have no session" is a true
+		// and useful answer to that question.
+		writeJSON(w, http.StatusOK, session.Snapshot{})
+		return
+	}
+	writeJSON(w, http.StatusOK, snap)
+}
+
+func (s *Server) handleControlLog(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireUser(w, r)
+	if !ok {
+		return
+	}
+	id, lines, err := s.Sessions.Log(user.UserID)
+	if errors.Is(err, session.ErrNoSession) {
+		writeJSON(w, http.StatusOK, map[string]any{"jobId": "", "lines": []string{}})
+		return
+	}
+	if lines == nil {
+		lines = []string{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"jobId": id, "lines": lines})
+}

--- a/hub/internal/api/session.go
+++ b/hub/internal/api/session.go
@@ -79,8 +79,8 @@ func (s *Server) handleSessionStart(w http.ResponseWriter, r *http.Request) {
 
 	if live.State == session.Failed {
 		writeJSON(w, http.StatusBadGateway, map[string]any{
-			"error": "your exam environment failed to start",
-			"state": live.State,
+			"error":  "your exam environment failed to start",
+			"state":  live.State,
 			"detail": live.Error,
 		})
 		return

--- a/hub/internal/api/session_test.go
+++ b/hub/internal/api/session_test.go
@@ -1,0 +1,389 @@
+package api
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"kubestronaut-sim/hub/internal/auth"
+	"kubestronaut-sim/hub/internal/session"
+)
+
+const podTemplate = `{"kind":"Pod","metadata":{},"spec":{"containers":[{"name":"facilitator","env":[{"name":"BANK","value":"x"}]}]}}`
+
+// hosted builds a hub with seats in front of a stand-in facilitator.
+func hosted(t *testing.T, seats int, upstream http.Handler) (*Server, *session.Manager) {
+	t.Helper()
+	s, _ := newServer(t, auth.ModeGitHub)
+
+	host := "127.0.0.1"
+	if upstream != nil {
+		srv := httptest.NewServer(upstream)
+		t.Cleanup(srv.Close)
+		u, err := url.Parse(srv.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		host = u.Hostname()
+		s.Sessions = session.New(&session.Static{Host: host}, session.Config{
+			Flavours: map[session.Kind]session.Flavour{
+				session.Practical: {Seats: seats, Template: session.Template(podTemplate), Bank: "ckad-mock-01"},
+			},
+			Port: atoi(u.Port()),
+			Logf: func(string, ...any) {},
+		})
+	} else {
+		s.Sessions = session.New(&session.Static{Host: host}, session.Config{
+			Flavours: map[session.Kind]session.Flavour{
+				session.Practical: {Seats: seats, Template: session.Template(podTemplate)},
+			},
+			Logf: func(string, ...any) {},
+		})
+	}
+	s.DefaultKind = session.Practical
+	return s, s.Sessions
+}
+
+func atoi(s string) int {
+	n := 0
+	for _, r := range s {
+		n = n*10 + int(r-'0')
+	}
+	return n
+}
+
+// ready polls start the way the SPA does, until the seat's Pod answers,
+// sending the same body every time — which is what the browser does, and
+// what makes the "did my options survive admission" assertion meaningful
+// on the request that finally lands.
+func ready(t *testing.T, s *Server, c *http.Cookie, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		r := httptest.NewRequest(http.MethodPost, "/api/session/start", strings.NewReader(body))
+		r.AddCookie(c)
+		w := do(s, r)
+		if w.Code != http.StatusAccepted {
+			return w
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("the session never became ready")
+	return nil
+}
+
+// Admission and the attempt are separate events minutes apart. The first
+// answer is "yours is starting"; only once the Pod answers does the
+// facilitator's own start run.
+func TestStartAdmitsThenForwardsToTheFacilitator(t *testing.T) {
+	var forwarded string
+	s, _ := hosted(t, 1, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		forwarded = r.Method + " " + r.URL.Path + " " + string(body)
+		w.Write([]byte(`{"state":"running"}`))
+	}))
+	c := login(t, s, "583231", "octocat")
+
+	first := httptest.NewRequest(http.MethodPost, "/api/session/start", strings.NewReader(`{"mode":"exam"}`))
+	first.AddCookie(c)
+	if w := do(s, first); w.Code != http.StatusAccepted {
+		t.Fatalf("first start = %d, want 202 while the pod boots", w.Code)
+	}
+
+	w := ready(t, s, c, `{"mode":"exam"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("start = %d, body %s", w.Code, w.Body)
+	}
+	if !strings.Contains(w.Body.String(), "running") {
+		t.Errorf("the facilitator's answer did not reach the browser: %s", w.Body)
+	}
+	// The body has to survive admission: a start whose options were
+	// eaten by the hub begins the wrong kind of attempt.
+	if !strings.Contains(forwarded, `{"mode":"exam"}`) {
+		t.Errorf("forwarded %q, want the original body", forwarded)
+	}
+}
+
+func TestStartQueuesWhenEverySeatIsTaken(t *testing.T) {
+	s, _ := hosted(t, 1, nil)
+	first := login(t, s, "583231", "octocat")
+	r := httptest.NewRequest(http.MethodPost, "/api/session/start", nil)
+	r.AddCookie(first)
+	do(s, r)
+
+	second := httptest.NewRequest(http.MethodPost, "/api/session/start", nil)
+	second.AddCookie(login(t, s, "999999", "someone"))
+	w := do(s, second)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", w.Code)
+	}
+	var body struct {
+		Queued   bool `json:"queued"`
+		Position int  `json:"position"`
+		Seats    int  `json:"seats"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &body)
+	if !body.Queued || body.Position != 1 || body.Seats != 1 {
+		t.Errorf("body = %+v, want a usable queue position", body)
+	}
+}
+
+// The catch-all. Everything the hub does not answer is the candidate's
+// own Pod, and it must not be reachable without a session.
+func TestProxyRequiresBothALoginAndASession(t *testing.T) {
+	s, _ := hosted(t, 1, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("upstream"))
+	}))
+
+	if w := do(s, httptest.NewRequest(http.MethodGet, "/api/exam", nil)); w.Code != http.StatusUnauthorized {
+		t.Errorf("logged out = %d, want 401", w.Code)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/api/exam", nil)
+	r.AddCookie(login(t, s, "583231", "octocat"))
+	if w := do(s, r); w.Code != http.StatusNotFound {
+		t.Errorf("no session = %d, want 404", w.Code)
+	}
+}
+
+func TestProxyReachesTheSessionPodOnceItIsReady(t *testing.T) {
+	s, _ := hosted(t, 1, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("questions for " + r.URL.Path))
+	}))
+	c := login(t, s, "583231", "octocat")
+	ready(t, s, c, "{}")
+
+	r := httptest.NewRequest(http.MethodGet, "/api/exam", nil)
+	r.AddCookie(c)
+	w := do(s, r)
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "/api/exam") {
+		t.Errorf("status %d body %q", w.Code, w.Body)
+	}
+}
+
+// The desktop is a WebSocket, and it is the single most fragile thing to
+// put behind a proxy: a 101 that is not hijacked and spliced leaves the
+// candidate looking at a blank screen with no error anywhere.
+//
+// httptest.NewRecorder cannot hijack, so this runs the hub over a real
+// listener and speaks the handshake by hand.
+func TestTheDesktopWebSocketUpgradeSurvivesTheProxy(t *testing.T) {
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/desktop/websockify" {
+			return // the admission poll, which shares this upstream
+		}
+		if !strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+			t.Errorf("upgrade header did not reach the pod: %v", r.Header)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		conn, buf, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		defer conn.Close()
+		buf.WriteString("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n")
+		buf.Flush()
+		// Echo one frame's worth of bytes, which is what proves the
+		// connection is spliced rather than merely opened.
+		line, _ := buf.ReadString('\n')
+		buf.WriteString("echo:" + line)
+		buf.Flush()
+	})
+	s, _ := hosted(t, 1, upstream)
+	c := login(t, s, "583231", "octocat")
+	ready(t, s, c, "{}")
+
+	hub := httptest.NewServer(s.Handler())
+	defer hub.Close()
+
+	conn, err := net.Dial("tcp", strings.TrimPrefix(hub.URL, "http://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(5 * time.Second))
+	req, _ := http.NewRequest(http.MethodGet, hub.URL+"/desktop/websockify", nil)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+	req.AddCookie(c)
+	if err := req.Write(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("status = %d, want 101", resp.StatusCode)
+	}
+	if _, err := conn.Write([]byte("hello\n")); err != nil {
+		t.Fatal(err)
+	}
+	got, err := br.ReadString('\n')
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "echo:hello\n" {
+		t.Errorf("read %q, want the upstream's echo — the connection is not spliced", got)
+	}
+}
+
+// A reset in hosted mode replaces the Pod, and says so in the
+// conductor's shape so ControlProgress renders it unchanged.
+func TestResetReturnsAJobInTheConductorsShape(t *testing.T) {
+	s, _ := hosted(t, 1, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	c := login(t, s, "583231", "octocat")
+	ready(t, s, c, "{}")
+
+	r := httptest.NewRequest(http.MethodPost, "/api/control/reset", nil)
+	r.AddCookie(c)
+	w := do(s, r)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body %s", w.Code, w.Body)
+	}
+	var body struct {
+		Job session.Job `json:"job"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Job.ID == "" || body.Job.Op != "reset" || len(body.Job.Phases) == 0 {
+		t.Errorf("job = %+v", body.Job)
+	}
+	if body.Job.Phases[0].State != session.PhasePending && body.Job.Phases[0].State != session.PhaseRunning {
+		t.Errorf("first phase = %q", body.Job.Phases[0].State)
+	}
+}
+
+// The SPA polls control status on load to decide whether an operation is
+// in flight. "You have no session" is a true answer to that, and a 404
+// would read to the UI as a broken control plane.
+func TestControlStatusAnswersBeforeAnySessionExists(t *testing.T) {
+	s, _ := hosted(t, 1, nil)
+	r := httptest.NewRequest(http.MethodGet, "/api/control/status", nil)
+	r.AddCookie(login(t, s, "583231", "octocat"))
+	w := do(s, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var snap session.Snapshot
+	json.Unmarshal(w.Body.Bytes(), &snap)
+	if snap.Busy {
+		t.Error("busy with no session")
+	}
+}
+
+// Every /api/history route is the hub's. One left to the catch-all would
+// answer from the Pod's own /state volume — the copy that is about to be
+// destroyed — so "clear my history" would clear nothing that lasts.
+func TestHistoryRoutesNeverReachThePod(t *testing.T) {
+	var reached []string
+	s, _ := hosted(t, 1, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = append(reached, r.URL.Path)
+	}))
+	c := login(t, s, "583231", "octocat")
+	ready(t, s, c, "{}")
+
+	for _, tc := range []struct {
+		method, path string
+		want         int
+	}{
+		{http.MethodGet, "/api/history", http.StatusOK},
+		{http.MethodDelete, "/api/history", http.StatusNoContent},
+		{http.MethodGet, "/api/history/export", http.StatusOK},
+		{http.MethodPost, "/api/history/import", http.StatusNotImplemented},
+		{http.MethodGet, "/api/history/summary", http.StatusNotImplemented},
+	} {
+		r := httptest.NewRequest(tc.method, tc.path, nil)
+		r.AddCookie(c)
+		if w := do(s, r); w.Code != tc.want {
+			t.Errorf("%s %s = %d, want %d", tc.method, tc.path, w.Code, tc.want)
+		}
+	}
+	for _, p := range reached {
+		if strings.HasPrefix(p, "/api/history") {
+			t.Errorf("%s was proxied to the pod", p)
+		}
+	}
+}
+
+func TestClearingHistoryReallyRemovesIt(t *testing.T) {
+	s, st := newServer(t, auth.ModeGitHub)
+	if _, err := st.Add("583231", json.RawMessage(`{"id":"a1","gradedAt":"2026-08-03T10:00:00Z"}`), nil); err != nil {
+		t.Fatal(err)
+	}
+	c := login(t, s, "583231", "octocat")
+
+	del := httptest.NewRequest(http.MethodDelete, "/api/history", nil)
+	del.AddCookie(c)
+	if w := do(s, del); w.Code != http.StatusNoContent {
+		t.Fatalf("delete = %d", w.Code)
+	}
+	get := httptest.NewRequest(http.MethodGet, "/api/history", nil)
+	get.AddCookie(c)
+	if body := do(s, get).Body.String(); strings.Contains(body, "a1") {
+		t.Errorf("the attempt survived: %s", body)
+	}
+}
+
+// The header chip and the queue dialog render from /api/me, so it has to
+// carry seat state — and the counts are visible logged out, because
+// someone deciding whether to sign in is entitled to know whether there
+// is anywhere to sit.
+func TestMeCarriesSeatAndSessionState(t *testing.T) {
+	s, _ := hosted(t, 2, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	var out me
+	json.Unmarshal(do(s, httptest.NewRequest(http.MethodGet, "/api/me", nil)).Body.Bytes(), &out)
+	if out.Seats["practical"].Total != 2 || out.Seats["practical"].Used != 0 {
+		t.Errorf("logged-out seats = %+v", out.Seats)
+	}
+
+	c := login(t, s, "583231", "octocat")
+	ready(t, s, c, "{}")
+	r := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	r.AddCookie(c)
+	out = me{}
+	json.Unmarshal(do(s, r).Body.Bytes(), &out)
+	if out.Session == nil || out.Session.State != session.Ready {
+		t.Fatalf("session = %+v", out.Session)
+	}
+	if out.Seats["practical"].Used != 1 {
+		t.Errorf("used seats = %d, want 1", out.Seats["practical"].Used)
+	}
+	// The Pod's address is the candidate's own, but publishing an
+	// in-cluster address in a JSON response tells every user something
+	// about the infrastructure they have no use for.
+	if strings.Contains(do(s, r).Body.String(), "127.0.0.1:") {
+		t.Error("/api/me leaked the pod address")
+	}
+}
+
+func TestEndingASessionFreesTheSeat(t *testing.T) {
+	s, m := hosted(t, 1, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	c := login(t, s, "583231", "octocat")
+	ready(t, s, c, "{}")
+
+	end := httptest.NewRequest(http.MethodPost, "/hub/session/end", nil)
+	end.AddCookie(c)
+	if w := do(s, end); w.Code != http.StatusNoContent {
+		t.Fatalf("end = %d", w.Code)
+	}
+	if used := m.Seats()[session.Practical][0]; used != 0 {
+		t.Errorf("%d seats still used after ending", used)
+	}
+	if _, err := m.Get("583231"); err == nil {
+		t.Error("the session outlived the request to end it")
+	}
+}

--- a/hub/internal/auth/authenticator.go
+++ b/hub/internal/auth/authenticator.go
@@ -1,0 +1,183 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Mode is how the hub decides who someone is.
+//
+// Three of them, because a self-hoster's situation is not this
+// deployment's. github is what the public tier runs; header is for
+// anyone already behind an authenticating proxy; none is for a private
+// network where the whole question is uninteresting. The plan's promise
+// that a third party can self-host with their own limits is only true if
+// they are not forced to register a GitHub OAuth app first.
+type Mode string
+
+const (
+	ModeGitHub Mode = "github"
+	ModeHeader Mode = "header"
+	ModeNone   Mode = "none"
+)
+
+// ParseMode validates an AUTH_MODE value.
+func ParseMode(s string) (Mode, error) {
+	switch Mode(s) {
+	case ModeGitHub, ModeHeader, ModeNone:
+		return Mode(s), nil
+	}
+	return "", fmt.Errorf("auth: unknown AUTH_MODE %q (want github, header or none)", s)
+}
+
+// DefaultCookieName is the session cookie. __Host- is not cosmetic: it
+// makes the browser refuse the cookie unless it is Secure, path=/ and
+// has no Domain, which forecloses a subdomain setting a cookie for the
+// hub. Dropped automatically when Secure is off, since the prefix would
+// make the cookie unsettable over plain HTTP in local development.
+const DefaultCookieName = "__Host-kubestronaut_session"
+
+// ErrNoSession means nobody is logged in — not that anything failed.
+var ErrNoSession = errors.New("auth: no session")
+
+// Authenticator resolves the current user and issues session cookies.
+type Authenticator struct {
+	Mode   Mode
+	Signer *Signer
+	GitHub *GitHub
+
+	// HeaderName is the trusted identity header for ModeHeader.
+	//
+	// SECURITY: in header mode the hub MUST NOT be reachable except
+	// through the proxy that sets it, because anyone who can reach the
+	// hub directly can set it too and become any user. The mode exists
+	// for a deployment that already terminates auth upstream; it is not
+	// a way to add auth.
+	HeaderName string
+
+	CookieName string
+	// Secure marks the cookie Secure and enables the __Host- prefix.
+	Secure bool
+	TTL    time.Duration
+
+	Now func() time.Time
+}
+
+func (a *Authenticator) now() time.Time {
+	if a.Now != nil {
+		return a.Now()
+	}
+	return time.Now()
+}
+
+func (a *Authenticator) cookieName() string {
+	if a.CookieName != "" {
+		return a.CookieName
+	}
+	if !a.Secure {
+		// __Host- requires Secure, so over plain HTTP the browser would
+		// silently drop every cookie we set and the user would loop
+		// through login forever.
+		return "kubestronaut_session"
+	}
+	return DefaultCookieName
+}
+
+func (a *Authenticator) ttl() time.Duration {
+	if a.TTL > 0 {
+		return a.TTL
+	}
+	return 12 * time.Hour
+}
+
+// Current returns the session for r, or ErrNoSession.
+func (a *Authenticator) Current(r *http.Request) (Session, error) {
+	switch a.Mode {
+	case ModeNone:
+		// One fixed identity. It still goes through the store's name
+		// rules, so it is a plain name rather than something clever.
+		return Session{UserID: "local", Login: "local"}, nil
+
+	case ModeHeader:
+		name := a.HeaderName
+		if name == "" {
+			name = "X-Forwarded-User"
+		}
+		v := r.Header.Get(name)
+		if v == "" {
+			return Session{}, ErrNoSession
+		}
+		return Session{UserID: v, Login: v}, nil
+
+	case ModeGitHub:
+		c, err := r.Cookie(a.cookieName())
+		if err != nil || c.Value == "" {
+			return Session{}, ErrNoSession
+		}
+		if a.Signer == nil {
+			return Session{}, errors.New("auth: github mode without a signer")
+		}
+		sess, err := a.Signer.Decode(c.Value)
+		if err != nil {
+			// Both a forgery and an expiry mean the same thing to the
+			// caller: nobody is logged in. They differ in the log, not
+			// in the response.
+			return Session{}, ErrNoSession
+		}
+		return sess, nil
+	}
+	return Session{}, fmt.Errorf("auth: unconfigured mode %q", a.Mode)
+}
+
+// Issue sets the session cookie for sess, stamping its expiry.
+func (a *Authenticator) Issue(w http.ResponseWriter, sess Session) error {
+	if a.Signer == nil {
+		return errors.New("auth: cannot issue a cookie without a signer")
+	}
+	expires := a.now().Add(a.ttl())
+	sess.Expires = expires.Unix()
+	v, err := a.Signer.Encode(sess)
+	if err != nil {
+		return err
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     a.cookieName(),
+		Value:    v,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   a.Secure,
+		// Lax, not Strict: the OAuth callback is a cross-site
+		// navigation back from github.com, and Strict would not send
+		// the cookie on it — so login would appear to succeed and then
+		// land the user logged out.
+		SameSite: http.SameSiteLaxMode,
+		Expires:  expires,
+	})
+	return nil
+}
+
+// Clear removes the session cookie.
+func (a *Authenticator) Clear(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     a.cookieName(),
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   a.Secure,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	})
+}
+
+// NewState returns a CSRF state token for the OAuth round trip.
+func NewState() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("auth: generate state: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/hub/internal/auth/authenticator_test.go
+++ b/hub/internal/auth/authenticator_test.go
@@ -1,0 +1,241 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func githubStub(t *testing.T, token, user string, tokenStatus, userStatus int) *GitHub {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(tokenStatus)
+			w.Write([]byte(token))
+		case "/user":
+			if got := r.Header.Get("Authorization"); got != "Bearer tok-123" {
+				t.Errorf("user request Authorization = %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(userStatus)
+			w.Write([]byte(user))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	g := NewGitHub("cid", "csecret", "https://hub.example/hub/auth/callback")
+	g.TokenURL = srv.URL + "/token"
+	g.UserURL = srv.URL + "/user"
+	g.AuthorizeURL = srv.URL + "/authorize"
+	return g
+}
+
+func TestAuthCodeURLCarriesClientRedirectAndState(t *testing.T) {
+	g := NewGitHub("cid", "csecret", "https://hub.example/hub/auth/callback")
+	u, err := url.Parse(g.AuthCodeURL("state-abc"))
+	if err != nil {
+		t.Fatalf("AuthCodeURL produced an unparseable URL: %v", err)
+	}
+	q := u.Query()
+	for k, want := range map[string]string{
+		"client_id":    "cid",
+		"redirect_uri": "https://hub.example/hub/auth/callback",
+		"state":        "state-abc",
+	} {
+		if got := q.Get(k); got != want {
+			t.Errorf("%s = %q, want %q", k, got, want)
+		}
+	}
+	// No scope: the hub wants an identity, not access to anything.
+	if q.Has("scope") {
+		t.Errorf("AuthCodeURL requested scope %q; identity needs none", q.Get("scope"))
+	}
+}
+
+func TestExchangeAndUser(t *testing.T) {
+	g := githubStub(t, `{"access_token":"tok-123"}`, `{"login":"octocat","id":583231}`, 200, 200)
+
+	tok, err := g.Exchange(context.Background(), "code-1")
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if tok != "tok-123" {
+		t.Errorf("token = %q, want tok-123", tok)
+	}
+	sess, err := g.User(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("User: %v", err)
+	}
+	// The numeric id, not the login: a login can be renamed and reused.
+	if sess.UserID != "583231" || sess.Login != "octocat" {
+		t.Errorf("session = %+v, want UserID 583231 / Login octocat", sess)
+	}
+}
+
+// GitHub reports a bad code with HTTP 200 and an error field, so a
+// status-only check would treat a refusal as a successful login.
+func TestExchangeFailures(t *testing.T) {
+	cases := map[string]struct {
+		body   string
+		status int
+	}{
+		"error field with 200": {`{"error":"bad_verification_code","error_description":"expired"}`, 200},
+		"no token with 200":    {`{}`, 200},
+		"non-200":              {`{"access_token":"tok-123"}`, 500},
+		"unparseable":          {`not json`, 200},
+	}
+	for name, c := range cases {
+		g := githubStub(t, c.body, `{}`, c.status, 200)
+		if _, err := g.Exchange(context.Background(), "code-1"); err == nil {
+			t.Errorf("%s: Exchange succeeded, want an error", name)
+		}
+	}
+}
+
+func TestUserWithoutAnIDIsRefused(t *testing.T) {
+	g := githubStub(t, `{"access_token":"tok-123"}`, `{"login":"octocat"}`, 200, 200)
+	if _, err := g.User(context.Background(), "tok-123"); err == nil {
+		t.Error("User accepted a response with no id")
+	}
+}
+
+func TestModeNoneIsAlwaysTheSameLocalUser(t *testing.T) {
+	a := &Authenticator{Mode: ModeNone}
+	sess, err := a.Current(httptest.NewRequest(http.MethodGet, "/api/me", nil))
+	if err != nil {
+		t.Fatalf("Current: %v", err)
+	}
+	if sess.UserID != "local" {
+		t.Errorf("UserID = %q, want local", sess.UserID)
+	}
+}
+
+func TestModeHeaderReadsTheTrustedHeader(t *testing.T) {
+	a := &Authenticator{Mode: ModeHeader, HeaderName: "X-Forwarded-User"}
+
+	r := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	if _, err := a.Current(r); !errors.Is(err, ErrNoSession) {
+		t.Errorf("no header = %v, want ErrNoSession", err)
+	}
+	r.Header.Set("X-Forwarded-User", "1234")
+	sess, err := a.Current(r)
+	if err != nil {
+		t.Fatalf("Current: %v", err)
+	}
+	if sess.UserID != "1234" {
+		t.Errorf("UserID = %q, want 1234", sess.UserID)
+	}
+}
+
+func TestGitHubModeCookieRoundTrip(t *testing.T) {
+	a := &Authenticator{Mode: ModeGitHub, Signer: testSigner(t), Secure: true, TTL: time.Hour}
+
+	w := httptest.NewRecorder()
+	if err := a.Issue(w, Session{UserID: "583231", Login: "octocat"}); err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	cookies := w.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("cookies = %d, want 1", len(cookies))
+	}
+	c := cookies[0]
+	if !c.HttpOnly || !c.Secure {
+		t.Errorf("cookie = %+v, want HttpOnly and Secure", c)
+	}
+	// Lax, not Strict: the OAuth callback is a cross-site navigation
+	// back from github.com and Strict would not send the cookie on it.
+	if c.SameSite != http.SameSiteLaxMode {
+		t.Errorf("SameSite = %v, want Lax", c.SameSite)
+	}
+	if !strings.HasPrefix(c.Name, "__Host-") {
+		t.Errorf("secure cookie name = %q, want a __Host- prefix", c.Name)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	r.AddCookie(c)
+	sess, err := a.Current(r)
+	if err != nil {
+		t.Fatalf("Current: %v", err)
+	}
+	if sess.UserID != "583231" || sess.Login != "octocat" {
+		t.Errorf("session = %+v", sess)
+	}
+	if sess.Expires == 0 {
+		t.Error("Issue did not stamp an expiry")
+	}
+}
+
+// __Host- requires Secure, so over plain HTTP the browser would drop
+// every cookie the hub sets and login would loop forever.
+func TestInsecureDeploymentDropsTheHostPrefix(t *testing.T) {
+	a := &Authenticator{Mode: ModeGitHub, Signer: testSigner(t), Secure: false}
+	w := httptest.NewRecorder()
+	if err := a.Issue(w, Session{UserID: "1"}); err != nil {
+		t.Fatal(err)
+	}
+	if name := w.Result().Cookies()[0].Name; strings.HasPrefix(name, "__Host-") {
+		t.Errorf("insecure cookie name = %q, must not use __Host-", name)
+	}
+}
+
+func TestForgedAndExpiredCookiesBothReadAsNoSession(t *testing.T) {
+	a := &Authenticator{Mode: ModeGitHub, Signer: testSigner(t), Secure: true}
+	for name, value := range map[string]string{
+		"garbage": "not-a-cookie",
+		"empty":   "",
+	} {
+		r := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+		r.AddCookie(&http.Cookie{Name: a.cookieName(), Value: value})
+		if _, err := a.Current(r); !errors.Is(err, ErrNoSession) {
+			t.Errorf("%s cookie = %v, want ErrNoSession", name, err)
+		}
+	}
+}
+
+func TestClearExpiresTheCookie(t *testing.T) {
+	a := &Authenticator{Mode: ModeGitHub, Signer: testSigner(t), Secure: true}
+	w := httptest.NewRecorder()
+	a.Clear(w)
+	c := w.Result().Cookies()[0]
+	if c.MaxAge >= 0 {
+		t.Errorf("MaxAge = %d, want negative so the browser drops it", c.MaxAge)
+	}
+}
+
+func TestParseMode(t *testing.T) {
+	for _, ok := range []string{"github", "header", "none"} {
+		if _, err := ParseMode(ok); err != nil {
+			t.Errorf("ParseMode(%q) = %v", ok, err)
+		}
+	}
+	for _, bad := range []string{"", "oidc", "GitHub"} {
+		if _, err := ParseMode(bad); err == nil {
+			t.Errorf("ParseMode(%q) succeeded, want an error", bad)
+		}
+	}
+}
+
+func TestNewStateIsRandomAndURLSafe(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		s, err := NewState()
+		if err != nil {
+			t.Fatalf("NewState: %v", err)
+		}
+		if seen[s] {
+			t.Fatal("NewState repeated a value")
+		}
+		seen[s] = true
+		if s != url.QueryEscape(s) {
+			t.Errorf("state %q is not URL-safe", s)
+		}
+	}
+}

--- a/hub/internal/auth/cookie.go
+++ b/hub/internal/auth/cookie.go
@@ -1,0 +1,127 @@
+// Package auth establishes who a request is from.
+//
+// The load-bearing idea of the whole hosted tier lives here: identity
+// sits ABOVE the simulator. The facilitator keeps its "no authentication
+// anywhere" property literally — it is simply never reachable except
+// through the hub. That is what lets `./sim up` stay byte-identical with
+// no accounts, no cookies and no new configuration.
+//
+// Stdlib only, like every other module in this repo. The signed cookie
+// is a few lines of crypto/hmac rather than a JWT dependency, and the
+// OAuth exchange is two HTTP POSTs rather than an OAuth library.
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// minKeyLen is the shortest signing key this package will accept.
+//
+// Refused rather than stretched: a hub deployed with COOKIE_KEY=secret
+// would look identical to a correct one from the outside, and the
+// failure mode is silent forgery of anyone's identity. Better to not
+// start.
+const minKeyLen = 32
+
+// Session is who a request is from.
+type Session struct {
+	// UserID is the provider's stable numeric identity, NOT the login.
+	// A GitHub user can rename themselves and someone else can then take
+	// the freed name; the numeric ID cannot change hands. History is
+	// keyed on this, so getting it wrong would hand one person another
+	// person's attempts.
+	UserID string `json:"uid"`
+	// Login is for display only. Never use it to key anything.
+	Login   string `json:"login"`
+	Expires int64  `json:"exp"`
+}
+
+var (
+	// ErrInvalidCookie covers every "this is not a cookie we issued"
+	// case — malformed, truncated, or signed with a different key. They
+	// are deliberately indistinguishable to the caller: telling an
+	// attacker which half of their forgery was wrong is free help.
+	ErrInvalidCookie = errors.New("auth: invalid session cookie")
+	// ErrExpired is separate because it is the one failure that is not
+	// suspicious: it is what every returning user hits eventually, and
+	// the caller answers it by redirecting to log in again.
+	ErrExpired = errors.New("auth: session expired")
+)
+
+// Signer encodes and verifies session cookies.
+type Signer struct {
+	key []byte
+	// Now is overridable so expiry can be tested without sleeping.
+	Now func() time.Time
+}
+
+// NewSigner returns a Signer over key, which must be at least 32 bytes.
+func NewSigner(key []byte) (*Signer, error) {
+	if len(key) < minKeyLen {
+		return nil, fmt.Errorf("auth: signing key is %d bytes, need at least %d", len(key), minKeyLen)
+	}
+	return &Signer{key: key, Now: time.Now}, nil
+}
+
+func (s *Signer) now() time.Time {
+	if s.Now != nil {
+		return s.Now()
+	}
+	return time.Now()
+}
+
+// Encode returns the cookie value for sess: the payload and its MAC,
+// each base64url without padding, separated by a dot.
+func (s *Signer) Encode(sess Session) (string, error) {
+	payload, err := json.Marshal(sess)
+	if err != nil {
+		return "", fmt.Errorf("auth: encode session: %w", err)
+	}
+	body := base64.RawURLEncoding.EncodeToString(payload)
+	return body + "." + base64.RawURLEncoding.EncodeToString(s.mac(body)), nil
+}
+
+// Decode verifies a cookie value and returns the session it carries.
+func (s *Signer) Decode(v string) (Session, error) {
+	body, sig, ok := strings.Cut(v, ".")
+	if !ok {
+		return Session{}, ErrInvalidCookie
+	}
+	got, err := base64.RawURLEncoding.DecodeString(sig)
+	if err != nil {
+		return Session{}, ErrInvalidCookie
+	}
+	// Constant time, and BEFORE the payload is parsed: a forged cookie
+	// must not reach the JSON decoder at all.
+	if !hmac.Equal(got, s.mac(body)) {
+		return Session{}, ErrInvalidCookie
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(body)
+	if err != nil {
+		return Session{}, ErrInvalidCookie
+	}
+	var sess Session
+	if err := json.Unmarshal(payload, &sess); err != nil {
+		return Session{}, ErrInvalidCookie
+	}
+	if sess.UserID == "" {
+		return Session{}, ErrInvalidCookie
+	}
+	if sess.Expires != 0 && s.now().After(time.Unix(sess.Expires, 0)) {
+		return Session{}, ErrExpired
+	}
+	return sess, nil
+}
+
+func (s *Signer) mac(body string) []byte {
+	m := hmac.New(sha256.New, s.key)
+	m.Write([]byte(body))
+	return m.Sum(nil)
+}

--- a/hub/internal/auth/cookie_test.go
+++ b/hub/internal/auth/cookie_test.go
@@ -1,0 +1,140 @@
+package auth
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testSigner(t *testing.T) *Signer {
+	t.Helper()
+	s, err := NewSigner([]byte(strings.Repeat("k", 32)))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	return s
+}
+
+func TestRoundTrip(t *testing.T) {
+	s := testSigner(t)
+	want := Session{UserID: "12345", Login: "octocat", Expires: time.Now().Add(time.Hour).Unix()}
+
+	v, err := s.Encode(want)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	got, err := s.Decode(v)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got != want {
+		t.Errorf("round trip = %+v, want %+v", got, want)
+	}
+}
+
+// A short key is refused at construction rather than stretched, because
+// a hub running on COOKIE_KEY=secret looks identical from the outside to
+// one that is safe.
+func TestShortKeysAreRefused(t *testing.T) {
+	for _, k := range []string{"", "secret", strings.Repeat("k", 31)} {
+		if _, err := NewSigner([]byte(k)); err == nil {
+			t.Errorf("NewSigner(%d bytes) succeeded, want an error", len(k))
+		}
+	}
+	if _, err := NewSigner([]byte(strings.Repeat("k", 32))); err != nil {
+		t.Errorf("NewSigner(32 bytes) = %v, want success", err)
+	}
+}
+
+func TestTamperingIsRejected(t *testing.T) {
+	s := testSigner(t)
+	good, err := s.Encode(Session{UserID: "12345", Login: "octocat"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, sig, _ := strings.Cut(good, ".")
+
+	// The payload of a different user, with the original signature: the
+	// forgery this whole mechanism exists to stop.
+	other, _ := s.Encode(Session{UserID: "99999", Login: "attacker"})
+	otherBody, _, _ := strings.Cut(other, ".")
+
+	for name, v := range map[string]string{
+		"swapped payload":  otherBody + "." + sig,
+		"flipped sig byte": body + "." + flip(sig),
+		"no separator":     body + sig,
+		"empty":            "",
+		"only a payload":   body,
+		"garbage":          "not-a-cookie",
+		"empty payload":    "." + sig,
+	} {
+		if _, err := s.Decode(v); !errors.Is(err, ErrInvalidCookie) {
+			t.Errorf("Decode(%s) error = %v, want ErrInvalidCookie", name, err)
+		}
+	}
+}
+
+// A cookie signed with a different key must be indistinguishable from
+// any other forgery — including to a caller trying to be helpful.
+func TestAnotherKeysCookieIsInvalid(t *testing.T) {
+	mine := testSigner(t)
+	theirs, err := NewSigner([]byte(strings.Repeat("z", 32)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, err := theirs.Encode(Session{UserID: "12345", Login: "octocat"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mine.Decode(v); !errors.Is(err, ErrInvalidCookie) {
+		t.Errorf("Decode of a foreign cookie = %v, want ErrInvalidCookie", err)
+	}
+}
+
+func TestExpiryIsEnforcedAndDistinguishable(t *testing.T) {
+	s := testSigner(t)
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	s.Now = func() time.Time { return now }
+
+	v, err := s.Encode(Session{UserID: "12345", Expires: now.Add(-time.Second).Unix()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Expired is its own error: it is the one failure that is normal, and
+	// the caller answers it by asking the user to log in again rather
+	// than by treating them as an attacker.
+	if _, err := s.Decode(v); !errors.Is(err, ErrExpired) {
+		t.Errorf("Decode of an expired cookie = %v, want ErrExpired", err)
+	}
+
+	fresh, _ := s.Encode(Session{UserID: "12345", Expires: now.Add(time.Hour).Unix()})
+	if _, err := s.Decode(fresh); err != nil {
+		t.Errorf("Decode of a live cookie = %v, want success", err)
+	}
+}
+
+// A session with no user is not a session, however well signed.
+func TestSessionWithoutAUserIsInvalid(t *testing.T) {
+	s := testSigner(t)
+	v, err := s.Encode(Session{Login: "octocat", Expires: time.Now().Add(time.Hour).Unix()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Decode(v); !errors.Is(err, ErrInvalidCookie) {
+		t.Errorf("Decode of a session with no UserID = %v, want ErrInvalidCookie", err)
+	}
+}
+
+func flip(s string) string {
+	if s == "" {
+		return "x"
+	}
+	b := []byte(s)
+	if b[0] == 'A' {
+		b[0] = 'B'
+	} else {
+		b[0] = 'A'
+	}
+	return string(b)
+}

--- a/hub/internal/auth/derive.go
+++ b/hub/internal/auth/derive.go
@@ -1,0 +1,30 @@
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+)
+
+// Derive returns a signing key for one purpose, from the single secret
+// the hub is configured with.
+//
+// It exists so a credential minted for one job cannot be spent on
+// another. The session Pod's history ticket carries a user id and is
+// signed by the same package that signs login cookies; signed with the
+// same key it would BE a login cookie, and a ticket read out of a Pod
+// spec would become that candidate's session. A ticket signed with a
+// derived key does not verify against the cookie key, in either
+// direction, and no second secret has to be configured and rotated to
+// get that.
+//
+// HMAC rather than a hash of the concatenation: this is a key, and
+// keyed-prefix constructions are what HMAC exists to make safe.
+func Derive(key []byte, purpose string) []byte {
+	m := hmac.New(sha256.New, key)
+	m.Write([]byte(purpose))
+	return m.Sum(nil)
+}
+
+// PurposeIngest signs the tickets session Pods post their graded
+// attempts back with.
+const PurposeIngest = "history-ingest"

--- a/hub/internal/auth/derive_test.go
+++ b/hub/internal/auth/derive_test.go
@@ -1,0 +1,32 @@
+package auth
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestDeriveSeparatesPurposes(t *testing.T) {
+	key := []byte(strings.Repeat("k", 32))
+
+	ingest := Derive(key, PurposeIngest)
+	other := Derive(key, "something-else")
+
+	if bytes.Equal(ingest, key) {
+		t.Error("the derived key is the configured key; a ticket would be a cookie")
+	}
+	if bytes.Equal(ingest, other) {
+		t.Error("two purposes derived the same key")
+	}
+	// Deterministic, or every hub restart would invalidate every ticket
+	// still held by a running Pod.
+	if !bytes.Equal(ingest, Derive(key, PurposeIngest)) {
+		t.Error("Derive is not deterministic")
+	}
+	// Long enough for NewSigner, which refuses anything shorter — a
+	// derived key that could not be used would be found at the first
+	// login, in production.
+	if _, err := NewSigner(ingest); err != nil {
+		t.Errorf("the derived key cannot sign: %v", err)
+	}
+}

--- a/hub/internal/auth/github.go
+++ b/hub/internal/auth/github.go
@@ -1,0 +1,159 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// GitHub is the OAuth web flow, which is two HTTP POSTs and a GET.
+//
+// Hand-rolled rather than pulled from golang.org/x/oauth2 because that
+// is the entire dependency: this module has no go.sum and the rule that
+// it stays that way is the same rule conductor/internal/docker follows
+// when it speaks the Docker Engine API directly for three calls.
+//
+// No scopes are requested. The hub needs a stable identity and a name to
+// show, both of which /user returns unauthenticated-by-scope. Asking for
+// less is the difference between "log in" and "grant this app access to
+// your repositories".
+type GitHub struct {
+	ClientID     string
+	ClientSecret string
+	RedirectURL  string
+
+	HTTP *http.Client
+
+	// Endpoints, overridable so the flow can be exercised end to end
+	// against an httptest server rather than against github.com.
+	AuthorizeURL string
+	TokenURL     string
+	UserURL      string
+}
+
+// NewGitHub returns a GitHub with the real endpoints filled in.
+func NewGitHub(clientID, clientSecret, redirectURL string) *GitHub {
+	return &GitHub{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  redirectURL,
+		HTTP:         &http.Client{Timeout: 10 * time.Second},
+		AuthorizeURL: "https://github.com/login/oauth/authorize",
+		TokenURL:     "https://github.com/login/oauth/access_token",
+		UserURL:      "https://api.github.com/user",
+	}
+}
+
+func (g *GitHub) client() *http.Client {
+	if g.HTTP != nil {
+		return g.HTTP
+	}
+	return &http.Client{Timeout: 10 * time.Second}
+}
+
+// AuthCodeURL is where the browser is sent to log in. state is the CSRF
+// token the caller must check on the way back.
+func (g *GitHub) AuthCodeURL(state string) string {
+	q := url.Values{
+		"client_id":    {g.ClientID},
+		"redirect_uri": {g.RedirectURL},
+		"state":        {state},
+	}
+	sep := "?"
+	if strings.Contains(g.AuthorizeURL, "?") {
+		sep = "&"
+	}
+	return g.AuthorizeURL + sep + q.Encode()
+}
+
+// Exchange trades an authorization code for an access token.
+func (g *GitHub) Exchange(ctx context.Context, code string) (string, error) {
+	form := url.Values{
+		"client_id":     {g.ClientID},
+		"client_secret": {g.ClientSecret},
+		"code":          {code},
+		"redirect_uri":  {g.RedirectURL},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, g.TokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("auth: build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	// Without this GitHub answers in form encoding, which is a silent
+	// parse failure rather than a loud one.
+	req.Header.Set("Accept", "application/json")
+
+	body, err := g.do(req, "token exchange")
+	if err != nil {
+		return "", err
+	}
+	var out struct {
+		AccessToken      string `json:"access_token"`
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return "", fmt.Errorf("auth: unreadable token response: %w", err)
+	}
+	// GitHub reports a bad code with HTTP 200 and an error field, so the
+	// status alone is not enough to tell success from failure.
+	if out.Error != "" {
+		return "", fmt.Errorf("auth: token exchange refused: %s (%s)", out.Error, out.ErrorDescription)
+	}
+	if out.AccessToken == "" {
+		return "", fmt.Errorf("auth: token exchange returned no token")
+	}
+	return out.AccessToken, nil
+}
+
+// User resolves an access token to the identity the hub stores.
+func (g *GitHub) User(ctx context.Context, token string) (Session, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, g.UserURL, nil)
+	if err != nil {
+		return Session{}, fmt.Errorf("auth: build user request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	body, err := g.do(req, "user lookup")
+	if err != nil {
+		return Session{}, err
+	}
+	var out struct {
+		Login string `json:"login"`
+		// A number on the wire. Kept as a string everywhere else,
+		// because it is an identifier and never an amount of anything.
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return Session{}, fmt.Errorf("auth: unreadable user response: %w", err)
+	}
+	if out.ID == 0 {
+		return Session{}, fmt.Errorf("auth: user response carried no id")
+	}
+	return Session{UserID: strconv.FormatInt(out.ID, 10), Login: out.Login}, nil
+}
+
+func (g *GitHub) do(req *http.Request, what string) ([]byte, error) {
+	resp, err := g.client().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("auth: %s: %w", what, err)
+	}
+	defer resp.Body.Close()
+	// Bounded: this is a response from a third party, and an unbounded
+	// ReadAll on one is a memory bug waiting for a bad day.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("auth: %s: read response: %w", what, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("auth: %s: %s", what, resp.Status)
+	}
+	return body, nil
+}

--- a/hub/internal/kube/kube.go
+++ b/hub/internal/kube/kube.go
@@ -1,0 +1,300 @@
+// Package kube is a hand-rolled Kubernetes client for the four calls the
+// hub makes: create, get, delete and list Pods in one namespace.
+//
+// No client-go, for the same reason conductor/internal/docker hand-rolls
+// the Docker Engine API for exactly three calls: the dependency is two
+// orders of magnitude larger than the use, and every module in this repo
+// is stdlib-only with no go.sum. Four REST calls against a documented,
+// versioned API is less code than the vendoring would be.
+//
+// The Pod type here is deliberately partial. It carries the handful of
+// fields the hub reads and nothing else; the spec it sends is passed
+// through as bytes, so this package never has to model a PodSpec.
+package kube
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// The projected service account token, its CA, and the namespace, at the
+// paths the kubelet mounts them.
+const (
+	tokenPath     = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	caPath        = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	namespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+)
+
+var (
+	// ErrNotFound is a 404 from the API server.
+	ErrNotFound = errors.New("kube: not found")
+	// ErrConflict is a 409 — for a create, that the name is taken.
+	ErrConflict = errors.New("kube: already exists")
+	// ErrForbidden is a 403, which for this client always means the
+	// ServiceAccount's Role is missing a verb rather than anything the
+	// caller did wrong.
+	ErrForbidden = errors.New("kube: forbidden — check the hub's Role")
+)
+
+// Pod is the part of a Pod the hub reads back.
+type Pod struct {
+	Metadata Metadata  `json:"metadata"`
+	Status   PodStatus `json:"status"`
+}
+
+// Metadata carries only what the hub uses to decide a Pod's fate:
+// which session it belongs to (labels), how old it is, and whether it is
+// already on its way out.
+type Metadata struct {
+	Name              string            `json:"name"`
+	Namespace         string            `json:"namespace,omitempty"`
+	Labels            map[string]string `json:"labels,omitempty"`
+	CreationTimestamp time.Time         `json:"creationTimestamp,omitempty"`
+	// DeletionTimestamp is set the moment a delete is accepted, long
+	// before the Pod disappears — a 30s grace period on a session Pod is
+	// 30s during which Get still succeeds. Treating a terminating Pod as
+	// live is how a seat stays occupied by something already dying.
+	DeletionTimestamp *time.Time `json:"deletionTimestamp,omitempty"`
+}
+
+type PodStatus struct {
+	Phase             string            `json:"phase"`
+	PodIP             string            `json:"podIP"`
+	ContainerStatuses []ContainerStatus `json:"containerStatuses"`
+}
+
+type ContainerStatus struct {
+	Name  string `json:"name"`
+	Ready bool   `json:"ready"`
+}
+
+// Terminating reports whether this Pod has been asked to go away.
+func (p Pod) Terminating() bool { return p.Metadata.DeletionTimestamp != nil }
+
+// Ready reports whether the named container is passing its readiness
+// probe. The hub asks about one container — the facilitator — because
+// that is the only one it proxies to, and a session is usable the moment
+// that answers. k8s-env's startup probe gates the rest.
+func (p Pod) Ready(container string) bool {
+	for _, cs := range p.Status.ContainerStatuses {
+		if cs.Name == container {
+			return cs.Ready
+		}
+	}
+	return false
+}
+
+// Client talks to one namespace of one API server.
+type Client struct {
+	// BaseURL is the API server, e.g. https://10.43.0.1:443.
+	BaseURL   string
+	Namespace string
+	HTTP      *http.Client
+
+	// TokenFile is re-read on every request, not cached at startup.
+	//
+	// A projected service account token is short-lived by design — the
+	// kubelet rotates it well before expiry, and a client that read it
+	// once at boot works perfectly until the first rotation and then
+	// 401s forever. Re-reading is one page-cached read per API call, and
+	// the hub makes a handful per minute.
+	TokenFile string
+	// Token, when set, is used instead of TokenFile. For tests and for
+	// running the hub outside the cluster.
+	Token string
+
+	mu       sync.Mutex
+	lastRead time.Time
+	cached   string
+}
+
+// InCluster builds a Client from the ServiceAccount the kubelet
+// projected into this Pod.
+func InCluster() (*Client, error) {
+	host, port := os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")
+	if host == "" || port == "" {
+		return nil, errors.New("kube: not running in a cluster (no KUBERNETES_SERVICE_HOST)")
+	}
+	ns, err := os.ReadFile(namespacePath)
+	if err != nil {
+		return nil, fmt.Errorf("kube: read namespace: %w", err)
+	}
+	ca, err := os.ReadFile(caPath)
+	if err != nil {
+		return nil, fmt.Errorf("kube: read CA: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(ca) {
+		return nil, fmt.Errorf("kube: %s is not a usable CA bundle", caPath)
+	}
+	return &Client{
+		BaseURL:   "https://" + net.JoinHostPort(host, port),
+		Namespace: strings.TrimSpace(string(ns)),
+		TokenFile: tokenPath,
+		HTTP: &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12},
+			},
+		},
+	}, nil
+}
+
+func (c *Client) token() (string, error) {
+	if c.Token != "" {
+		return c.Token, nil
+	}
+	if c.TokenFile == "" {
+		return "", nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// A short cache so a burst of calls does not re-read the file each
+	// time, short enough that a rotation is picked up promptly.
+	if c.cached != "" && time.Since(c.lastRead) < 30*time.Second {
+		return c.cached, nil
+	}
+	b, err := os.ReadFile(c.TokenFile)
+	if err != nil {
+		return "", fmt.Errorf("kube: read token: %w", err)
+	}
+	c.cached, c.lastRead = strings.TrimSpace(string(b)), time.Now()
+	return c.cached, nil
+}
+
+func (c *Client) httpClient() *http.Client {
+	if c.HTTP != nil {
+		return c.HTTP
+	}
+	return http.DefaultClient
+}
+
+// CreatePod posts a Pod manifest as JSON. spec is passed through
+// untouched: this package models what it reads, never what it writes.
+func (c *Client) CreatePod(ctx context.Context, spec []byte) (Pod, error) {
+	var out Pod
+	err := c.do(ctx, http.MethodPost, c.podsURL(), spec, &out)
+	return out, err
+}
+
+// GetPod returns one Pod, or ErrNotFound.
+func (c *Client) GetPod(ctx context.Context, name string) (Pod, error) {
+	var out Pod
+	err := c.do(ctx, http.MethodGet, c.podsURL()+"/"+url.PathEscape(name), nil, &out)
+	return out, err
+}
+
+// DeletePod removes a Pod. A Pod that is already gone is not an error to
+// the caller that wanted it gone — ErrNotFound is returned so a caller
+// who cares can tell, and every caller here treats it as success.
+func (c *Client) DeletePod(ctx context.Context, name string) error {
+	return c.do(ctx, http.MethodDelete, c.podsURL()+"/"+url.PathEscape(name), nil, nil)
+}
+
+// ListPods returns the Pods matching a label selector.
+//
+// This is how the hub recovers its own state after a restart: sessions
+// live in the cluster, not in the hub's memory, so a redeployed hub
+// re-adopts running sessions instead of stranding them.
+func (c *Client) ListPods(ctx context.Context, selector string) ([]Pod, error) {
+	u := c.podsURL()
+	if selector != "" {
+		u += "?labelSelector=" + url.QueryEscape(selector)
+	}
+	var out struct {
+		Items []Pod `json:"items"`
+	}
+	if err := c.do(ctx, http.MethodGet, u, nil, &out); err != nil {
+		return nil, err
+	}
+	return out.Items, nil
+}
+
+func (c *Client) podsURL() string {
+	return fmt.Sprintf("%s/api/v1/namespaces/%s/pods",
+		strings.TrimSuffix(c.BaseURL, "/"), url.PathEscape(c.Namespace))
+}
+
+func (c *Client) do(ctx context.Context, method, u string, body []byte, out any) error {
+	var rdr io.Reader
+	if body != nil {
+		rdr = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u, rdr)
+	if err != nil {
+		return fmt.Errorf("kube: %s %s: %w", method, u, err)
+	}
+	tok, err := c.token()
+	if err != nil {
+		return err
+	}
+	if tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("kube: %s %s: %w", method, u, err)
+	}
+	defer resp.Body.Close()
+	// Bounded: an API server response is kilobytes, and an unbounded
+	// read here would let a misrouted request exhaust the hub's memory.
+	b, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return fmt.Errorf("kube: read %s %s: %w", method, u, err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return ErrNotFound
+	case http.StatusConflict:
+		return ErrConflict
+	case http.StatusForbidden, http.StatusUnauthorized:
+		return fmt.Errorf("%w: %s", ErrForbidden, apiMessage(b))
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("kube: %s %s: %s: %s", method, u, resp.Status, apiMessage(b))
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(b, out); err != nil {
+		return fmt.Errorf("kube: decode %s %s: %w", method, u, err)
+	}
+	return nil
+}
+
+// apiMessage pulls the human sentence out of a Status object. The API
+// server explains refusals precisely ("pods is forbidden: User ... cannot
+// create resource"), and losing that in favour of the status code turns a
+// one-line RBAC fix into an investigation.
+func apiMessage(b []byte) string {
+	var status struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(b, &status); err == nil && status.Message != "" {
+		return status.Message
+	}
+	s := strings.TrimSpace(string(b))
+	if len(s) > 300 {
+		s = s[:300] + "…"
+	}
+	return s
+}

--- a/hub/internal/kube/kube_test.go
+++ b/hub/internal/kube/kube_test.go
@@ -1,0 +1,159 @@
+package kube
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newClient(t *testing.T, h http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return &Client{BaseURL: srv.URL, Namespace: "kubestronaut-sim", Token: "tok", HTTP: srv.Client()}
+}
+
+func TestCreateGetDeleteList(t *testing.T) {
+	var seen []string
+	c := newClient(t, func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.Method+" "+r.URL.Path+"?"+r.URL.RawQuery)
+		if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+			t.Errorf("Authorization = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"metadata":{"name":"sim-1"},"status":{"phase":"Pending"}}`))
+		case r.Method == http.MethodDelete:
+			w.Write([]byte(`{"kind":"Status","status":"Success"}`))
+		case strings.HasSuffix(r.URL.Path, "/pods"):
+			w.Write([]byte(`{"items":[{"metadata":{"name":"sim-1"}},{"metadata":{"name":"sim-2"}}]}`))
+		default:
+			w.Write([]byte(`{"metadata":{"name":"sim-1"},"status":{"phase":"Running","podIP":"10.42.0.7","containerStatuses":[{"name":"facilitator","ready":true},{"name":"desktop","ready":false}]}}`))
+		}
+	})
+	ctx := context.Background()
+
+	if _, err := c.CreatePod(ctx, []byte(`{"kind":"Pod"}`)); err != nil {
+		t.Fatal(err)
+	}
+	pod, err := c.GetPod(ctx, "sim-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pod.Status.PodIP != "10.42.0.7" {
+		t.Errorf("podIP = %q", pod.Status.PodIP)
+	}
+	// Readiness is per-container: the hub proxies to the facilitator, and
+	// the desktop being unready is a normal moment during boot, not a
+	// reason to withhold the session.
+	if !pod.Ready("facilitator") {
+		t.Error("facilitator should be ready")
+	}
+	if pod.Ready("desktop") {
+		t.Error("desktop should not be ready")
+	}
+	if pod.Ready("nonexistent") {
+		t.Error("a container that is not in the status cannot be ready")
+	}
+	if err := c.DeletePod(ctx, "sim-1"); err != nil {
+		t.Fatal(err)
+	}
+	pods, err := c.ListPods(ctx, "kubestronaut-sim/user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pods) != 2 {
+		t.Fatalf("listed %d pods, want 2", len(pods))
+	}
+
+	want := []string{
+		"POST /api/v1/namespaces/kubestronaut-sim/pods?",
+		"GET /api/v1/namespaces/kubestronaut-sim/pods/sim-1?",
+		"DELETE /api/v1/namespaces/kubestronaut-sim/pods/sim-1?",
+		"GET /api/v1/namespaces/kubestronaut-sim/pods?labelSelector=kubestronaut-sim%2Fuser",
+	}
+	for i := range want {
+		if i >= len(seen) || seen[i] != want[i] {
+			t.Errorf("request %d = %q, want %q", i, seen[i], want[i])
+		}
+	}
+}
+
+// The three statuses the manager makes decisions from. A 409 that is not
+// distinguishable from a 500 turns "the name is still taken, wait" into
+// "something broke, give up".
+func TestStatusesMapToSentinels(t *testing.T) {
+	for _, tc := range []struct {
+		code int
+		want error
+	}{
+		{http.StatusNotFound, ErrNotFound},
+		{http.StatusConflict, ErrConflict},
+		{http.StatusForbidden, ErrForbidden},
+	} {
+		c := newClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(tc.code)
+			w.Write([]byte(`{"kind":"Status","message":"pods is forbidden: no permission"}`))
+		})
+		_, err := c.GetPod(context.Background(), "sim-1")
+		if !errors.Is(err, tc.want) {
+			t.Errorf("%d gave %v, want %v", tc.code, err, tc.want)
+		}
+	}
+}
+
+// A refusal that loses the API server's sentence turns a one-line RBAC
+// fix into an investigation.
+func TestForbiddenKeepsTheAPIServersExplanation(t *testing.T) {
+	c := newClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"kind":"Status","message":"pods is forbidden: User \"system:serviceaccount:kubestronaut-sim:hub\" cannot create resource \"pods\""}`))
+	})
+	_, err := c.CreatePod(context.Background(), []byte(`{}`))
+	if err == nil || !strings.Contains(err.Error(), "cannot create resource") {
+		t.Errorf("err = %v, want the API server's own message", err)
+	}
+}
+
+// A projected token is rotated by the kubelet. A client that reads it
+// once at startup works until the first rotation and then 401s forever,
+// which is the kind of failure that shows up hours after a deploy.
+func TestTokenIsRereadAfterRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token")
+	if err := os.WriteFile(path, []byte("first\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	c := newClient(t, func(w http.ResponseWriter, r *http.Request) {
+		got = append(got, r.Header.Get("Authorization"))
+		w.Write([]byte(`{}`))
+	})
+	c.Token, c.TokenFile = "", path
+
+	if _, err := c.GetPod(context.Background(), "a"); err != nil {
+		t.Fatal(err)
+	}
+	// Rotate, and defeat the short read cache the way the clock would.
+	if err := os.WriteFile(path, []byte("second\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	c.mu.Lock()
+	c.lastRead = time.Now().Add(-time.Hour)
+	c.mu.Unlock()
+
+	if _, err := c.GetPod(context.Background(), "a"); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0] != "Bearer first" || got[1] != "Bearer second" {
+		t.Errorf("authorization headers = %q, want first then second", got)
+	}
+}

--- a/hub/internal/session/chart_test.go
+++ b/hub/internal/session/chart_test.go
@@ -1,0 +1,111 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// The gate between the chart and this package.
+//
+// Everything else in pod_test.go exercises render() against templates
+// written for the test. This one runs it against the real thing: the
+// JSON `helm template` actually produces from
+// deploy/helm/kubestronaut-sim/files/*.yaml. Without it the two halves
+// are only checked separately — helm proves the manifest is valid YAML,
+// the tests prove render() handles a Pod, and nobody proves the hub can
+// stamp out the specific Pod this chart ships.
+//
+// The failure it exists to catch is quiet and late: a manifest that
+// stops declaring HISTORY_WEBHOOK_URL, or a chart change that renames a
+// container, produces a hub that starts, serves, admits a candidate, and
+// then returns 500 the moment they press start.
+//
+// Fed by SESSION_POD_JSON, a colon-separated list of rendered files, and
+// skipped when it is unset — the module must stay testable with nothing
+// but `go test`, and helm is not a Go dependency. CI renders the chart
+// and sets it; see the chart step in .github/workflows/ci.yml.
+func TestTheChartRendersSomethingThisPackageCanStampOut(t *testing.T) {
+	paths := os.Getenv("SESSION_POD_JSON")
+	if paths == "" {
+		t.Skip("SESSION_POD_JSON unset — render the chart and point this at the result")
+	}
+	for _, path := range strings.Split(paths, ":") {
+		t.Run(path, func(t *testing.T) {
+			b, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			out, err := Template(b).render(patch{
+				Name:         "sim-session-practical-583231",
+				Labels:       map[string]string{"kubestronaut-sim/user": "583231"},
+				Bank:         "a-bank-that-is-not-the-default",
+				WebhookURL:   "https://hub.example/hub/ingest/history",
+				WebhookToken: "ticket",
+			})
+			if err != nil {
+				t.Fatalf("the hub cannot render this chart's pod: %v", err)
+			}
+
+			var pod map[string]any
+			if err := json.Unmarshal(out, &pod); err != nil {
+				t.Fatal(err)
+			}
+			meta := pod["metadata"].(map[string]any)
+			if meta["name"] != "sim-session-practical-583231" {
+				t.Errorf("name = %v", meta["name"])
+			}
+			// The chart sets a namespace and the hub must not lose it: a
+			// create whose body names a different namespace from the URL
+			// is a 400 from the API server, and an empty one is worse —
+			// it defaults, silently, to whichever namespace the hub is in.
+			if meta["namespace"] == nil || meta["namespace"] == "" {
+				t.Error("the chart's namespace did not survive rendering")
+			}
+
+			// Every value the hub is responsible for filling in reached
+			// every container that declares it. A miss here is a session
+			// that boots and is wrong rather than one that fails.
+			spec := pod["spec"].(map[string]any)
+			want := map[string]string{
+				"BANK":                  "a-bank-that-is-not-the-default",
+				"HISTORY_WEBHOOK_URL":   "https://hub.example/hub/ingest/history",
+				"HISTORY_WEBHOOK_TOKEN": "ticket",
+			}
+			seen := map[string]int{}
+			for _, key := range []string{"initContainers", "containers"} {
+				list, _ := spec[key].([]any)
+				for _, c := range list {
+					container := c.(map[string]any)
+					env, _ := container["env"].([]any)
+					for _, e := range env {
+						entry := e.(map[string]any)
+						name, _ := entry["name"].(string)
+						v, ok := want[name]
+						if !ok {
+							continue
+						}
+						seen[name]++
+						if entry["value"] != v {
+							t.Errorf("%v: %s = %v, want %q", container["name"], name, entry["value"], v)
+						}
+					}
+				}
+			}
+			for name := range want {
+				if seen[name] == 0 {
+					t.Errorf("no container declares %s, so the hub had nowhere to put it", name)
+				}
+			}
+
+			// Nothing left pointing at a tag the release workflow does not
+			// publish. `:dev` is what the manifest carries so it can be
+			// applied by hand; a chart render that still says it means the
+			// image rewrite silently matched nothing.
+			if strings.Contains(string(out), ":dev\"") {
+				t.Error("a rendered image still points at :dev — images.tag did not reach it")
+			}
+		})
+	}
+}

--- a/hub/internal/session/job.go
+++ b/hub/internal/session/job.go
@@ -1,0 +1,202 @@
+package session
+
+import (
+	"strconv"
+	"sync"
+	"time"
+)
+
+// A hosted reset or switch is a Pod recycle, and it is reported in the
+// conductor's job shape on purpose.
+//
+// The UI's ControlProgress polls GET /api/control/status and renders
+// whatever phase list it finds. Emitting the same JSON here means reset
+// and switch keep working in hosted mode with no hosted branch in the
+// UI — the phases differ (there is no cluster to rebuild in place, the
+// Pod is simply replaced) but the protocol does not.
+//
+// This is a per-user job store, not the conductor's global one: two
+// candidates resetting at the same moment are two independent Pods, and
+// the conductor's "exactly one job at a time" rule is a property of one
+// session, not of the deployment.
+
+const maxLogLines = 200
+
+// PhaseState mirrors the conductor's vocabulary exactly; the UI switches
+// on these strings.
+type PhaseState string
+
+const (
+	PhasePending PhaseState = "pending"
+	PhaseRunning PhaseState = "running"
+	PhaseDone    PhaseState = "done"
+	PhaseFailed  PhaseState = "failed"
+)
+
+type Phase struct {
+	ID         string     `json:"id"`
+	Label      string     `json:"label"`
+	State      PhaseState `json:"state"`
+	StartedAt  string     `json:"startedAt,omitempty"`
+	FinishedAt string     `json:"finishedAt,omitempty"`
+	Detail     string     `json:"detail,omitempty"`
+}
+
+type Job struct {
+	ID         string  `json:"id"`
+	Op         string  `json:"op"`
+	Bank       string  `json:"bank,omitempty"`
+	StartedAt  string  `json:"startedAt"`
+	FinishedAt string  `json:"finishedAt,omitempty"`
+	Phase      string  `json:"phase"`
+	Error      string  `json:"error,omitempty"`
+	Phases     []Phase `json:"phases"`
+}
+
+// Snapshot is what GET /api/control/status returns.
+type Snapshot struct {
+	Busy bool `json:"busy"`
+	Job  *Job `json:"job,omitempty"`
+	Last *Job `json:"last,omitempty"`
+}
+
+// jobStore holds one user's in-flight job and their last finished one.
+type jobStore struct {
+	mu      sync.Mutex
+	current *Job
+	last    *Job
+	lines   []string
+	logJob  string
+	seq     int
+	now     func() time.Time
+}
+
+func (s *jobStore) clock() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
+}
+
+func stamp(t time.Time) string { return t.UTC().Format(time.RFC3339) }
+
+// begin starts a job. Returns false when one is already in flight, which
+// the HTTP layer maps to 409 exactly as the conductor does.
+func (s *jobStore) begin(op, bank string, phases []Phase) (Job, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.current != nil {
+		return Job{}, false
+	}
+	s.seq++
+	j := &Job{
+		ID:        "job-" + strconv.Itoa(s.seq),
+		Op:        op,
+		Bank:      bank,
+		StartedAt: stamp(s.clock()),
+		Phases:    append([]Phase(nil), phases...),
+	}
+	for i := range j.Phases {
+		j.Phases[i].State = PhasePending
+	}
+	s.current = j
+	s.lines, s.logJob = nil, j.ID
+	return *j.copy(), true
+}
+
+// enter marks a phase running and the previous one done.
+func (s *jobStore) enter(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.current == nil {
+		return
+	}
+	now := stamp(s.clock())
+	for i := range s.current.Phases {
+		p := &s.current.Phases[i]
+		switch {
+		case p.ID == id:
+			p.State, p.StartedAt = PhaseRunning, now
+			s.current.Phase = id
+		case p.State == PhaseRunning:
+			p.State, p.FinishedAt = PhaseDone, now
+		}
+	}
+}
+
+// detail replaces the one-line tail shown against the running phase.
+func (s *jobStore) detail(text string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.current == nil {
+		return
+	}
+	for i := range s.current.Phases {
+		if s.current.Phases[i].State == PhaseRunning {
+			s.current.Phases[i].Detail = text
+		}
+	}
+}
+
+func (s *jobStore) log(line string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(line) > 500 {
+		line = line[:500] + "…"
+	}
+	s.lines = append(s.lines, line)
+	if len(s.lines) > maxLogLines {
+		s.lines = s.lines[len(s.lines)-maxLogLines:]
+	}
+}
+
+// finish closes the job out. err nil means every phase succeeded.
+func (s *jobStore) finish(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.current == nil {
+		return
+	}
+	now := stamp(s.clock())
+	for i := range s.current.Phases {
+		p := &s.current.Phases[i]
+		if p.State != PhaseRunning {
+			continue
+		}
+		p.FinishedAt = now
+		if err != nil {
+			p.State = PhaseFailed
+		} else {
+			p.State = PhaseDone
+		}
+	}
+	if err != nil {
+		s.current.Error = err.Error()
+	}
+	s.current.FinishedAt = now
+	s.last, s.current = s.current, nil
+}
+
+func (s *jobStore) snapshot() Snapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return Snapshot{Busy: s.current != nil, Job: s.current.copy(), Last: s.last.copy()}
+}
+
+func (s *jobStore) logLines() (string, []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.logJob, append([]string(nil), s.lines...)
+}
+
+// copy is what keeps a snapshot from aliasing live state: the phases
+// slice is mutated in place by every enter() while the caller is still
+// encoding the JSON.
+func (j *Job) copy() *Job {
+	if j == nil {
+		return nil
+	}
+	out := *j
+	out.Phases = append([]Phase(nil), j.Phases...)
+	return &out
+}

--- a/hub/internal/session/pod.go
+++ b/hub/internal/session/pod.go
@@ -13,11 +13,11 @@ import (
 // dependency, and the standard library has no YAML parser. Converting is
 // a one-liner with a tool every operator of this already has:
 //
-//	kubectl apply --dry-run=client -o json -f deploy/session-pod.yaml
+//	kubectl apply --dry-run=client -o json -f deploy/helm/kubestronaut-sim/files/session-pod.yaml
 //
 // and the Helm chart does it at render time with fromYaml | toJson. So
-// deploy/session-pod.yaml stays the single source of truth, comments and
-// all, and no second copy of the spec exists to drift.
+// the manifest in the chart's files/ stays the single source of truth,
+// comments and all, and no second copy of the spec exists to drift.
 type Template []byte
 
 // patch is what varies between one session and the next. Everything else

--- a/hub/internal/session/pod.go
+++ b/hub/internal/session/pod.go
@@ -29,6 +29,12 @@ type patch struct {
 	Name   string
 	Labels map[string]string
 	Bank   string
+	// WebhookURL and WebhookToken are how this session's graded attempts
+	// reach a store that outlives it. Per-session, because the token
+	// names the candidate: the Pod cannot say whose history it is
+	// writing, it can only present the ticket it was given.
+	WebhookURL   string
+	WebhookToken string
 }
 
 // render returns the template with the session's identity and bank
@@ -71,32 +77,59 @@ func (t Template) render(p patch) ([]byte, error) {
 	}
 
 	if p.Bank != "" {
-		spec, _ := pod["spec"].(map[string]any)
-		if spec == nil {
-			return nil, errors.New("session: pod template has no spec")
-		}
 		// BANK appears in four containers and the init container, and a
 		// session that sets it in three of them is a session where the
 		// docs proxy allows one bank's sites while the facilitator serves
 		// another's questions. Set wherever it already appears rather
 		// than in a hardcoded list of container names.
-		n := 0
-		for _, key := range []string{"initContainers", "containers"} {
-			list, _ := spec[key].([]any)
-			for _, c := range list {
-				container, _ := c.(map[string]any)
-				if container == nil {
-					continue
-				}
-				n += setEnv(container, "BANK", p.Bank)
-			}
+		n, err := setEverywhere(pod, "BANK", p.Bank)
+		if err != nil {
+			return nil, err
 		}
 		if n == 0 {
 			return nil, fmt.Errorf("session: no container in the template takes a BANK env var, so %q cannot be selected", p.Bank)
 		}
 	}
 
+	if p.WebhookURL != "" {
+		n, err := setEverywhere(pod, "HISTORY_WEBHOOK_URL", p.WebhookURL)
+		if err != nil {
+			return nil, err
+		}
+		if n == 0 {
+			// Loud, for the same reason BANK is: a hub configured to
+			// collect history against a template with nowhere to put the
+			// endpoint would run perfectly and quietly record nothing,
+			// and the candidate would find out after their exam.
+			return nil, errors.New("session: no container in the template takes a HISTORY_WEBHOOK_URL env var, so attempts could not be recorded")
+		}
+		if _, err := setEverywhere(pod, "HISTORY_WEBHOOK_TOKEN", p.WebhookToken); err != nil {
+			return nil, err
+		}
+	}
+
 	return json.Marshal(pod)
+}
+
+// setEverywhere rewrites name in every container that already declares
+// it, and reports how many it found.
+func setEverywhere(pod map[string]any, name, value string) (int, error) {
+	spec, _ := pod["spec"].(map[string]any)
+	if spec == nil {
+		return 0, errors.New("session: pod template has no spec")
+	}
+	n := 0
+	for _, key := range []string{"initContainers", "containers"} {
+		list, _ := spec[key].([]any)
+		for _, c := range list {
+			container, _ := c.(map[string]any)
+			if container == nil {
+				continue
+			}
+			n += setEnv(container, name, value)
+		}
+	}
+	return n, nil
 }
 
 // setEnv rewrites an existing BANK entry in place and reports whether it

--- a/hub/internal/session/pod.go
+++ b/hub/internal/session/pod.go
@@ -1,0 +1,123 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Template is a Pod manifest, as JSON, that the hub stamps out once per
+// session.
+//
+// JSON rather than YAML because nothing in this repo may add a
+// dependency, and the standard library has no YAML parser. Converting is
+// a one-liner with a tool every operator of this already has:
+//
+//	kubectl apply --dry-run=client -o json -f deploy/session-pod.yaml
+//
+// and the Helm chart does it at render time with fromYaml | toJson. So
+// deploy/session-pod.yaml stays the single source of truth, comments and
+// all, and no second copy of the spec exists to drift.
+type Template []byte
+
+// patch is what varies between one session and the next. Everything else
+// — every container, capability, volume and probe — comes from the
+// template untouched, which is the point: the hub does not model a
+// PodSpec and cannot silently disagree with the manifest that was
+// debugged against a real cluster.
+type patch struct {
+	Name   string
+	Labels map[string]string
+	Bank   string
+}
+
+// render returns the template with the session's identity and bank
+// substituted.
+//
+// The manifest is decoded to map[string]any rather than to typed structs
+// so that fields this package has never heard of survive the round trip.
+// encoding/json discards unknown fields into a struct, which for a Pod
+// spec means a field added to session-pod.yaml would be silently dropped
+// on the way to the API server — the failure would be a session missing a
+// volume, not a compile error.
+func (t Template) render(p patch) ([]byte, error) {
+	if len(t) == 0 {
+		return nil, errors.New("session: no pod template configured")
+	}
+	var pod map[string]any
+	if err := json.Unmarshal(t, &pod); err != nil {
+		return nil, fmt.Errorf("session: pod template is not JSON: %w", err)
+	}
+	if kind, _ := pod["kind"].(string); kind != "Pod" {
+		return nil, fmt.Errorf("session: pod template is a %q, want a Pod", kind)
+	}
+
+	meta, _ := pod["metadata"].(map[string]any)
+	if meta == nil {
+		meta = map[string]any{}
+		pod["metadata"] = meta
+	}
+	meta["name"] = p.Name
+	// A template carrying generateName as well would have the API server
+	// ignore the name we just set.
+	delete(meta, "generateName")
+	labels, _ := meta["labels"].(map[string]any)
+	if labels == nil {
+		labels = map[string]any{}
+		meta["labels"] = labels
+	}
+	for k, v := range p.Labels {
+		labels[k] = v
+	}
+
+	if p.Bank != "" {
+		spec, _ := pod["spec"].(map[string]any)
+		if spec == nil {
+			return nil, errors.New("session: pod template has no spec")
+		}
+		// BANK appears in four containers and the init container, and a
+		// session that sets it in three of them is a session where the
+		// docs proxy allows one bank's sites while the facilitator serves
+		// another's questions. Set wherever it already appears rather
+		// than in a hardcoded list of container names.
+		n := 0
+		for _, key := range []string{"initContainers", "containers"} {
+			list, _ := spec[key].([]any)
+			for _, c := range list {
+				container, _ := c.(map[string]any)
+				if container == nil {
+					continue
+				}
+				n += setEnv(container, "BANK", p.Bank)
+			}
+		}
+		if n == 0 {
+			return nil, fmt.Errorf("session: no container in the template takes a BANK env var, so %q cannot be selected", p.Bank)
+		}
+	}
+
+	return json.Marshal(pod)
+}
+
+// setEnv rewrites an existing BANK entry in place and reports whether it
+// found one. Only existing entries: a container that was not given a bank
+// under compose does not want one here either, and adding it would be
+// this package inventing spec the manifest never declared.
+func setEnv(container map[string]any, name, value string) int {
+	env, _ := container["env"].([]any)
+	found := 0
+	for _, e := range env {
+		entry, _ := e.(map[string]any)
+		if entry == nil {
+			continue
+		}
+		if n, _ := entry["name"].(string); n == name {
+			entry["value"] = value
+			// valueFrom and value are mutually exclusive; a template that
+			// sourced BANK from elsewhere would now have both.
+			delete(entry, "valueFrom")
+			found++
+		}
+	}
+	return found
+}

--- a/hub/internal/session/pod_test.go
+++ b/hub/internal/session/pod_test.go
@@ -146,11 +146,11 @@ func TestRenderDropsGenerateName(t *testing.T) {
 
 func TestPodNameSafe(t *testing.T) {
 	for in, want := range map[string]string{
-		"583231":            "583231",
-		"Octo_Cat":          "octo-cat",
-		"user@example.com":  "user-example-com",
-		"---":               "anon",
-		"":                  "anon",
+		"583231":                "583231",
+		"Octo_Cat":              "octo-cat",
+		"user@example.com":      "user-example-com",
+		"---":                   "anon",
+		"":                      "anon",
 		strings.Repeat("a", 60): strings.Repeat("a", 40),
 	} {
 		if got := podNameSafe(in); got != want {

--- a/hub/internal/session/pod_test.go
+++ b/hub/internal/session/pod_test.go
@@ -129,6 +129,74 @@ func TestRenderRejectsWhatItCannotUse(t *testing.T) {
 	}
 }
 
+const withWebhook = `{
+  "kind": "Pod",
+  "metadata": {},
+  "spec": {"containers": [
+    {"name": "facilitator", "env": [
+      {"name": "BANK", "value": "old"},
+      {"name": "HISTORY_WEBHOOK_URL", "value": ""},
+      {"name": "HISTORY_WEBHOOK_TOKEN", "value": ""}
+    ]},
+    {"name": "conductor", "env": [{"name": "BANK", "value": "old"}]}
+  ]}
+}`
+
+func TestRenderSetsTheWebhookOnTheContainerThatDeclaresIt(t *testing.T) {
+	pod := render(t, withWebhook, patch{
+		Name:         "p",
+		Bank:         "ckad-mock-01",
+		WebhookURL:   "https://hub.example/hub/ingest/history",
+		WebhookToken: "tkt",
+	})
+	containers := pod["spec"].(map[string]any)["containers"].([]any)
+
+	env := map[string]any{}
+	for _, e := range containers[0].(map[string]any)["env"].([]any) {
+		entry := e.(map[string]any)
+		env[entry["name"].(string)] = entry["value"]
+	}
+	if env["HISTORY_WEBHOOK_URL"] != "https://hub.example/hub/ingest/history" {
+		t.Errorf("URL = %v", env["HISTORY_WEBHOOK_URL"])
+	}
+	if env["HISTORY_WEBHOOK_TOKEN"] != "tkt" {
+		t.Errorf("token = %v", env["HISTORY_WEBHOOK_TOKEN"])
+	}
+	// The conductor declares neither and must not acquire them: a ticket
+	// is a credential, and it belongs in the one container that has a
+	// use for it.
+	for _, e := range containers[1].(map[string]any)["env"].([]any) {
+		if name := e.(map[string]any)["name"]; name != "BANK" {
+			t.Errorf("conductor gained %v", name)
+		}
+	}
+}
+
+// A hub told to collect history against a template with nowhere to put
+// the endpoint would run perfectly and record nothing, and the
+// candidate would find out after their exam.
+func TestRenderRefusesAWebhookTheTemplateCannotTake(t *testing.T) {
+	_, err := Template(twoContainers).render(patch{
+		Name:       "p",
+		WebhookURL: "https://hub.example/hub/ingest/history",
+	})
+	if err == nil || !strings.Contains(err.Error(), "HISTORY_WEBHOOK_URL") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+// No webhook configured is a real deployment, not a broken one: a
+// self-hoster keeping seats and a proxy without a durable history.
+func TestRenderWithNoWebhookLeavesTheTemplateAlone(t *testing.T) {
+	pod := render(t, withWebhook, patch{Name: "p", Bank: "b"})
+	for _, e := range pod["spec"].(map[string]any)["containers"].([]any)[0].(map[string]any)["env"].([]any) {
+		entry := e.(map[string]any)
+		if strings.HasPrefix(entry["name"].(string), "HISTORY_WEBHOOK") && entry["value"] != "" {
+			t.Errorf("%v = %v with no webhook configured", entry["name"], entry["value"])
+		}
+	}
+}
+
 // generateName wins over name at the API server, so a template carrying
 // both would produce Pods the hub cannot address by the name it thinks
 // it gave them.

--- a/hub/internal/session/pod_test.go
+++ b/hub/internal/session/pod_test.go
@@ -1,0 +1,160 @@
+package session
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+const twoContainers = `{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {"name": "placeholder", "labels": {"app.kubernetes.io/name": "kubestronaut-sim"}},
+  "spec": {
+    "restartPolicy": "Never",
+    "hostAliases": [{"ip": "127.0.0.2", "hostnames": ["instance-1"]}],
+    "initContainers": [
+      {"name": "banks", "image": "banks:dev", "env": [{"name": "BANK", "value": "old"}]}
+    ],
+    "containers": [
+      {"name": "k8s-env", "image": "k8s-env:dev", "env": [{"name": "BANK", "value": "old"}, {"name": "SSHD_LISTEN", "value": "127.0.0.1"}]},
+      {"name": "docs-proxy", "image": "proxy:dev", "env": [{"name": "BANK", "value": "old"}]},
+      {"name": "registry", "image": "registry:2"}
+    ]
+  }
+}`
+
+func render(t *testing.T, tmpl string, p patch) map[string]any {
+	t.Helper()
+	out, err := Template(tmpl).render(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pod map[string]any
+	if err := json.Unmarshal(out, &pod); err != nil {
+		t.Fatal(err)
+	}
+	return pod
+}
+
+func TestRenderNamesAndLabelsThePod(t *testing.T) {
+	pod := render(t, twoContainers, patch{
+		Name:   "sim-session-practical-583231",
+		Labels: map[string]string{"kubestronaut-sim/user": "583231"},
+	})
+	meta := pod["metadata"].(map[string]any)
+	if meta["name"] != "sim-session-practical-583231" {
+		t.Errorf("name = %v", meta["name"])
+	}
+	labels := meta["labels"].(map[string]any)
+	if labels["kubestronaut-sim/user"] != "583231" {
+		t.Errorf("user label = %v", labels["kubestronaut-sim/user"])
+	}
+	// Patching labels must add to the template's, not replace them.
+	if labels["app.kubernetes.io/name"] != "kubestronaut-sim" {
+		t.Error("the template's own labels were dropped")
+	}
+}
+
+// The sharp one. BANK appears in four containers plus the init
+// container, and a render that sets it in three of them gives the
+// candidate a docs proxy allowing one exam's sites while the facilitator
+// serves another's questions — a session that looks fine and is wrong.
+func TestRenderSetsBankInEveryContainerThatTakesOne(t *testing.T) {
+	pod := render(t, twoContainers, patch{Name: "p", Bank: "ckad-mock-02"})
+	spec := pod["spec"].(map[string]any)
+
+	seen := 0
+	for _, key := range []string{"initContainers", "containers"} {
+		for _, c := range spec[key].([]any) {
+			container := c.(map[string]any)
+			env, _ := container["env"].([]any)
+			for _, e := range env {
+				entry := e.(map[string]any)
+				if entry["name"] != "BANK" {
+					continue
+				}
+				seen++
+				if entry["value"] != "ckad-mock-02" {
+					t.Errorf("%s: BANK = %v", container["name"], entry["value"])
+				}
+			}
+		}
+	}
+	if seen != 3 {
+		t.Errorf("set BANK in %d places, want 3", seen)
+	}
+	// A container with no BANK does not acquire one: the hub patches the
+	// manifest, it does not invent spec the manifest never declared.
+	for _, c := range spec["containers"].([]any) {
+		container := c.(map[string]any)
+		if container["name"] == "registry" {
+			if _, has := container["env"]; has {
+				t.Error("registry gained an env block it never had")
+			}
+		}
+	}
+}
+
+// The reason the template is decoded to map[string]any rather than to a
+// typed PodSpec: a field this package has never heard of must reach the
+// API server. Into a struct, encoding/json discards it silently, and the
+// symptom would be a session missing a volume rather than a build error.
+func TestRenderPreservesFieldsThisPackageDoesNotKnow(t *testing.T) {
+	out, err := Template(twoContainers).render(patch{Name: "p", Bank: "b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"hostAliases", "instance-1", "restartPolicy", "SSHD_LISTEN", "127.0.0.2"} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("rendered pod lost %q", want)
+		}
+	}
+}
+
+func TestRenderRejectsWhatItCannotUse(t *testing.T) {
+	for name, tc := range map[string]struct {
+		tmpl string
+		want string
+	}{
+		"not a pod":      {`{"kind":"Deployment","metadata":{}}`, "want a Pod"},
+		"not json":       {"kind: Pod\n", "not JSON"},
+		"empty":          {"", "no pod template"},
+		"nowhere to set": {`{"kind":"Pod","metadata":{},"spec":{"containers":[{"name":"x"}]}}`, "BANK"},
+	} {
+		_, err := Template(tc.tmpl).render(patch{Name: "p", Bank: "b"})
+		if err == nil || !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("%s: err = %v, want it to mention %q", name, err, tc.want)
+		}
+	}
+}
+
+// generateName wins over name at the API server, so a template carrying
+// both would produce Pods the hub cannot address by the name it thinks
+// it gave them.
+func TestRenderDropsGenerateName(t *testing.T) {
+	pod := render(t, `{"kind":"Pod","metadata":{"generateName":"sim-"},"spec":{"containers":[]}}`,
+		patch{Name: "sim-session-mcq-1"})
+	meta := pod["metadata"].(map[string]any)
+	if _, has := meta["generateName"]; has {
+		t.Error("generateName survived and would override the name")
+	}
+	if meta["name"] != "sim-session-mcq-1" {
+		t.Errorf("name = %v", meta["name"])
+	}
+}
+
+func TestPodNameSafe(t *testing.T) {
+	for in, want := range map[string]string{
+		"583231":            "583231",
+		"Octo_Cat":          "octo-cat",
+		"user@example.com":  "user-example-com",
+		"---":               "anon",
+		"":                  "anon",
+		strings.Repeat("a", 60): strings.Repeat("a", 40),
+	} {
+		if got := podNameSafe(in); got != want {
+			t.Errorf("podNameSafe(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/hub/internal/session/pods.go
+++ b/hub/internal/session/pods.go
@@ -1,0 +1,148 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"kubestronaut-sim/hub/internal/kube"
+)
+
+// KubePods adapts the Kubernetes client to what the manager needs.
+//
+// The whole reason this is a separate type is the sentinel translation.
+// The manager decides "already gone, carry on" and "name taken, wait for
+// it" by errors.Is against its own sentinels; a kube.ErrNotFound that
+// reaches it untranslated reads as an unknown failure, and the visible
+// symptom is a reset that waits out its entire timeout for a Pod that
+// vanished immediately. One adapter, one test.
+type KubePods struct {
+	Client         *kube.Client
+	ReadyContainer string
+}
+
+var _ Pods = (*KubePods)(nil)
+
+func (k *KubePods) Create(ctx context.Context, spec []byte) error {
+	_, err := k.Client.CreatePod(ctx, spec)
+	if errors.Is(err, kube.ErrConflict) {
+		return fmt.Errorf("%w", ErrPodExists)
+	}
+	return err
+}
+
+func (k *KubePods) Get(ctx context.Context, name string) (Pod, error) {
+	p, err := k.Client.GetPod(ctx, name)
+	if errors.Is(err, kube.ErrNotFound) {
+		return Pod{}, ErrPodGone
+	}
+	if err != nil {
+		return Pod{}, err
+	}
+	return k.convert(p), nil
+}
+
+func (k *KubePods) Delete(ctx context.Context, name string) error {
+	err := k.Client.DeletePod(ctx, name)
+	if errors.Is(err, kube.ErrNotFound) {
+		return ErrPodGone
+	}
+	return err
+}
+
+func (k *KubePods) List(ctx context.Context, selector string) ([]Pod, error) {
+	pods, err := k.Client.ListPods(ctx, selector)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Pod, 0, len(pods))
+	for _, p := range pods {
+		out = append(out, k.convert(p))
+	}
+	return out, nil
+}
+
+func (k *KubePods) convert(p kube.Pod) Pod {
+	return Pod{
+		Name:        p.Metadata.Name,
+		IP:          p.Status.PodIP,
+		Phase:       p.Status.Phase,
+		Ready:       p.Ready(k.ReadyContainer),
+		Terminating: p.Terminating(),
+		CreatedAt:   p.Metadata.CreationTimestamp,
+		Labels:      p.Metadata.Labels,
+	}
+}
+
+// Static is a Pods implementation with no Kubernetes behind it: every
+// session it hands out resolves to one fixed host.
+//
+// It exists so the hub — auth, seats, the queue, holds, reaping, the
+// proxy and the recycle job protocol — can be run against a local
+// `./sim up`, which is the only place the whole simulator runs without a
+// cluster. It really does track existence, so a recycle deletes, waits,
+// and creates exactly as it would against an API server; what it cannot
+// do is rebuild anything, so the facilitator on the other side is the
+// same one as before. That difference is the point of saying "static"
+// rather than "fake": the lifecycle is real, the teardown is not.
+type Static struct {
+	// Host is where every session's traffic goes. The manager appends
+	// the configured port.
+	Host string
+
+	mu   sync.Mutex
+	live map[string]time.Time
+}
+
+var _ Pods = (*Static)(nil)
+
+func (s *Static) Create(_ context.Context, spec []byte) error {
+	var pod struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(spec, &pod); err != nil {
+		return fmt.Errorf("static: unreadable pod spec: %w", err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.live == nil {
+		s.live = map[string]time.Time{}
+	}
+	if _, exists := s.live[pod.Metadata.Name]; exists {
+		return ErrPodExists
+	}
+	s.live[pod.Metadata.Name] = time.Now()
+	return nil
+}
+
+func (s *Static) Get(_ context.Context, name string) (Pod, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	created, ok := s.live[name]
+	if !ok {
+		return Pod{}, ErrPodGone
+	}
+	return Pod{
+		Name: name, IP: s.Host, Phase: "Running", Ready: true, CreatedAt: created,
+		Labels: map[string]string{"kubestronaut-sim/user": ""},
+	}, nil
+}
+
+func (s *Static) Delete(_ context.Context, name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.live[name]; !ok {
+		return ErrPodGone
+	}
+	delete(s.live, name)
+	return nil
+}
+
+// List returns nothing: a hub restart has nothing to adopt here, because
+// the Pods only ever existed in this process's memory.
+func (s *Static) List(context.Context, string) ([]Pod, error) { return nil, nil }

--- a/hub/internal/session/pods_test.go
+++ b/hub/internal/session/pods_test.go
@@ -1,0 +1,119 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"kubestronaut-sim/hub/internal/kube"
+)
+
+// The adapter's only real job, and the one that fails silently.
+//
+// The manager decides "already gone, carry on" and "name taken, wait for
+// it" with errors.Is against its own sentinels. A kube.ErrNotFound that
+// arrives untranslated is just an unknown error, and the visible symptom
+// is a reset that waits out its whole timeout for a Pod that vanished
+// instantly — twenty minutes of a progress bar that was finished before
+// it started.
+func TestKubePodsTranslatesEveryStatusTheManagerBranchesOn(t *testing.T) {
+	for name, tc := range map[string]struct {
+		code int
+		call func(*KubePods) error
+		want error
+	}{
+		"get on a missing pod": {http.StatusNotFound, func(k *KubePods) error {
+			_, err := k.Get(context.Background(), "sim-1")
+			return err
+		}, ErrPodGone},
+		"delete on a missing pod": {http.StatusNotFound, func(k *KubePods) error {
+			return k.Delete(context.Background(), "sim-1")
+		}, ErrPodGone},
+		"create onto a taken name": {http.StatusConflict, func(k *KubePods) error {
+			return k.Create(context.Background(), []byte(`{"kind":"Pod"}`))
+		}, ErrPodExists},
+	} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(tc.code)
+			w.Write([]byte(`{"kind":"Status","message":"nope"}`))
+		}))
+		k := &KubePods{
+			Client:         &kube.Client{BaseURL: srv.URL, Namespace: "ns", Token: "t", HTTP: srv.Client()},
+			ReadyContainer: "facilitator",
+		}
+		if err := tc.call(k); !errors.Is(err, tc.want) {
+			t.Errorf("%s: err = %v, want %v", name, err, tc.want)
+		}
+		srv.Close()
+	}
+}
+
+// Readiness is per-container: the hub proxies to the facilitator, and a
+// desktop still coming up is a normal moment during boot rather than a
+// reason to withhold a working session.
+func TestKubePodsConvertsWhatTheManagerReads(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"metadata":{"name":"sim-1","labels":{"kubestronaut-sim/user":"583231"},
+		  "creationTimestamp":"2026-08-03T10:00:00Z","deletionTimestamp":"2026-08-03T11:00:00Z"},
+		  "status":{"phase":"Running","podIP":"10.42.0.9",
+		  "containerStatuses":[{"name":"facilitator","ready":true},{"name":"desktop","ready":false}]}}`))
+	}))
+	defer srv.Close()
+	k := &KubePods{
+		Client:         &kube.Client{BaseURL: srv.URL, Namespace: "ns", Token: "t", HTTP: srv.Client()},
+		ReadyContainer: "facilitator",
+	}
+	pod, err := k.Get(context.Background(), "sim-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pod.Ready {
+		t.Error("a ready facilitator should make the session usable")
+	}
+	if pod.IP != "10.42.0.9" || pod.Labels["kubestronaut-sim/user"] != "583231" {
+		t.Errorf("pod = %+v", pod)
+	}
+	// A deletionTimestamp is set the moment a delete is accepted, and Get
+	// keeps succeeding for the whole grace period. Treating a
+	// terminating Pod as live is how a seat stays occupied by something
+	// already dying.
+	if !pod.Terminating {
+		t.Error("a pod with a deletionTimestamp is not live")
+	}
+	if pod.CreatedAt.IsZero() {
+		t.Error("creationTimestamp did not survive: the hard age cap depends on it")
+	}
+}
+
+// Static is what makes the hub runnable on a laptop, and its value
+// depends on the lifecycle being real rather than always-succeeds — a
+// Delete that does not delete leaves the recycle path waiting forever
+// for a Pod that never goes away.
+func TestStaticTracksExistenceSoRecycleTerminates(t *testing.T) {
+	s := &Static{Host: "127.0.0.1"}
+	ctx := context.Background()
+	spec := []byte(`{"metadata":{"name":"sim-session-practical-local"}}`)
+
+	if _, err := s.Get(ctx, "sim-session-practical-local"); !errors.Is(err, ErrPodGone) {
+		t.Fatalf("a pod that was never created: %v", err)
+	}
+	if err := s.Create(ctx, spec); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Create(ctx, spec); !errors.Is(err, ErrPodExists) {
+		t.Errorf("creating the same name twice: %v", err)
+	}
+	pod, err := s.Get(ctx, "sim-session-practical-local")
+	if err != nil || !pod.Ready || pod.IP != "127.0.0.1" {
+		t.Fatalf("pod = %+v, err = %v", pod, err)
+	}
+	if err := s.Delete(ctx, "sim-session-practical-local"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Get(ctx, "sim-session-practical-local"); !errors.Is(err, ErrPodGone) {
+		t.Errorf("after delete: %v — a recycle would wait for this forever", err)
+	}
+}

--- a/hub/internal/session/session.go
+++ b/hub/internal/session/session.go
@@ -149,6 +149,17 @@ type Config struct {
 	PodPrefix string
 	Labels    map[string]string
 
+	// Webhook mints the endpoint and the ticket a session Pod posts its
+	// graded attempts back with, for one user. Nil means nothing is
+	// collecting them and the Pod keeps only its own ephemeral history —
+	// which is what a self-hoster running this without the store gets,
+	// and what every test that does not care gets.
+	//
+	// Minted per Pod rather than once at boot because the ticket names
+	// the user: it is the Pod's only way to say whose attempt this is,
+	// and it must not be able to say anyone else's.
+	Webhook func(user string) (url, token string, err error)
+
 	Now  func() time.Time
 	Logf func(string, ...any)
 }
@@ -358,11 +369,22 @@ func (m *Manager) bootPod(e *entry, fl Flavour) {
 
 // createAndWait is the boot itself, shared by first start and recycle.
 func (m *Manager) createAndWait(ctx context.Context, e *entry, fl Flavour) error {
-	spec, err := fl.Template.render(patch{
+	p := patch{
 		Name:   e.Pod,
 		Labels: m.labelsFor(e),
 		Bank:   e.Bank,
-	})
+	}
+	// Minted here rather than when the session was admitted, so a
+	// recycle gets a fresh ticket: the replacement Pod may outlive the
+	// window the original one's was good for.
+	if m.cfg.Webhook != nil {
+		url, token, err := m.cfg.Webhook(e.User)
+		if err != nil {
+			return fmt.Errorf("mint a history ticket for %s: %w", e.User, err)
+		}
+		p.WebhookURL, p.WebhookToken = url, token
+	}
+	spec, err := fl.Template.render(p)
 	if err != nil {
 		return err
 	}

--- a/hub/internal/session/session.go
+++ b/hub/internal/session/session.go
@@ -1,0 +1,929 @@
+// Package session owns the scarce thing: a running exam Pod.
+//
+// The hosted tier is capped, so the interesting logic is not "start a
+// Pod" but "decide who may". Three rules shape it:
+//
+//   - A seat is held from admission to teardown, not from readiness.
+//     Counting only ready sessions would admit a second candidate while
+//     the first is still booting and hand both of them a half-built
+//     cluster.
+//
+//   - Pod creation is serialised. Boot is CPU-bound — one booting session
+//     measured 3090m of a 4-core node's 4000m while memory stayed at 25%
+//     — so two simultaneous boots on one node do not take turns, they
+//     both crawl. This is a throughput decision, not a politeness one.
+//
+//   - The queue hands the head a time-boxed hold rather than a seat.
+//     A browser that closed an hour ago must not keep a seat warm, and
+//     the only evidence that someone is still waiting is that they are
+//     still asking.
+package session
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Kind is a session flavour. They are separate pools because they are
+// separate costs: a practical session is a privileged Pod building a
+// two-node cluster, an MCQ session is a facilitator and 128Mi.
+type Kind string
+
+const (
+	Practical Kind = "practical"
+	MCQ       Kind = "mcq"
+)
+
+// ParseKind validates a requested flavour.
+func ParseKind(s string) (Kind, error) {
+	switch Kind(s) {
+	case Practical, MCQ:
+		return Kind(s), nil
+	case "":
+		return Practical, nil
+	}
+	return "", fmt.Errorf("session: unknown kind %q (want practical or mcq)", s)
+}
+
+// State is where a session is in its life.
+type State string
+
+const (
+	// Pending: seat held, waiting for a boot slot. Distinct from Starting
+	// because the difference matters to the person waiting — nothing is
+	// wrong, someone else is booting.
+	Pending State = "pending"
+	// Starting: the Pod exists and is not ready yet.
+	Starting State = "starting"
+	Ready    State = "ready"
+	// Failed: the seat is still held so the candidate can read why
+	// before it is reaped.
+	Failed State = "failed"
+)
+
+// Session is one candidate's Pod, as the rest of the hub sees it.
+type Session struct {
+	User      string    `json:"-"`
+	Kind      Kind      `json:"kind"`
+	Bank      string    `json:"bank,omitempty"`
+	Pod       string    `json:"pod"`
+	State     State     `json:"state"`
+	StartedAt time.Time `json:"startedAt"`
+	ExpiresAt time.Time `json:"expiresAt"`
+	LastSeen  time.Time `json:"lastSeen"`
+	Error     string    `json:"error,omitempty"`
+
+	// addr is where the proxy sends traffic. Unexported: it is the
+	// candidate's own Pod, but publishing an in-cluster address in a JSON
+	// response is telling every user something about the infrastructure
+	// that they have no use for.
+	addr string
+}
+
+// Addr is the host:port the proxy should dial, empty until ready.
+func (s Session) Addr() string { return s.addr }
+
+// Pods is what the manager needs from Kubernetes, and no more.
+//
+// An interface rather than *kube.Client so the manager's rules — seats,
+// queue, holds, reaping — are testable without an API server, and so a
+// laptop can run the hub against `./sim up` through Static.
+type Pods interface {
+	// Create returns ErrPodExists if the name is taken.
+	Create(ctx context.Context, spec []byte) error
+	// Get and Delete return ErrPodGone for a Pod that is not there.
+	Get(ctx context.Context, name string) (Pod, error)
+	Delete(ctx context.Context, name string) error
+	List(ctx context.Context, selector string) ([]Pod, error)
+}
+
+// Pod is the manager's view of a running Pod.
+type Pod struct {
+	Name        string
+	IP          string
+	Phase       string
+	Ready       bool
+	Terminating bool
+	CreatedAt   time.Time
+	Labels      map[string]string
+}
+
+// Flavour is the per-kind configuration: how many may run at once, and
+// what to run.
+type Flavour struct {
+	Seats    int
+	Template Template
+	// Bank is the exam this flavour starts on. Empty leaves whatever the
+	// template declares.
+	Bank string
+}
+
+// Config is everything the manager needs to be built.
+type Config struct {
+	Flavours map[Kind]Flavour
+
+	// HoldFor is how long the head of the queue keeps its claim.
+	HoldFor time.Duration
+	// IdleAfter ends a session nobody has touched. The proxy touches on
+	// every request, so this measures a closed tab, not a quiet think.
+	IdleAfter time.Duration
+	// MaxAge is the hard cap. A real CKAD sitting is two hours.
+	MaxAge time.Duration
+	// BootTimeout gives up on a Pod that never becomes ready.
+	BootTimeout time.Duration
+	// BootConcurrency is how many Pods may boot at once. See the package
+	// comment: this defaults to 1 deliberately.
+	BootConcurrency int
+
+	// ReadyContainer is the container whose readiness means "usable".
+	ReadyContainer string
+	// Port is the port on that container the hub proxies to.
+	Port int
+
+	// PodPrefix names Pods, and the label selector adopts them.
+	PodPrefix string
+	Labels    map[string]string
+
+	Now  func() time.Time
+	Logf func(string, ...any)
+}
+
+func (c *Config) defaults() {
+	if c.HoldFor == 0 {
+		c.HoldFor = 2 * time.Minute
+	}
+	if c.IdleAfter == 0 {
+		c.IdleAfter = 30 * time.Minute
+	}
+	if c.MaxAge == 0 {
+		c.MaxAge = 10 * time.Hour
+	}
+	if c.BootTimeout == 0 {
+		c.BootTimeout = 20 * time.Minute
+	}
+	if c.BootConcurrency == 0 {
+		c.BootConcurrency = 1
+	}
+	if c.ReadyContainer == "" {
+		c.ReadyContainer = "facilitator"
+	}
+	if c.Port == 0 {
+		c.Port = 8080
+	}
+	if c.PodPrefix == "" {
+		c.PodPrefix = "sim-session"
+	}
+}
+
+// Queued is returned by Start when every seat is taken. It is an error
+// because the caller cannot proceed, and it carries a position because
+// "try later" without a place in line is what makes people refresh.
+type Queued struct {
+	Position int
+	Seats    int
+	Kind     Kind
+}
+
+func (q *Queued) Error() string {
+	return fmt.Sprintf("session: all %d %s seats are in use — you are number %d in the queue",
+		q.Seats, q.Kind, q.Position)
+}
+
+// ErrNoSuchKind is a request for a flavour this deployment does not
+// offer — an MCQ-only hub, say, or a practical-only one.
+var ErrNoSuchKind = errors.New("session: this deployment does not offer that kind of session")
+
+// ErrNoSession is asking about a session that does not exist.
+var ErrNoSession = errors.New("session: no session")
+
+// ErrBusy is a second control operation while one is in flight.
+var ErrBusy = errors.New("session: another control operation is in flight")
+
+// Manager is the whole hosted tier's admission control.
+type Manager struct {
+	cfg  Config
+	pods Pods
+
+	mu       sync.Mutex
+	sessions map[string]*entry
+	queues   map[Kind][]*waiter
+
+	// boot is the serialising semaphore. Capacity, not a mutex, because
+	// BootConcurrency is a value an operator with more nodes will raise.
+	boot chan struct{}
+}
+
+// entry is a session plus the machinery that is nobody else's business.
+type entry struct {
+	Session
+	jobs jobStore
+	// done is closed when the session ends, so a boot that is minutes
+	// into polling stops rather than resurrecting a session the
+	// candidate already left.
+	done chan struct{}
+}
+
+type waiter struct {
+	user string
+	kind Kind
+	// holdUntil is zero until this waiter reaches the head and a seat
+	// frees. From then the seat is theirs to claim until it lapses.
+	holdUntil time.Time
+	joined    time.Time
+}
+
+// New builds a Manager. It does not touch the cluster; call Adopt for
+// that.
+func New(pods Pods, cfg Config) *Manager {
+	cfg.defaults()
+	m := &Manager{
+		cfg:      cfg,
+		pods:     pods,
+		sessions: map[string]*entry{},
+		queues:   map[Kind][]*waiter{},
+		boot:     make(chan struct{}, cfg.BootConcurrency),
+	}
+	return m
+}
+
+func (m *Manager) now() time.Time {
+	if m.cfg.Now != nil {
+		return m.cfg.Now()
+	}
+	return time.Now()
+}
+
+func (m *Manager) logf(format string, args ...any) {
+	if m.cfg.Logf != nil {
+		m.cfg.Logf(format, args...)
+	}
+}
+
+// Start admits a user, or tells them where they are in the queue.
+//
+// Idempotent: a user who already has a session gets it back rather than a
+// second one. The UI polls this while queued, and each poll is also how a
+// held seat is claimed.
+func (m *Manager) Start(ctx context.Context, user string, kind Kind) (Session, error) {
+	m.mu.Lock()
+
+	if e, ok := m.sessions[user]; ok {
+		e.LastSeen = m.now()
+		s := e.Session
+		m.mu.Unlock()
+		return s, nil
+	}
+
+	fl, ok := m.cfg.Flavours[kind]
+	if !ok || fl.Seats <= 0 {
+		m.mu.Unlock()
+		return Session{}, fmt.Errorf("%w: %s", ErrNoSuchKind, kind)
+	}
+
+	// A seat this user is already holding through the queue counts as
+	// theirs; anyone else's hold counts against them.
+	if m.usedLocked(kind) >= fl.Seats && !m.claimLocked(user, kind) {
+		pos := m.enqueueLocked(user, kind)
+		m.mu.Unlock()
+		return Session{}, &Queued{Position: pos, Seats: fl.Seats, Kind: kind}
+	}
+	m.dequeueLocked(user)
+
+	now := m.now()
+	e := &entry{
+		Session: Session{
+			User:      user,
+			Kind:      kind,
+			Bank:      fl.Bank,
+			Pod:       m.podName(user, kind),
+			State:     Pending,
+			StartedAt: now,
+			LastSeen:  now,
+			ExpiresAt: now.Add(m.cfg.MaxAge),
+		},
+		done: make(chan struct{}),
+	}
+	e.jobs.now = m.now
+	m.sessions[user] = e
+	s := e.Session
+	m.mu.Unlock()
+
+	m.logf("hub: admitted %s to a %s seat as %s", user, kind, e.Pod)
+	// Detached from the request: booting takes minutes and the browser
+	// polls. ctx here would cancel the boot when the admitting request
+	// returned.
+	go m.bootPod(e, fl)
+	return s, nil
+}
+
+// bootPod claims a boot slot, creates the Pod and waits for it.
+func (m *Manager) bootPod(e *entry, fl Flavour) {
+	select {
+	case m.boot <- struct{}{}:
+	case <-e.done:
+		return
+	}
+	defer func() { <-m.boot }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), m.cfg.BootTimeout)
+	defer cancel()
+	// A session ended mid-boot must abandon the boot, not finish it.
+	go func() {
+		select {
+		case <-e.done:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	if err := m.createAndWait(ctx, e, fl); err != nil {
+		select {
+		case <-e.done: // ended on purpose; not a failure to report
+			return
+		default:
+		}
+		m.logf("hub: %s failed to start: %v", e.Pod, err)
+		m.mu.Lock()
+		if cur, ok := m.sessions[e.User]; ok && cur == e {
+			cur.State, cur.Error = Failed, err.Error()
+		}
+		m.mu.Unlock()
+	}
+}
+
+// createAndWait is the boot itself, shared by first start and recycle.
+func (m *Manager) createAndWait(ctx context.Context, e *entry, fl Flavour) error {
+	spec, err := fl.Template.render(patch{
+		Name:   e.Pod,
+		Labels: m.labelsFor(e),
+		Bank:   e.Bank,
+	})
+	if err != nil {
+		return err
+	}
+
+	m.setState(e, Starting, "")
+	if err := m.pods.Create(ctx, spec); err != nil {
+		if !errors.Is(err, ErrPodExists) {
+			return fmt.Errorf("create %s: %w", e.Pod, err)
+		}
+		// Reachable, and not a corner case: a reaped session deletes its
+		// Pod, the candidate presses start again, and a Pod still inside
+		// its 30s grace period owns the name. Waiting for the name is the
+		// whole fix; adopting the old Pod would hand them a cluster from
+		// the session they just lost.
+		m.logf("hub: %s still exists; waiting for it to go", e.Pod)
+		if err := m.waitGone(ctx, e); err != nil {
+			return err
+		}
+		if err := m.pods.Create(ctx, spec); err != nil {
+			return fmt.Errorf("create %s: %w", e.Pod, err)
+		}
+	}
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		pod, err := m.pods.Get(ctx, e.Pod)
+		switch {
+		case err != nil:
+			m.logf("hub: %s: %v", e.Pod, err)
+		case pod.Phase == "Failed" || pod.Phase == "Succeeded":
+			// restartPolicy: Never, so a container exiting is terminal.
+			return fmt.Errorf("pod %s is %s", e.Pod, pod.Phase)
+		case pod.Ready && pod.IP != "":
+			m.mu.Lock()
+			e.addr = fmt.Sprintf("%s:%d", pod.IP, m.cfg.Port)
+			e.State, e.Error = Ready, ""
+			e.LastSeen = m.now()
+			m.mu.Unlock()
+			m.logf("hub: %s is ready", e.Pod)
+			return nil
+		}
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			return fmt.Errorf("waiting for %s: %w", e.Pod, ctx.Err())
+		}
+	}
+}
+
+func (m *Manager) setState(e *entry, st State, errText string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	e.State, e.Error = st, errText
+}
+
+// Get returns a user's session.
+func (m *Manager) Get(user string) (Session, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	e, ok := m.sessions[user]
+	if !ok {
+		return Session{}, ErrNoSession
+	}
+	return e.Session, nil
+}
+
+// Touch records that a user is still there. Called on every proxied
+// request, so it must stay cheap.
+func (m *Manager) Touch(user string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if e, ok := m.sessions[user]; ok {
+		e.LastSeen = m.now()
+	}
+}
+
+// Position reports where a user stands in the queue, 0 if they are not
+// in one.
+func (m *Manager) Position(user string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for kind := range m.queues {
+		for i, w := range m.queues[kind] {
+			if w.user == user {
+				return i + 1
+			}
+		}
+	}
+	return 0
+}
+
+// Seats reports usage for the UI: how many of each flavour are taken.
+func (m *Manager) Seats() map[Kind][2]int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := map[Kind][2]int{}
+	for kind, fl := range m.cfg.Flavours {
+		out[kind] = [2]int{m.usedLocked(kind), fl.Seats}
+	}
+	return out
+}
+
+// End tears a session down and frees its seat.
+func (m *Manager) End(ctx context.Context, user string) error {
+	m.mu.Lock()
+	e, ok := m.sessions[user]
+	if !ok {
+		m.mu.Unlock()
+		m.dequeue(user)
+		return ErrNoSession
+	}
+	delete(m.sessions, user)
+	close(e.done)
+	m.promoteLocked(e.Kind)
+	m.mu.Unlock()
+
+	m.logf("hub: ending %s", e.Pod)
+	if err := m.pods.Delete(ctx, e.Pod); err != nil && !isGone(err) {
+		return fmt.Errorf("session: delete %s: %w", e.Pod, err)
+	}
+	return nil
+}
+
+// Recycle is what a hosted reset or switch actually is: the Pod is
+// replaced. bank empty means reset (same exam, clean cluster); a bank
+// means switch.
+//
+// It returns as soon as the job is accepted, in the conductor's 202
+// shape, and the work continues in the background where the UI polls it.
+func (m *Manager) Recycle(user, bank string) (Job, error) {
+	m.mu.Lock()
+	e, ok := m.sessions[user]
+	if !ok {
+		m.mu.Unlock()
+		return Job{}, ErrNoSession
+	}
+	fl, haveFlavour := m.cfg.Flavours[e.Kind]
+	m.mu.Unlock()
+	if !haveFlavour {
+		return Job{}, fmt.Errorf("%w: %s", ErrNoSuchKind, e.Kind)
+	}
+
+	op, phases := "reset", []Phase{
+		{ID: "stop", Label: "Stop the current session"},
+		{ID: "start", Label: "Start a clean session"},
+		{ID: "verify", Label: "Wait for the exam environment"},
+	}
+	if bank != "" {
+		op = "switch"
+		phases[1].Label = "Start a session on the new exam"
+	}
+	j, ok := e.jobs.begin(op, bank, phases)
+	if !ok {
+		return Job{}, ErrBusy
+	}
+
+	go m.runRecycle(e, fl, bank)
+	return j, nil
+}
+
+func (m *Manager) runRecycle(e *entry, fl Flavour, bank string) {
+	ctx, cancel := context.WithTimeout(context.Background(), m.cfg.BootTimeout+2*time.Minute)
+	defer cancel()
+	// Same watcher as a first boot: a reset the candidate abandoned, or
+	// one whose session was reaped underneath it, must stop rather than
+	// spend twenty minutes waiting for a Pod nobody will use.
+	go func() {
+		select {
+		case <-e.done:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	err := func() error {
+		e.jobs.enter("stop")
+		e.jobs.log("deleting " + e.Pod)
+		if err := m.pods.Delete(ctx, e.Pod); err != nil && !isGone(err) {
+			return err
+		}
+		// A Pod name cannot be reused until the old one is really gone,
+		// and delete is asynchronous — 30s of grace on a session Pod is
+		// 30s during which create returns 409.
+		if err := m.waitGone(ctx, e); err != nil {
+			return err
+		}
+
+		e.jobs.enter("start")
+		m.mu.Lock()
+		if bank != "" {
+			e.Bank = bank
+		}
+		now := m.now()
+		e.StartedAt, e.LastSeen = now, now
+		e.ExpiresAt = now.Add(m.cfg.MaxAge)
+		e.addr, e.State, e.Error = "", Pending, ""
+		m.mu.Unlock()
+
+		// Through the same semaphore as a first boot: a recycle costs
+		// exactly what a boot costs, and is no more entitled to a core.
+		select {
+		case m.boot <- struct{}{}:
+		case <-e.done:
+			return errors.New("session ended")
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		defer func() { <-m.boot }()
+
+		e.jobs.log("creating " + e.Pod)
+		e.jobs.enter("verify")
+		return m.createAndWait(ctx, e, fl)
+	}()
+
+	if err != nil {
+		e.jobs.log("failed: " + err.Error())
+		m.mu.Lock()
+		e.State, e.Error = Failed, err.Error()
+		m.mu.Unlock()
+		m.logf("hub: recycle of %s failed: %v", e.Pod, err)
+	} else {
+		e.jobs.log(e.Pod + " is ready")
+	}
+	e.jobs.finish(err)
+}
+
+func (m *Manager) waitGone(ctx context.Context, e *entry) error {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		_, err := m.pods.Get(ctx, e.Pod)
+		if isGone(err) {
+			return nil
+		}
+		e.jobs.detail("waiting for the old session to shut down")
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			return fmt.Errorf("waiting for %s to go away: %w", e.Pod, ctx.Err())
+		}
+	}
+}
+
+// Status and Log expose one user's control job in the conductor's shape.
+func (m *Manager) Status(user string) (Snapshot, error) {
+	m.mu.Lock()
+	e, ok := m.sessions[user]
+	m.mu.Unlock()
+	if !ok {
+		return Snapshot{}, ErrNoSession
+	}
+	return e.jobs.snapshot(), nil
+}
+
+func (m *Manager) Log(user string) (string, []string, error) {
+	m.mu.Lock()
+	e, ok := m.sessions[user]
+	m.mu.Unlock()
+	if !ok {
+		return "", nil, ErrNoSession
+	}
+	id, lines := e.jobs.logLines()
+	return id, lines, nil
+}
+
+// Reap enforces every time limit and reconciles against the cluster. Run
+// it on a ticker; it is the only thing that ends a session nobody ended
+// deliberately.
+func (m *Manager) Reap(ctx context.Context) {
+	now := m.now()
+
+	m.mu.Lock()
+	// Lapsed holds first, so a seat a vanished user was granted returns
+	// to the queue rather than staying reserved for them.
+	for kind, q := range m.queues {
+		kept := q[:0]
+		for _, w := range q {
+			if !w.holdUntil.IsZero() && now.After(w.holdUntil) {
+				m.logf("hub: %s did not claim its %s seat in time", w.user, kind)
+				continue
+			}
+			kept = append(kept, w)
+		}
+		m.queues[kind] = kept
+		m.promoteLocked(kind)
+	}
+
+	type doomed struct {
+		e      *entry
+		reason string
+	}
+	var kill []doomed
+	for user, e := range m.sessions {
+		switch {
+		case now.After(e.ExpiresAt):
+			kill = append(kill, doomed{e, "reached the maximum session length"})
+		case now.Sub(e.LastSeen) > m.cfg.IdleAfter:
+			kill = append(kill, doomed{e, "was idle"})
+		default:
+			continue
+		}
+		delete(m.sessions, user)
+		close(e.done)
+	}
+	for _, d := range kill {
+		m.promoteLocked(d.e.Kind)
+	}
+	// A snapshot of what is left, to reconcile without holding the lock
+	// across API calls.
+	live := make([]*entry, 0, len(m.sessions))
+	for _, e := range m.sessions {
+		live = append(live, e)
+	}
+	m.mu.Unlock()
+
+	for _, d := range kill {
+		m.logf("hub: reaping %s: it %s", d.e.Pod, d.reason)
+		if err := m.pods.Delete(ctx, d.e.Pod); err != nil && !isGone(err) {
+			m.logf("hub: delete %s: %v", d.e.Pod, err)
+		}
+	}
+
+	// Reconcile: a Pod evicted, OOM-killed or lost with its node leaves a
+	// session record holding a seat for something that no longer exists.
+	for _, e := range live {
+		m.mu.Lock()
+		st, booting := e.State, e.State == Pending || e.State == Starting
+		m.mu.Unlock()
+		if booting {
+			continue // the boot is watching it already
+		}
+		pod, err := m.pods.Get(ctx, e.Pod)
+		if isGone(err) || (err == nil && pod.Terminating) {
+			m.logf("hub: %s disappeared; freeing the seat", e.Pod)
+			m.mu.Lock()
+			if cur, ok := m.sessions[e.User]; ok && cur == e {
+				delete(m.sessions, e.User)
+				close(e.done)
+				m.promoteLocked(e.Kind)
+			}
+			m.mu.Unlock()
+			continue
+		}
+		if err == nil && st == Ready && !pod.Ready {
+			m.setState(e, Starting, "")
+		}
+	}
+}
+
+// Adopt re-attaches to Pods that outlived the hub process.
+//
+// Sessions live in the cluster, not in this process's memory: a hub
+// redeployed mid-exam that forgot its sessions would strand every
+// candidate behind a queue for seats that are already taken, with their
+// own Pods running and unreachable.
+func (m *Manager) Adopt(ctx context.Context) error {
+	pods, err := m.pods.List(ctx, m.selector())
+	if err != nil {
+		return fmt.Errorf("session: list existing sessions: %w", err)
+	}
+	now := m.now()
+	adopted := 0
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, pod := range pods {
+		user := pod.Labels["kubestronaut-sim/user"]
+		kind := Kind(pod.Labels["kubestronaut-sim/kind"])
+		if user == "" || pod.Terminating {
+			continue
+		}
+		if _, taken := m.sessions[user]; taken {
+			continue
+		}
+		started := pod.CreatedAt
+		if started.IsZero() {
+			started = now
+		}
+		e := &entry{
+			Session: Session{
+				User: user, Kind: kind, Bank: pod.Labels["kubestronaut-sim/bank"],
+				Pod: pod.Name, StartedAt: started, LastSeen: now,
+				ExpiresAt: started.Add(m.cfg.MaxAge),
+				State:     Starting,
+			},
+			done: make(chan struct{}),
+		}
+		e.jobs.now = m.now
+		if pod.Ready && pod.IP != "" {
+			e.State = Ready
+			e.addr = fmt.Sprintf("%s:%d", pod.IP, m.cfg.Port)
+		}
+		m.sessions[user] = e
+		adopted++
+	}
+	if adopted > 0 {
+		m.logf("hub: adopted %d session(s) already running", adopted)
+	}
+	return nil
+}
+
+// Run drives Reap until ctx is cancelled.
+func (m *Manager) Run(ctx context.Context, every time.Duration) {
+	if every <= 0 {
+		every = 30 * time.Second
+	}
+	t := time.NewTicker(every)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			m.Reap(ctx)
+		}
+	}
+}
+
+// --- seats and the queue -------------------------------------------
+
+// usedLocked counts seats that are spoken for: running sessions plus
+// outstanding holds. Holds count, or the seat a queued user was just
+// granted would be taken by whoever asked next.
+func (m *Manager) usedLocked(kind Kind) int {
+	n := 0
+	for _, e := range m.sessions {
+		if e.Kind == kind {
+			n++
+		}
+	}
+	for _, w := range m.queues[kind] {
+		if !w.holdUntil.IsZero() {
+			n++
+		}
+	}
+	return n
+}
+
+// claimLocked converts this user's outstanding hold into a seat.
+func (m *Manager) claimLocked(user string, kind Kind) bool {
+	for _, w := range m.queues[kind] {
+		if w.user == user && !w.holdUntil.IsZero() && !m.now().After(w.holdUntil) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Manager) enqueueLocked(user string, kind Kind) int {
+	for i, w := range m.queues[kind] {
+		if w.user == user {
+			return i + 1
+		}
+	}
+	m.queues[kind] = append(m.queues[kind], &waiter{user: user, kind: kind, joined: m.now()})
+	// Stable by arrival, so a restart or a map iteration cannot reorder
+	// people who have been waiting.
+	sort.SliceStable(m.queues[kind], func(i, j int) bool {
+		return m.queues[kind][i].joined.Before(m.queues[kind][j].joined)
+	})
+	m.promoteLocked(kind)
+	return len(m.queues[kind])
+}
+
+func (m *Manager) dequeueLocked(user string) {
+	for kind, q := range m.queues {
+		for i, w := range q {
+			if w.user == user {
+				m.queues[kind] = append(q[:i], q[i+1:]...)
+				break
+			}
+		}
+	}
+}
+
+func (m *Manager) dequeue(user string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.dequeueLocked(user)
+}
+
+// promoteLocked hands the head of the queue a hold if a seat is free.
+func (m *Manager) promoteLocked(kind Kind) {
+	fl, ok := m.cfg.Flavours[kind]
+	if !ok {
+		return
+	}
+	q := m.queues[kind]
+	for i := 0; i < len(q) && m.usedLocked(kind) < fl.Seats; i++ {
+		if q[i].holdUntil.IsZero() {
+			q[i].holdUntil = m.now().Add(m.cfg.HoldFor)
+			m.logf("hub: %s may claim a %s seat within %s", q[i].user, kind, m.cfg.HoldFor)
+		}
+	}
+}
+
+func (m *Manager) labelsFor(e *entry) map[string]string {
+	out := map[string]string{}
+	for k, v := range m.cfg.Labels {
+		out[k] = v
+	}
+	out["kubestronaut-sim/user"] = e.User
+	out["kubestronaut-sim/kind"] = string(e.Kind)
+	if e.Bank != "" {
+		out["kubestronaut-sim/bank"] = e.Bank
+	}
+	return out
+}
+
+func (m *Manager) selector() string {
+	// One label is enough to find this hub's Pods and it is the one the
+	// manager always sets.
+	return "kubestronaut-sim/user"
+}
+
+func (m *Manager) podName(user string, kind Kind) string {
+	return fmt.Sprintf("%s-%s-%s", m.cfg.PodPrefix, kind, podNameSafe(user))
+}
+
+// isGone treats "already deleted" as done rather than as an error, for
+// every caller that wanted it deleted.
+func isGone(err error) bool {
+	return err != nil && errors.Is(err, ErrPodGone)
+}
+
+// The two conditions a Pods implementation must report distinguishably,
+// declared here rather than imported from kube so this package does not
+// depend on the transport. An adapter that forgets to translate its own
+// not-found sentinel turns "the Pod is gone" into "something went wrong",
+// and the manager would wait out a full timeout for a Pod that already
+// vanished — so the adapter is where this is tested.
+var (
+	ErrPodGone   = errors.New("session: pod does not exist")
+	ErrPodExists = errors.New("session: pod already exists")
+)
+
+// podNameSafe turns a user identifier into a DNS-1123 label.
+//
+// A GitHub numeric ID already is one. Header mode's identifier is
+// whatever the upstream proxy sets, and an uppercase letter or an
+// underscore there is not a validation error the candidate could ever
+// act on — it is a 422 from the API server that reads like a hub bug.
+func podNameSafe(s string) string {
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
+			out = append(out, r)
+		case r >= 'A' && r <= 'Z':
+			out = append(out, r+('a'-'A'))
+		default:
+			out = append(out, '-')
+		}
+	}
+	// Must start and end alphanumeric, and a Pod name is capped at 253.
+	s = strings.Trim(string(out), "-")
+	if s == "" {
+		s = "anon"
+	}
+	if len(s) > 40 {
+		s = strings.TrimRight(s[:40], "-")
+	}
+	return s
+}

--- a/hub/internal/session/session_test.go
+++ b/hub/internal/session/session_test.go
@@ -18,7 +18,7 @@ type fakePods struct {
 	created []string
 	// notReady names Pods that never become ready, to exercise the
 	// waiting paths.
-	notReady map[string]bool
+	notReady   map[string]bool
 	failCreate error
 }
 

--- a/hub/internal/session/session_test.go
+++ b/hub/internal/session/session_test.go
@@ -1,0 +1,466 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakePods is an in-memory cluster. It exists so the manager's rules —
+// seats, queue, holds, reaping — are tested without an API server, and
+// so a test can hold a Pod un-ready for as long as it likes.
+type fakePods struct {
+	mu      sync.Mutex
+	pods    map[string]*Pod
+	created []string
+	// notReady names Pods that never become ready, to exercise the
+	// waiting paths.
+	notReady map[string]bool
+	failCreate error
+}
+
+func newFakePods() *fakePods {
+	return &fakePods{pods: map[string]*Pod{}, notReady: map[string]bool{}}
+}
+
+func (f *fakePods) Create(_ context.Context, spec []byte) error {
+	var pod struct {
+		Metadata struct {
+			Name   string            `json:"name"`
+			Labels map[string]string `json:"labels"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(spec, &pod); err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failCreate != nil {
+		return f.failCreate
+	}
+	name := pod.Metadata.Name
+	if _, exists := f.pods[name]; exists {
+		return ErrPodExists
+	}
+	f.created = append(f.created, name)
+	f.pods[name] = &Pod{
+		Name: name, IP: "10.42.0.9", Phase: "Running",
+		Ready: !f.notReady[name], CreatedAt: time.Now(), Labels: pod.Metadata.Labels,
+	}
+	return nil
+}
+
+func (f *fakePods) Get(_ context.Context, name string) (Pod, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	p, ok := f.pods[name]
+	if !ok {
+		return Pod{}, ErrPodGone
+	}
+	return *p, nil
+}
+
+func (f *fakePods) Delete(_ context.Context, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.pods[name]; !ok {
+		return ErrPodGone
+	}
+	delete(f.pods, name)
+	return nil
+}
+
+func (f *fakePods) List(context.Context, string) ([]Pod, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []Pod
+	for _, p := range f.pods {
+		out = append(out, *p)
+	}
+	return out, nil
+}
+
+func (f *fakePods) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.pods)
+}
+
+const miniTemplate = `{"kind":"Pod","metadata":{},"spec":{"containers":[{"name":"facilitator","env":[{"name":"BANK","value":"x"}]}]}}`
+
+func newManager(t *testing.T, seats int, tweak func(*Config)) (*Manager, *fakePods) {
+	t.Helper()
+	pods := newFakePods()
+	cfg := Config{
+		Flavours: map[Kind]Flavour{
+			Practical: {Seats: seats, Template: Template(miniTemplate), Bank: "ckad-mock-01"},
+		},
+		HoldFor:   time.Minute,
+		IdleAfter: 30 * time.Minute,
+		MaxAge:    10 * time.Hour,
+		Logf:      func(string, ...any) {},
+	}
+	if tweak != nil {
+		tweak(&cfg)
+	}
+	return New(pods, cfg), pods
+}
+
+// waitReady polls the manager the way the SPA does.
+func waitReady(t *testing.T, m *Manager, user string) Session {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		s, err := m.Get(user)
+		if err == nil && s.State == Ready {
+			return s
+		}
+		if err == nil && s.State == Failed {
+			t.Fatalf("%s failed: %s", user, s.Error)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	s, _ := m.Get(user)
+	t.Fatalf("%s never became ready (state %q)", user, s.State)
+	return Session{}
+}
+
+func TestStartCreatesAPodAndBecomesReady(t *testing.T) {
+	m, pods := newManager(t, 1, nil)
+	ctx := context.Background()
+
+	s, err := m.Start(ctx, "583231", Practical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Admission returns immediately: the boot takes minutes and the
+	// browser polls.
+	if s.State != Pending {
+		t.Errorf("state = %q, want pending", s.State)
+	}
+	live := waitReady(t, m, "583231")
+	if live.Addr() != "10.42.0.9:8080" {
+		t.Errorf("addr = %q", live.Addr())
+	}
+	if pods.count() != 1 {
+		t.Errorf("%d pods exist, want 1", pods.count())
+	}
+	// Idempotent: a second start returns the same session, not a second
+	// Pod and not a queue position.
+	if _, err := m.Start(ctx, "583231", Practical); err != nil {
+		t.Fatal(err)
+	}
+	if pods.count() != 1 {
+		t.Errorf("a second start created a second pod")
+	}
+}
+
+// A seat is held from admission, not from readiness. Counting only ready
+// sessions would admit a second candidate while the first is still
+// booting, and hand both of them a half-built cluster.
+func TestASeatIsHeldWhileTheSessionIsStillBooting(t *testing.T) {
+	m, pods := newManager(t, 1, nil)
+	pods.notReady["sim-session-practical-first"] = true
+	ctx := context.Background()
+
+	if _, err := m.Start(ctx, "first", Practical); err != nil {
+		t.Fatal(err)
+	}
+	_, err := m.Start(ctx, "second", Practical)
+	var q *Queued
+	if !errors.As(err, &q) {
+		t.Fatalf("second candidate got %v, want a queue position", err)
+	}
+	if q.Position != 1 {
+		t.Errorf("position = %d, want 1", q.Position)
+	}
+}
+
+// The queue hands the head a time-boxed hold, not a seat. A browser that
+// closed an hour ago must not keep one warm.
+func TestTheQueueHeadGetsAHoldAndOnlyTheyCanClaimIt(t *testing.T) {
+	now := time.Now()
+	m, _ := newManager(t, 1, func(c *Config) {
+		c.HoldFor = time.Minute
+		c.Now = func() time.Time { return now }
+	})
+	ctx := context.Background()
+
+	if _, err := m.Start(ctx, "holder", Practical); err != nil {
+		t.Fatal(err)
+	}
+	waitReady(t, m, "holder")
+
+	// Two candidates queue, in order.
+	for _, u := range []string{"queued-1", "queued-2"} {
+		if _, err := m.Start(ctx, u, Practical); err == nil {
+			t.Fatalf("%s was admitted with no free seat", u)
+		}
+	}
+	if got := m.Position("queued-1"); got != 1 {
+		t.Errorf("queued-1 position = %d, want 1", got)
+	}
+
+	// The seat frees. The head — and only the head — may take it.
+	if err := m.End(ctx, "holder"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.Start(ctx, "queued-2", Practical); err == nil {
+		t.Error("queued-2 jumped the queue")
+	}
+	if _, err := m.Start(ctx, "queued-1", Practical); err != nil {
+		t.Fatalf("the head of the queue could not claim its seat: %v", err)
+	}
+	waitReady(t, m, "queued-1")
+	if got := m.Position("queued-1"); got != 0 {
+		t.Errorf("queued-1 is still in the queue at %d", got)
+	}
+}
+
+// A hold nobody claims must lapse, or one vanished browser costs a seat
+// for as long as the deployment runs.
+func TestAnUnclaimedHoldLapsesAndThePersonBehindGetsTheSeat(t *testing.T) {
+	now := time.Now()
+	clock := func() time.Time { return now }
+	m, _ := newManager(t, 1, func(c *Config) {
+		c.HoldFor = time.Minute
+		c.Now = clock
+	})
+	ctx := context.Background()
+
+	if _, err := m.Start(ctx, "holder", Practical); err != nil {
+		t.Fatal(err)
+	}
+	waitReady(t, m, "holder")
+	m.Start(ctx, "ghost", Practical)
+	m.Start(ctx, "patient", Practical)
+	if err := m.End(ctx, "holder"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The ghost never comes back.
+	now = now.Add(2 * time.Minute)
+	m.Reap(ctx)
+
+	if got := m.Position("ghost"); got != 0 {
+		t.Errorf("ghost is still queued at %d", got)
+	}
+	if _, err := m.Start(ctx, "patient", Practical); err != nil {
+		t.Fatalf("patient still cannot start after the hold lapsed: %v", err)
+	}
+}
+
+// Boot is CPU-bound: one booting session took a 4-core node to 77% CPU.
+// Two at once do not take turns, they both crawl — so the manager must
+// not have two Pods booting simultaneously.
+func TestPodCreationIsSerialised(t *testing.T) {
+	m, pods := newManager(t, 3, func(c *Config) { c.BootConcurrency = 1 })
+	ctx := context.Background()
+	for _, u := range []string{"a", "b", "c"} {
+		pods.notReady["sim-session-practical-"+u] = true
+	}
+
+	for _, u := range []string{"a", "b", "c"} {
+		if _, err := m.Start(ctx, u, Practical); err != nil {
+			t.Fatalf("%s: %v", u, err)
+		}
+	}
+	// All three hold seats; only one Pod may exist, because the other two
+	// are still waiting for the boot slot.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) && pods.count() == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if n := pods.count(); n != 1 {
+		t.Errorf("%d pods booting at once, want 1", n)
+	}
+}
+
+func TestIdleAndAgedSessionsAreReaped(t *testing.T) {
+	now := time.Now()
+	m, pods := newManager(t, 4, func(c *Config) {
+		c.IdleAfter = 30 * time.Minute
+		c.MaxAge = 2 * time.Hour
+		c.Now = func() time.Time { return now }
+	})
+	ctx := context.Background()
+
+	for _, u := range []string{"idle", "old", "active"} {
+		if _, err := m.Start(ctx, u, Practical); err != nil {
+			t.Fatal(err)
+		}
+		waitReady(t, m, u)
+	}
+
+	now = now.Add(31 * time.Minute)
+	m.Touch("active")
+	m.Touch("old")
+	m.Reap(ctx)
+
+	if _, err := m.Get("idle"); !errors.Is(err, ErrNoSession) {
+		t.Error("an idle session survived the reaper")
+	}
+	if _, err := m.Get("active"); err != nil {
+		t.Error("a session someone is using was reaped")
+	}
+	if pods.count() != 2 {
+		t.Errorf("%d pods left, want 2", pods.count())
+	}
+
+	// The hard cap ignores activity entirely: that is what makes it a cap.
+	now = now.Add(2 * time.Hour)
+	m.Touch("active")
+	m.Touch("old")
+	m.Reap(ctx)
+	for _, u := range []string{"active", "old"} {
+		if _, err := m.Get(u); !errors.Is(err, ErrNoSession) {
+			t.Errorf("%s outlived the maximum session length", u)
+		}
+	}
+}
+
+// A Pod lost with its node, evicted, or deleted by an operator leaves a
+// session record holding a seat for something that no longer exists.
+func TestAVanishedPodFreesItsSeat(t *testing.T) {
+	m, pods := newManager(t, 1, nil)
+	ctx := context.Background()
+	if _, err := m.Start(ctx, "unlucky", Practical); err != nil {
+		t.Fatal(err)
+	}
+	waitReady(t, m, "unlucky")
+
+	if err := pods.Delete(ctx, "sim-session-practical-unlucky"); err != nil {
+		t.Fatal(err)
+	}
+	m.Reap(ctx)
+
+	if _, err := m.Get("unlucky"); !errors.Is(err, ErrNoSession) {
+		t.Error("the session outlived its pod")
+	}
+	if _, err := m.Start(ctx, "next", Practical); err != nil {
+		t.Errorf("the seat was never released: %v", err)
+	}
+}
+
+// Sessions live in the cluster, not in the hub's memory. A hub
+// redeployed mid-exam that forgot them would put every candidate behind
+// a queue for seats that are already taken, with their own Pods running
+// and unreachable.
+func TestAdoptReattachesToRunningSessions(t *testing.T) {
+	m, pods := newManager(t, 2, nil)
+	ctx := context.Background()
+	if _, err := m.Start(ctx, "583231", Practical); err != nil {
+		t.Fatal(err)
+	}
+	waitReady(t, m, "583231")
+
+	// A brand new Manager over the same cluster: the process restarted.
+	fresh := New(pods, Config{
+		Flavours: map[Kind]Flavour{Practical: {Seats: 2, Template: Template(miniTemplate)}},
+		Logf:     func(string, ...any) {},
+	})
+	if err := fresh.Adopt(ctx); err != nil {
+		t.Fatal(err)
+	}
+	got, err := fresh.Get("583231")
+	if err != nil {
+		t.Fatalf("the session was not adopted: %v", err)
+	}
+	if got.State != Ready || got.Addr() != "10.42.0.9:8080" {
+		t.Errorf("adopted session = %+v, addr %q", got, got.Addr())
+	}
+	if seats := fresh.Seats()[Practical]; seats[0] != 1 {
+		t.Errorf("adopted seats used = %d, want 1", seats[0])
+	}
+}
+
+// A reset is a Pod replacement here, reported in the conductor's job
+// shape so ControlProgress renders it with no hosted branch.
+func TestRecycleReplacesThePodAndReportsPhases(t *testing.T) {
+	m, pods := newManager(t, 1, nil)
+	ctx := context.Background()
+	if _, err := m.Start(ctx, "583231", Practical); err != nil {
+		t.Fatal(err)
+	}
+	waitReady(t, m, "583231")
+	before := pods.created[0]
+
+	job, err := m.Recycle("583231", "ckad-mock-02")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.Op != "switch" || job.Bank != "ckad-mock-02" {
+		t.Errorf("job = %+v, want a switch to ckad-mock-02", job)
+	}
+	if len(job.Phases) != 3 {
+		t.Errorf("%d phases, want 3", len(job.Phases))
+	}
+
+	// A second control operation while one is in flight is a 409, as it
+	// is on the conductor.
+	if _, err := m.Recycle("583231", ""); !errors.Is(err, ErrBusy) {
+		t.Errorf("a concurrent recycle gave %v, want ErrBusy", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if snap, _ := m.Status("583231"); !snap.Busy && snap.Last != nil {
+			if snap.Last.Error != "" {
+				t.Fatalf("recycle failed: %s", snap.Last.Error)
+			}
+			for _, p := range snap.Last.Phases {
+				if p.State != PhaseDone {
+					t.Errorf("phase %s ended %q, want done", p.ID, p.State)
+				}
+			}
+			s, _ := m.Get("583231")
+			if s.Bank != "ckad-mock-02" {
+				t.Errorf("bank = %q after the switch", s.Bank)
+			}
+			if len(pods.created) != 2 || pods.created[1] != before {
+				t.Errorf("created = %v, want the pod recreated", pods.created)
+			}
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("the recycle job never finished")
+}
+
+// Reachable, not theoretical: a reaped session deletes its Pod, the
+// candidate presses start again, and the old Pod still owns the name for
+// the length of its grace period.
+func TestStartWaitsOutAPodStillTerminating(t *testing.T) {
+	m, pods := newManager(t, 1, nil)
+	ctx := context.Background()
+
+	// A Pod under the name the next session will want.
+	name := "sim-session-practical-583231"
+	if err := pods.Create(ctx, []byte(`{"metadata":{"name":"`+name+`"}}`)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.Start(ctx, "583231", Practical); err != nil {
+		t.Fatal(err)
+	}
+
+	// It is stuck until the name frees, and then it proceeds.
+	time.Sleep(30 * time.Millisecond)
+	if s, _ := m.Get("583231"); s.State == Ready {
+		t.Fatal("it adopted the pod that was on its way out")
+	}
+	if err := pods.Delete(ctx, name); err != nil {
+		t.Fatal(err)
+	}
+	waitReady(t, m, "583231")
+}
+
+func TestUnknownKindIsRefused(t *testing.T) {
+	m, _ := newManager(t, 1, nil)
+	if _, err := m.Start(context.Background(), "u", MCQ); !errors.Is(err, ErrNoSuchKind) {
+		t.Errorf("err = %v, want ErrNoSuchKind for a flavour this deployment does not offer", err)
+	}
+}

--- a/hub/internal/store/rollup.go
+++ b/hub/internal/store/rollup.go
@@ -1,0 +1,178 @@
+package store
+
+import (
+	"encoding/json"
+	"math"
+	"sort"
+	"time"
+)
+
+// The cross-attempt rollup: the four numbers and the weak-domain ranking
+// that GET /api/history carries beside the attempts.
+//
+// This is a deliberate mirror of facilitator/internal/history's
+// Summarize, and it is worth being explicit about why it is a copy.
+//
+// The hub is a separate Go module. Every module here is stdlib-only with
+// no go.sum, and `history` is an internal package of the facilitator's
+// module — internal is scoped to that module's tree, so it cannot be
+// imported from here whatever the go.mod says. Lifting it out of
+// internal would couple the hub's build to the facilitator's for one
+// function, and the hub's image copies hub/ alone.
+//
+// So: mirrored, narrowly. Only the fields this rollup reads are decoded
+// out of each record — the rest stays raw bytes exactly as it does in
+// Add, so a field added over there still reaches the browser untouched.
+// If the two ever disagree the symptom is a hosted dashboard whose
+// numbers differ from a local one, which is why the parts most likely to
+// drift (which modes count, which certifications the path holds) are
+// stated here rather than inferred.
+
+// track is the certification path this product is named after.
+//
+// A constant of the PROGRAM, not of the banks a deployment ships: the
+// denominator of "3 of 5" must not shrink because a bank is missing.
+var track = []string{"KCNA", "KCSA", "CKA", "CKAD", "CKS"}
+
+// modeTraining is the one mode that is graded but not counted. Training
+// lets the candidate read the solutions while they work, so a training
+// score is not a sitting.
+const modeTraining = "training"
+
+// attempt is the part of a record this rollup reads. Everything else in
+// the record is passed through as bytes.
+type attempt struct {
+	Bank          string          `json:"bank"`
+	Certification string          `json:"certification"`
+	Mode          string          `json:"mode"`
+	DomainFilter  []string        `json:"domainFilter"`
+	GradedAt      time.Time       `json:"gradedAt"`
+	Percent       int             `json:"percent"`
+	Passed        bool            `json:"passed"`
+	Counted       bool            `json:"counted"`
+	Domains       []DomainSummary `json:"domains"`
+}
+
+// counts re-derives the record's own `counted` flag from the two clauses
+// a record can verify about itself, exactly as the facilitator's rollup
+// does. The third clause — that the draw covered the bank's declared
+// length — cannot be checked without that bank loaded, and a record's
+// whole point is being readable without it.
+func (a attempt) counts() bool {
+	return a.Counted && a.Mode != modeTraining && len(a.DomainFilter) == 0
+}
+
+// DomainSummary is one domain rolled up across attempts. Percent is raw
+// points earned over points available, never the curriculum-weighted
+// figure: this ranks a candidate's domains against each other, and how
+// heavily the exam board weights a domain is not part of that question.
+type DomainSummary struct {
+	Domain   string `json:"domain"`
+	Earned   int    `json:"earned"`
+	Total    int    `json:"total"`
+	Percent  int    `json:"percent"`
+	Attempts int    `json:"attempts"`
+}
+
+// Summary is the whole record in four numbers.
+type Summary struct {
+	Attempts int `json:"attempts"`
+	// PassedCount counts distinct TRACK certifications with a counted,
+	// passing attempt; TrackCount is how many the path holds. Restricting
+	// the numerator to the track is what keeps "3 of 5" from reading
+	// "6 of 5" once a bank outside the path exists.
+	PassedCount int             `json:"passedCount"`
+	TrackCount  int             `json:"trackCount"`
+	WeakDomains []DomainSummary `json:"weakDomains"`
+}
+
+// summarize rolls a user's raw records up.
+//
+// A record that will not decode is counted and otherwise skipped rather
+// than failing the request: it was written by a build of the facilitator
+// this one has never met, and one unreadable attempt must not cost the
+// candidate the rest of their history.
+func summarize(records []json.RawMessage) Summary {
+	parsed := decodeAll(records)
+	sum := Summary{
+		Attempts:    len(records),
+		TrackCount:  len(track),
+		WeakDomains: weakDomains(parsed),
+	}
+	inTrack := map[string]bool{}
+	for _, cert := range track {
+		inTrack[cert] = true
+	}
+	passed := map[string]bool{}
+	for _, a := range parsed {
+		if a.counts() && a.Passed && inTrack[a.Certification] {
+			passed[a.Certification] = true
+		}
+	}
+	sum.PassedCount = len(passed)
+	return sum
+}
+
+func decodeAll(records []json.RawMessage) []attempt {
+	out := make([]attempt, 0, len(records))
+	for _, raw := range records {
+		var a attempt
+		if err := json.Unmarshal(raw, &a); err != nil {
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
+// weakDomains ranks every domain the candidate has been graded on,
+// weakest first.
+//
+// Over EVERY attempt, not only the counted ones: "which domains am I
+// weak in" is a different question from "does this count as a sitting",
+// and a drill is the most informative thing a candidate can do about a
+// weak domain. A rollup that ignored drills would keep reporting the
+// weakness they spent all week fixing.
+func weakDomains(attempts []attempt) []DomainSummary {
+	type acc struct{ earned, total, attempts int }
+	totals := map[string]*acc{}
+	var order []string
+	for _, a := range attempts {
+		for _, d := range a.Domains {
+			t, ok := totals[d.Domain]
+			if !ok {
+				t = &acc{}
+				totals[d.Domain] = t
+				order = append(order, d.Domain)
+			}
+			t.earned += d.Earned
+			t.total += d.Total
+			t.attempts++
+		}
+	}
+	// Never nil: the wire contract types this as an array, and a null is
+	// a crash in every caller that maps over it.
+	out := make([]DomainSummary, 0, len(order))
+	for _, name := range order {
+		t := totals[name]
+		// A domain worth no points is an authoring artefact — every check
+		// skipped — not a signal about the candidate.
+		if t.total <= 0 {
+			continue
+		}
+		out = append(out, DomainSummary{
+			Domain:   name,
+			Earned:   t.earned,
+			Total:    t.total,
+			Percent:  int(math.Round(float64(t.earned) / float64(t.total) * 100)),
+			Attempts: t.attempts,
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Percent == out[j].Percent {
+			return out[i].Domain < out[j].Domain
+		}
+		return out[i].Percent < out[j].Percent
+	})
+	return out
+}

--- a/hub/internal/store/rollup_test.go
+++ b/hub/internal/store/rollup_test.go
@@ -1,0 +1,170 @@
+package store
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// attempts are written as JSON text, not as a struct literal, because
+// that is what the store actually holds: bytes the facilitator produced.
+// A struct literal here would only prove this file agrees with itself.
+func raw(t *testing.T, body string) json.RawMessage {
+	t.Helper()
+	if !json.Valid([]byte(body)) {
+		t.Fatalf("test fixture is not JSON: %s", body)
+	}
+	return json.RawMessage(body)
+}
+
+const ckadPass = `{
+  "id": "a1", "bank": "ckad-mock-01", "certification": "CKAD",
+  "mode": "exam", "gradedAt": "2026-01-02T10:00:00Z",
+  "percent": 80, "passed": true, "counted": true,
+  "domains": [
+    {"domain": "Application Design", "earned": 8, "total": 10},
+    {"domain": "Observability", "earned": 2, "total": 10}
+  ]
+}`
+
+const kcnaPass = `{
+  "id": "b2", "bank": "kcna-mock", "certification": "KCNA",
+  "mode": "exam", "gradedAt": "2026-01-03T10:00:00Z",
+  "percent": 90, "passed": true, "counted": true,
+  "domains": [{"domain": "Kubernetes Fundamentals", "earned": 9, "total": 10}]
+}`
+
+// Training is graded and shown, and it is not a sitting: the candidate
+// can read the solutions while they work.
+const ckadTraining = `{
+  "id": "c3", "bank": "ckad-mock-01", "certification": "CKAD",
+  "mode": "training", "gradedAt": "2026-01-04T10:00:00Z",
+  "percent": 100, "passed": true, "counted": true,
+  "domains": [{"domain": "Observability", "earned": 10, "total": 10}]
+}`
+
+// A drill over one domain. 100% here is a good session and not a pass.
+const ckadDrill = `{
+  "id": "d4", "bank": "ckad-mock-01", "certification": "CKAD",
+  "mode": "exam", "domainFilter": ["Observability"],
+  "gradedAt": "2026-01-05T10:00:00Z",
+  "percent": 100, "passed": true, "counted": true,
+  "domains": [{"domain": "Observability", "earned": 10, "total": 10}]
+}`
+
+func TestSummaryCountsOnlyTrackCertificationsThatActuallyCount(t *testing.T) {
+	sum := summarize([]json.RawMessage{
+		raw(t, ckadPass), raw(t, kcnaPass), raw(t, ckadTraining), raw(t, ckadDrill),
+	})
+	if sum.Attempts != 4 {
+		t.Errorf("Attempts = %d, want 4 — every graded attempt is one", sum.Attempts)
+	}
+	if sum.PassedCount != 2 {
+		t.Errorf("PassedCount = %d, want 2 (CKAD and KCNA)", sum.PassedCount)
+	}
+	// The denominator is the program, not the banks a deployment ships.
+	if sum.TrackCount != 5 {
+		t.Errorf("TrackCount = %d, want 5", sum.TrackCount)
+	}
+	if sum.PassedCount > sum.TrackCount {
+		t.Error("'6 of 5' must be unreachable")
+	}
+}
+
+// Neither a training run nor a domain drill is a sitting, and each is
+// excluded by a different clause. Asserted separately because a rollup
+// that dropped one of the two clauses would still pass a test that only
+// used the other.
+func TestNeitherTrainingNorADrillCanPassACertification(t *testing.T) {
+	for name, only := range map[string]string{
+		"training": ckadTraining,
+		"drill":    ckadDrill,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := summarize([]json.RawMessage{raw(t, only)}).PassedCount; got != 0 {
+				t.Errorf("PassedCount = %d, want 0", got)
+			}
+		})
+	}
+}
+
+// A certification outside the Kubestronaut path can be attempted and
+// passed; it must not move the path figure.
+func TestAPassOutsideTheTrackDoesNotCount(t *testing.T) {
+	off := `{"id":"z9","bank":"other","certification":"CKX","mode":"exam",
+	         "gradedAt":"2026-02-01T10:00:00Z","percent":95,"passed":true,"counted":true,
+	         "domains":[{"domain":"Whatever","earned":9,"total":10}]}`
+	sum := summarize([]json.RawMessage{raw(t, off)})
+	if sum.PassedCount != 0 {
+		t.Errorf("PassedCount = %d, want 0", sum.PassedCount)
+	}
+	if sum.Attempts != 1 {
+		t.Errorf("Attempts = %d, want 1 — it still happened", sum.Attempts)
+	}
+}
+
+// Weakest first, across every attempt including the ones that do not
+// count. A rollup that ignored drills would keep reporting the weakness
+// the candidate spent all week fixing.
+func TestWeakDomainsRankWeakestFirstAndIncludeDrills(t *testing.T) {
+	sum := summarize([]json.RawMessage{
+		raw(t, ckadPass), raw(t, ckadDrill),
+	})
+	if len(sum.WeakDomains) != 2 {
+		t.Fatalf("weak domains = %+v, want 2", sum.WeakDomains)
+	}
+	// Observability: 2/10 from the exam plus 10/10 from the drill = 60%.
+	// Application Design: 8/10 = 80%. So Observability ranks first, and
+	// it ranks first only because the drill was included.
+	if sum.WeakDomains[0].Domain != "Observability" {
+		t.Errorf("weakest = %q, want Observability", sum.WeakDomains[0].Domain)
+	}
+	if sum.WeakDomains[0].Percent != 60 {
+		t.Errorf("Observability = %d%%, want 60 — the drill was not rolled in", sum.WeakDomains[0].Percent)
+	}
+	if sum.WeakDomains[0].Attempts != 2 {
+		t.Errorf("Observability attempts = %d, want 2", sum.WeakDomains[0].Attempts)
+	}
+	if sum.WeakDomains[1].Domain != "Application Design" {
+		t.Errorf("second = %q", sum.WeakDomains[1].Domain)
+	}
+}
+
+// A domain worth no points is an authoring artefact — every check
+// skipped — not a candidate scoring zero.
+func TestADomainWorthNoPointsIsNotRanked(t *testing.T) {
+	empty := `{"id":"e5","certification":"CKAD","mode":"exam",
+	           "gradedAt":"2026-01-06T10:00:00Z","counted":true,
+	           "domains":[{"domain":"Skipped","earned":0,"total":0}]}`
+	if got := summarize([]json.RawMessage{raw(t, empty)}).WeakDomains; len(got) != 0 {
+		t.Errorf("weak domains = %+v, want none", got)
+	}
+}
+
+// Never null. The UI maps over this array without checking.
+func TestWeakDomainsMarshalAsAnArrayWhenThereAreNone(t *testing.T) {
+	b, err := json.Marshal(summarize(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := out["weakDomains"].([]any); !ok {
+		t.Errorf("weakDomains = %v, want []", out["weakDomains"])
+	}
+}
+
+// One record written by a build this one has never met must not cost the
+// candidate the rest of their history.
+func TestARecordThatWillNotDecodeIsCountedAndSkipped(t *testing.T) {
+	sum := summarize([]json.RawMessage{
+		raw(t, ckadPass), json.RawMessage(`"not an object"`),
+	})
+	if sum.Attempts != 2 {
+		t.Errorf("Attempts = %d, want 2 — it is still an attempt", sum.Attempts)
+	}
+	if sum.PassedCount != 1 {
+		t.Errorf("PassedCount = %d, want 1 — the readable record still counts", sum.PassedCount)
+	}
+}

--- a/hub/internal/store/store.go
+++ b/hub/internal/store/store.go
@@ -163,6 +163,40 @@ func (s *Store) Document(user string) (Document, error) {
 	return s.documentLocked(user)
 }
 
+// History is what GET /api/history answers with, and it is a different
+// shape from Document on purpose.
+//
+// Document is the INTERCHANGE format: versioned, oldest first, and the
+// thing an export writes and a local `./sim` can import. History is the
+// DASHBOARD format the facilitator serves — most recent first, with the
+// cross-attempt rollup beside it — and the UI's Progress screen reads
+// exactly this. Serving the interchange document here would leave that
+// screen with attempts in grading order and no `summary` at all, which
+// is a blank dashboard rather than a visibly wrong one.
+type History struct {
+	// Never nil: the wire contract types this as an array.
+	Attempts []json.RawMessage `json:"attempts"`
+	Summary  Summary           `json:"summary"`
+}
+
+// History returns one user's attempts, most recent first, with the
+// rollup.
+func (s *Store) History(user string) (History, error) {
+	doc, err := s.Document(user)
+	if err != nil {
+		return History{}, err
+	}
+	// Reversed rather than re-sorted: the document is already in graded
+	// order, which is the order the dashboard wants read backwards, and a
+	// sort here would need to decode every record to find a timestamp
+	// that Add has already used to place it.
+	attempts := make([]json.RawMessage, 0, len(doc.Attempts))
+	for i := len(doc.Attempts) - 1; i >= 0; i-- {
+		attempts = append(attempts, doc.Attempts[i])
+	}
+	return History{Attempts: attempts, Summary: summarize(doc.Attempts)}, nil
+}
+
 // Clear erases one user's history: every attempt and every results
 // blob. There is no undo, which is also true of the facilitator's own
 // DELETE /api/history — the difference is that here it is the only copy

--- a/hub/internal/store/store.go
+++ b/hub/internal/store/store.go
@@ -1,0 +1,286 @@
+// Package store is the hub's durable record of who attempted what.
+//
+// It exists because a session Pod is disposable: its /state volume dies
+// with it, and the hub recycles Pods for reset, switch, idle reap and
+// every crash. The facilitator keeps writing its own history exactly as
+// it always has — that is what a local `./sim up` relies on, and it must
+// not change — and additionally posts a copy here, where it outlives the
+// Pod that produced it.
+//
+// One document per user, not one shared file. Attempts are rare and
+// users are independent, so a shared file would buy nothing and would
+// mean one unreadable record costs everyone their history.
+//
+// Writes are atomic (temp file in the same directory, then os.Rename),
+// the same pattern facilitator/internal/history and phase.sh use. A
+// crash mid-write leaves the previous document intact.
+package store
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"sync"
+	"time"
+)
+
+// documentVersion is the on-disk format this build writes.
+const documentVersion = 1
+
+// Document is the persisted shape, and also exactly what GET
+// /api/history returns — attempts oldest first, which is grading order.
+type Document struct {
+	Version  int               `json:"version"`
+	Attempts []json.RawMessage `json:"attempts"`
+}
+
+// Attempts are stored as raw JSON, deliberately.
+//
+// The facilitator's history.Record has two dozen fields and gains more
+// as the product grows. The hub is a separate module and cannot import
+// it, so a mirrored struct here would be a hand-maintained copy that
+// drifts the first time a field is added over there — and it would drift
+// *silently*, because encoding/json discards unknown fields on the way
+// in. Passing the record through byte for byte means GET /api/history
+// returns precisely what the facilitator would have returned, and the UI
+// needs no branch for hosted mode.
+//
+// Only the two fields the hub itself has to reason about are extracted.
+type header struct {
+	ID       string    `json:"id"`
+	GradedAt time.Time `json:"gradedAt"`
+}
+
+// ErrBadName rejects an identifier that cannot be used as a path
+// element. Callers pass a GitHub numeric user ID and an attempt token,
+// neither of which should ever fail this — which is exactly why a
+// failure means something is wrong rather than something is unusual.
+var ErrBadName = errors.New("store: identifier is not a safe path element")
+
+// ErrNotFound is returned for an attempt with no stored results blob.
+var ErrNotFound = errors.New("store: not found")
+
+// safeName is the whole defence against path traversal. Anything that is
+// not plainly a name is refused rather than escaped, because there is no
+// legitimate caller that needs a slash, a dot-dot or a control character
+// here, and "sanitise it and carry on" is how a traversal gets through.
+var safeName = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$`)
+
+func checkName(kind, s string) error {
+	if !safeName.MatchString(s) {
+		return fmt.Errorf("%w: %s %q", ErrBadName, kind, s)
+	}
+	return nil
+}
+
+// Store is a directory of per-user history documents.
+type Store struct {
+	dir string
+
+	// One mutex for the whole store, not one per user. Attempts arrive
+	// at human pace — a few per hour across every seat — so contention
+	// is not a consideration, and a single lock is one fewer thing to
+	// get wrong than a map of locks that must itself be locked.
+	mu sync.Mutex
+}
+
+// New returns a Store rooted at dir, creating it if needed.
+func New(dir string) (*Store, error) {
+	if dir == "" {
+		return nil, errors.New("store: empty directory")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("store: create %s: %w", dir, err)
+	}
+	return &Store{dir: dir}, nil
+}
+
+// Add records one graded attempt for user, returning whether it was new.
+//
+// Idempotent on the attempt ID, mirroring history.Store.Add: a recovery
+// re-grade, a retried webhook or a duplicate delivery records nothing
+// twice. record is the facilitator's history.Record as received; results
+// is the full graded-results document, which may be nil.
+func (s *Store) Add(user string, record, results json.RawMessage) (bool, error) {
+	if err := checkName("user", user); err != nil {
+		return false, err
+	}
+	var h header
+	if err := json.Unmarshal(record, &h); err != nil {
+		return false, fmt.Errorf("store: unreadable record: %w", err)
+	}
+	if err := checkName("attempt", h.ID); err != nil {
+		return false, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	doc, err := s.documentLocked(user)
+	if err != nil {
+		return false, err
+	}
+	for _, existing := range doc.Attempts {
+		var e header
+		if err := json.Unmarshal(existing, &e); err != nil {
+			continue // a record we cannot read cannot be the duplicate
+		}
+		if e.ID == h.ID {
+			return false, nil
+		}
+	}
+
+	doc.Attempts = append(doc.Attempts, record)
+	sortByGradedAt(doc.Attempts)
+
+	// Results first: a results blob with no attempt referencing it is
+	// invisible, while an attempt whose results 404 is a broken link the
+	// candidate can see.
+	if len(results) > 0 {
+		if err := s.writeResultsLocked(user, h.ID, results); err != nil {
+			return false, err
+		}
+	}
+	if err := s.writeDocumentLocked(user, doc); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// Document returns user's attempts, oldest first. A user who has never
+// attempted anything gets an empty document rather than an error — that
+// is the normal state of a new account, not a failure.
+func (s *Store) Document(user string) (Document, error) {
+	if err := checkName("user", user); err != nil {
+		return Document{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.documentLocked(user)
+}
+
+// Clear erases one user's history: every attempt and every results
+// blob. There is no undo, which is also true of the facilitator's own
+// DELETE /api/history — the difference is that here it is the only copy
+// that outlives the Pod.
+//
+// Removes the user's whole directory rather than truncating the
+// document, so a results blob cannot survive the attempt that referenced
+// it and reappear against a later attempt with a colliding ID.
+func (s *Store) Clear(user string) error {
+	if err := checkName("user", user); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := os.RemoveAll(s.userDir(user)); err != nil {
+		return fmt.Errorf("store: clear history for %s: %w", user, err)
+	}
+	return nil
+}
+
+// Results returns the stored graded-results blob for one attempt.
+func (s *Store) Results(user, attempt string) (json.RawMessage, error) {
+	if err := checkName("user", user); err != nil {
+		return nil, err
+	}
+	if err := checkName("attempt", attempt); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, err := os.ReadFile(s.resultsPath(user, attempt))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("store: read results: %w", err)
+	}
+	return b, nil
+}
+
+func (s *Store) userDir(user string) string  { return filepath.Join(s.dir, user) }
+func (s *Store) docPath(user string) string  { return filepath.Join(s.userDir(user), "history.json") }
+func (s *Store) resultsPath(user, attempt string) string {
+	return filepath.Join(s.userDir(user), "results", attempt+".json")
+}
+
+func (s *Store) documentLocked(user string) (Document, error) {
+	b, err := os.ReadFile(s.docPath(user))
+	if errors.Is(err, os.ErrNotExist) {
+		return Document{Version: documentVersion, Attempts: []json.RawMessage{}}, nil
+	}
+	if err != nil {
+		return Document{}, fmt.Errorf("store: read history: %w", err)
+	}
+	var doc Document
+	if err := json.Unmarshal(b, &doc); err != nil {
+		return Document{}, fmt.Errorf("store: unreadable history for %s: %w", user, err)
+	}
+	if doc.Attempts == nil {
+		doc.Attempts = []json.RawMessage{}
+	}
+	return doc, nil
+}
+
+func (s *Store) writeDocumentLocked(user string, doc Document) error {
+	doc.Version = documentVersion
+	b, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("store: encode history: %w", err)
+	}
+	return writeFileAtomic(s.docPath(user), b)
+}
+
+func (s *Store) writeResultsLocked(user, attempt string, results json.RawMessage) error {
+	return writeFileAtomic(s.resultsPath(user, attempt), results)
+}
+
+// writeFileAtomic writes b to path via a temp file in the same directory
+// and a rename. Same directory matters: rename(2) is only atomic within
+// one filesystem, and a temp dir can be on another.
+func writeFileAtomic(path string, b []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("store: create %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, ".store-*.tmp")
+	if err != nil {
+		return fmt.Errorf("store: temp file in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("store: write %s: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("store: close %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("store: rename %s to %s: %w", tmpPath, path, err)
+	}
+	return nil
+}
+
+// sortByGradedAt keeps attempts oldest first. A record the sort cannot
+// read sorts to the end rather than panicking or being dropped.
+func sortByGradedAt(attempts []json.RawMessage) {
+	at := func(raw json.RawMessage) time.Time {
+		var h header
+		if err := json.Unmarshal(raw, &h); err != nil {
+			return time.Unix(1<<62, 0)
+		}
+		return h.GradedAt
+	}
+	sort.SliceStable(attempts, func(i, j int) bool {
+		return at(attempts[i]).Before(at(attempts[j]))
+	})
+}

--- a/hub/internal/store/store.go
+++ b/hub/internal/store/store.go
@@ -204,8 +204,8 @@ func (s *Store) Results(user, attempt string) (json.RawMessage, error) {
 	return b, nil
 }
 
-func (s *Store) userDir(user string) string  { return filepath.Join(s.dir, user) }
-func (s *Store) docPath(user string) string  { return filepath.Join(s.userDir(user), "history.json") }
+func (s *Store) userDir(user string) string { return filepath.Join(s.dir, user) }
+func (s *Store) docPath(user string) string { return filepath.Join(s.userDir(user), "history.json") }
 func (s *Store) resultsPath(user, attempt string) string {
 	return filepath.Join(s.userDir(user), "results", attempt+".json")
 }

--- a/hub/internal/store/store_test.go
+++ b/hub/internal/store/store_test.go
@@ -1,0 +1,172 @@
+package store
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func newStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return s
+}
+
+func record(id, gradedAt string, extra string) json.RawMessage {
+	return json.RawMessage(`{"id":"` + id + `","gradedAt":"` + gradedAt + `"` + extra + `}`)
+}
+
+// The reason attempts are stored as raw JSON rather than as a struct
+// mirroring the facilitator's history.Record: a field this module has
+// never heard of must survive the round trip. A mirrored struct would
+// drop it silently, and the candidate would lose data the facilitator
+// thought it had saved.
+func TestAnUnknownFieldSurvivesVerbatim(t *testing.T) {
+	s := newStore(t)
+	in := record("a1", "2026-08-03T10:00:00Z", `,"aFieldAddedLater":{"nested":[1,2,3]},"percent":91`)
+
+	if added, err := s.Add("1234", in, nil); err != nil || !added {
+		t.Fatalf("Add = %v, %v; want true, nil", added, err)
+	}
+	doc, err := s.Document("1234")
+	if err != nil {
+		t.Fatalf("Document: %v", err)
+	}
+	if len(doc.Attempts) != 1 {
+		t.Fatalf("attempts = %d, want 1", len(doc.Attempts))
+	}
+	var got, want any
+	if err := json.Unmarshal(doc.Attempts[0], &got); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(in, &want); err != nil {
+		t.Fatal(err)
+	}
+	gotJSON, _ := json.Marshal(got)
+	wantJSON, _ := json.Marshal(want)
+	if string(gotJSON) != string(wantJSON) {
+		t.Errorf("record changed in storage:\n got %s\nwant %s", gotJSON, wantJSON)
+	}
+}
+
+// Recording is idempotent on the attempt ID: a retried webhook, a
+// duplicate delivery or a recovery re-grade must not double-count.
+func TestAddIsIdempotentOnAttemptID(t *testing.T) {
+	s := newStore(t)
+	first := record("a1", "2026-08-03T10:00:00Z", `,"earned":10`)
+	again := record("a1", "2026-08-03T10:00:00Z", `,"earned":10`)
+
+	if added, err := s.Add("1234", first, nil); err != nil || !added {
+		t.Fatalf("first Add = %v, %v; want true, nil", added, err)
+	}
+	added, err := s.Add("1234", again, nil)
+	if err != nil {
+		t.Fatalf("second Add: %v", err)
+	}
+	if added {
+		t.Error("second Add reported the attempt as new")
+	}
+	doc, _ := s.Document("1234")
+	if len(doc.Attempts) != 1 {
+		t.Errorf("attempts = %d, want 1 after a duplicate", len(doc.Attempts))
+	}
+}
+
+func TestAttemptsComeBackOldestFirst(t *testing.T) {
+	s := newStore(t)
+	for _, r := range []json.RawMessage{
+		record("c", "2026-08-03T12:00:00Z", ""),
+		record("a", "2026-08-03T10:00:00Z", ""),
+		record("b", "2026-08-03T11:00:00Z", ""),
+	} {
+		if _, err := s.Add("1234", r, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	doc, _ := s.Document("1234")
+	var ids []string
+	for _, a := range doc.Attempts {
+		var h header
+		json.Unmarshal(a, &h)
+		ids = append(ids, h.ID)
+	}
+	if strings.Join(ids, ",") != "a,b,c" {
+		t.Errorf("order = %v, want a,b,c (oldest first)", ids)
+	}
+}
+
+// The store turns identifiers into path elements, so an identifier that
+// is not plainly a name is refused rather than escaped.
+func TestTraversalAndOddNamesAreRefused(t *testing.T) {
+	s := newStore(t)
+	good := record("a1", "2026-08-03T10:00:00Z", "")
+	for _, bad := range []string{
+		"../etc/passwd", "..", ".", "a/b", "a\\b", "", "with space",
+		"a\x00b", strings.Repeat("x", 65), "-leading-dash",
+	} {
+		if _, err := s.Add(bad, good, nil); !errors.Is(err, ErrBadName) {
+			t.Errorf("Add(user=%q) error = %v, want ErrBadName", bad, err)
+		}
+		if _, err := s.Document(bad); !errors.Is(err, ErrBadName) {
+			t.Errorf("Document(%q) error = %v, want ErrBadName", bad, err)
+		}
+		if _, err := s.Results(bad, "a1"); !errors.Is(err, ErrBadName) {
+			t.Errorf("Results(user=%q) error = %v, want ErrBadName", bad, err)
+		}
+		if _, err := s.Results("1234", bad); !errors.Is(err, ErrBadName) {
+			t.Errorf("Results(attempt=%q) error = %v, want ErrBadName", bad, err)
+		}
+	}
+	// And an attempt ID inside the record is an identifier too — it
+	// reaches the filesystem as the results filename.
+	evil := record("../../escape", "2026-08-03T10:00:00Z", "")
+	if _, err := s.Add("1234", evil, json.RawMessage(`{"x":1}`)); !errors.Is(err, ErrBadName) {
+		t.Errorf("Add with a traversing attempt id = %v, want ErrBadName", err)
+	}
+}
+
+func TestResultsRoundTripAndMissingIsNotFound(t *testing.T) {
+	s := newStore(t)
+	results := json.RawMessage(`{"checks":[{"id":"q01","passed":true}]}`)
+	if _, err := s.Add("1234", record("a1", "2026-08-03T10:00:00Z", ""), results); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.Results("1234", "a1")
+	if err != nil {
+		t.Fatalf("Results: %v", err)
+	}
+	if string(got) != string(results) {
+		t.Errorf("results = %s, want %s", got, results)
+	}
+	if _, err := s.Results("1234", "nosuch"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("missing results error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestUsersAreIsolatedAndNewUsersAreEmptyNotAnError(t *testing.T) {
+	s := newStore(t)
+	if _, err := s.Add("1111", record("a1", "2026-08-03T10:00:00Z", ""), nil); err != nil {
+		t.Fatal(err)
+	}
+
+	doc, err := s.Document("2222")
+	if err != nil {
+		t.Fatalf("a user with no history is not an error: %v", err)
+	}
+	if len(doc.Attempts) != 0 {
+		t.Errorf("new user saw %d attempts, want 0", len(doc.Attempts))
+	}
+	// Empty, not null: the UI iterates this without a nil check.
+	b, _ := json.Marshal(doc)
+	if !strings.Contains(string(b), `"attempts":[]`) {
+		t.Errorf("empty document marshalled as %s, want an empty array", b)
+	}
+	if doc.Version != documentVersion {
+		t.Errorf("version = %d, want %d", doc.Version, documentVersion)
+	}
+}

--- a/images/banks/Dockerfile
+++ b/images/banks/Dockerfile
@@ -1,0 +1,20 @@
+# The question banks, as an image.
+#
+# Under compose, ./banks is bind-mounted read-only into k8s-env, both
+# instances, docs-proxy, the conductor and the facilitator. A Pod has no
+# host to bind from, and those six containers are built from three
+# different Docker contexts, so baking banks into each of them would mean
+# three copies drifting apart and a facilitator rebuild every time a
+# question changes.
+#
+# Instead they ship once, here, and an init container stages them into a
+# shared volume the rest of the Pod mounts read-only. Content, versioned
+# and released like content.
+#
+# The build context is banks/, not the repository root: the root
+# .dockerignore excludes banks/ so it stays out of the facilitator's
+# context, and that exclusion would apply here too.
+#
+#   docker build -f images/banks/Dockerfile -t <repo>/kubestronaut-sim-banks banks/
+FROM alpine:3.21
+COPY . /src

--- a/images/desktop/entrypoint.sh
+++ b/images/desktop/entrypoint.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 echo "waiting for shared ssh key..."
-until [ -f /shared/ssh/id_ed25519 ]; do sleep 2; done
+# -s, not -f: same reason as images/instance/entrypoint.sh. An empty
+# private key installs fine and then fails every `ssh instance-1` the
+# candidate types, which is the entire exam from this container.
+until [ -s /shared/ssh/id_ed25519 ]; do sleep 2; done
 install -d -m 700 -o candidate -g candidate /home/candidate/.ssh
 install -m 600 -o candidate -g candidate /shared/ssh/id_ed25519 /home/candidate/.ssh/id_ed25519
 install -m 644 -o candidate -g candidate /etc/sim/ssh_config /home/candidate/.ssh/config

--- a/images/desktop/entrypoint.sh
+++ b/images/desktop/entrypoint.sh
@@ -42,6 +42,23 @@ until su - candidate -c 'DISPLAY=:1 xset q' >/dev/null 2>&1; do
   sleep 1
 done
 su - candidate -c 'DISPLAY=:1 dbus-launch startxfce4' &
-websockify --web /usr/share/novnc 6080 localhost:5901 &
+# --heartbeat sends a WebSocket Ping every 30s. A VNC session with a
+# still screen and nobody typing sends nothing at all, and a hosted
+# session's stream crosses a CDN that closes an idle WebSocket after
+# about 100 seconds. The candidate then sees the desktop drop while
+# they are reading a question.
+#
+# It belongs here and not in the facilitator's desktop proxy, which is
+# where it was first proposed: that proxy hijacks the connection after
+# the 101 and splices raw bytes: it does not parse frames, so a ping
+# injected there would land in the middle of whatever frame was in
+# flight. websockify owns the WebSocket protocol state at this end, so
+# its ping is well-formed and every proxy between here and the browser
+# — the facilitator, the hub, the CDN — just sees bytes moving, which
+# is what an idle timer measures. The browser answers Pong itself; no
+# UI change and nothing for noVNC to know about.
+#
+# Harmless under compose, where nothing was going to time out anyway.
+websockify --heartbeat=30 --web /usr/share/novnc 6080 localhost:5901 &
 echo "desktop ready: noVNC on :6080"
 wait -n   # exit (and let compose restart us) if any component dies

--- a/images/instance/Dockerfile
+++ b/images/instance/Dockerfile
@@ -31,6 +31,54 @@ COPY registries.conf /etc/containers/registries.conf
 COPY storage.conf /etc/containers/storage.conf
 COPY containers.conf /etc/containers/containers.conf
 
+# chroot, not the default oci isolation, for the RUN steps of a build.
+#
+# `cgroups = "disabled"` in containers.conf covers `podman run`, but a
+# build is buildah, and buildah still asks crun for a real container per
+# RUN step. Under compose that works because `cgroup: host` hands the
+# instance the host's cgroup namespace. Kubernetes has no pod-spec field
+# for cgroup namespace mode and gives an unprivileged container a private
+# one, where crun dies twice over — first
+#
+#   opening file `/sys/fs/cgroup/cgroup.subtree_control` for writing:
+#   Read-only file system
+#
+# and then, once that mount is made writable, on the eBPF program it
+# attaches for cgroup v2 device control:
+#
+#   bpf query: Operation not permitted
+#
+# Neither CAP_BPF and CAP_PERFMON nor a read-write bind of the host's
+# /sys/fs/cgroup moves it; all four combinations were measured in a pod.
+# The only two things that work are granting the container `privileged`
+# — which would make a candidate's shell the most privileged container
+# in the pod — or skipping the runtime for RUN steps, which is this.
+#
+# What it costs: a RUN step executes in a chroot rather than a container,
+# so it gets no namespaces of its own. Nothing here needs them — the
+# images the questions build are deliberately tiny, and the candidate is
+# already root in this container. What it buys is one image that behaves
+# the same under compose and under Kubernetes, with the capability set
+# unchanged. Revisit if a question ever needs a RUN step that isolates.
+#
+# Set three ways because no single one reaches every caller, and the one
+# that matters most is the one a candidate actually types:
+#
+#   ENV               only reaches processes the runtime execs directly
+#                     (`compose exec`, `kubectl exec`). sshd sanitises the
+#                     environment for login sessions, so it never reaches
+#                     a candidate's shell.
+#   /etc/environment  pam_env reads it for every login session, which is
+#                     how `ssh instance-1` from the exam desktop gets it.
+#   sudoers env_keep  sudo resets the environment, and q09 requires sudo
+#                     ("rootless builds fail outright on these
+#                     instances"), so without this the candidate's own
+#                     `sudo podman build` is the one path still broken.
+ENV BUILDAH_ISOLATION=chroot
+RUN echo 'BUILDAH_ISOLATION=chroot' >> /etc/environment \
+    && echo 'Defaults env_keep += "BUILDAH_ISOLATION"' > /etc/sudoers.d/buildah \
+    && chmod 0440 /etc/sudoers.d/buildah
+
 # Editor defaults. /etc/vim/vimrc.local is Debian's supported hook and is
 # sourced after defaults.vim, so it survives a candidate creating their own
 # ~/.vimrc — which would otherwise silently disable syntax highlighting,

--- a/images/instance/entrypoint.sh
+++ b/images/instance/entrypoint.sh
@@ -9,7 +9,13 @@ set -euo pipefail
 # and does nothing.
 echo "waiting for cluster kubeconfig..."
 wait_deadline=$((SECONDS + ${INSTANCE_WAIT_BUDGET:-2400}))
-until [ -f /shared/kubeconfig ] && [ -f /shared/ssh/id_ed25519.pub ]; do
+# -s, not -f: a zero-byte file is a file, and the whole failure this
+# guards against is copying one. bootstrap.sh now renames both of these
+# into place so the window is closed at the source; this stays because a
+# reader that accepts an empty kubeconfig hands the candidate a kubectl
+# that silently talks to its localhost:8080 default instead of the
+# cluster, which is a far worse failure than waiting two more seconds.
+until [ -s /shared/kubeconfig ] && [ -s /shared/ssh/id_ed25519.pub ]; do
   if [ "$SECONDS" -ge "$wait_deadline" ]; then
     echo "gave up waiting for /shared/kubeconfig — k8s-env never finished bootstrapping" >&2
     echo "check it with: docker compose logs k8s-env" >&2
@@ -103,5 +109,41 @@ if command -v podman >/dev/null 2>&1; then
   done
 fi
 
-echo "instance ready: $(hostname)"
-exec /usr/sbin/sshd -D -e
+echo "instance ready: ${SIM_HOSTNAME:-$(hostname)}"
+
+# SSHD_LISTEN exists for the hosted deployment, where both instances live
+# in one network namespace and would otherwise fight over port 22. All of
+# 127.0.0.0/8 routes to loopback, so each instance takes its own address
+# and keeps the port — which means `ssh instance-1` and the facilitator's
+# sshArgs both keep working with no ssh_config, no -p and no code change.
+# Unset under compose, where every instance has a namespace to itself.
+set -- /usr/sbin/sshd -D -e
+if [ -n "${SSHD_LISTEN:-}" ]; then
+  set -- "$@" -o "ListenAddress=$SSHD_LISTEN"
+fi
+
+# SIM_HOSTNAME is the same deployment and the next namespace up. A Pod
+# shares one UTS namespace across every container, so `hostname` — and
+# therefore the shell prompt — reads the Pod's name on the desktop and on
+# both instances alike. A candidate who types `ssh instance-1` then sees
+# a prompt identical to the one they typed it at, and cannot tell whether
+# it worked. On a timed exam that is reason enough on its own; nothing
+# else reads the hostname (this file's log line, and no bank content, no
+# validate.d check and no Go anywhere).
+#
+# A private UTS namespace rather than a PS1 override, so `hostname`
+# itself becomes correct and anything added later that asks the system
+# gets the right answer too. It needs CAP_SYS_ADMIN, which these
+# containers already carry for the image builds — so this grants nothing
+# new. Probed rather than assumed: an instance that cannot unshare for
+# any reason still starts sshd, because failing at the last line of the
+# entrypoint would cost the candidate the whole instance to fix a prompt.
+#
+# Unset under compose, where each container already has a UTS namespace
+# of its own and the hostname is already the service name.
+if [ -n "${SIM_HOSTNAME:-}" ] && unshare --uts true 2>/dev/null; then
+  exec unshare --uts -- sh -c \
+    'hostname "$1" || echo "warning: could not set hostname to $1" >&2; shift; exec "$@"' \
+    sh "$SIM_HOSTNAME" "$@"
+fi
+exec "$@"

--- a/images/k8s-env/Dockerfile
+++ b/images/k8s-env/Dockerfile
@@ -6,10 +6,22 @@ ARG CALICO_VERSION=v3.32.1
 ARG INGRESS_NGINX_VERSION=controller-v1.15.1
 ARG NODE_IMAGE=kindest/node:v1.35.5@sha256:ce977ae6d65918d0b58a5f8b5e940429c2ce42fa3a5619ec2bbc60b949c0ac95
 ENV NODE_IMAGE=${NODE_IMAGE}
+# The same constant again, as a file, because an ENV only reaches
+# processes descended from PID 1. On a hosted reset the conductor re-runs
+# bootstrap.sh over ssh (ENGINE=ssh) and an sshd session inherits none of
+# the image's environment: the rebuild aborted at `set -u` with
+# "NODE_IMAGE: unbound variable" — after it had already deleted the old
+# cluster, so the session was left with no cluster at all. A build-time
+# constant must not depend on how the script reading it was invoked.
+RUN mkdir -p /opt/sim && printf '%s' "${NODE_IMAGE}" > /opt/sim/node-image
 # busybox-extras is here for exactly one applet: httpd, which serves the
 # packaged Helm charts (see start.sh). Alpine's base busybox is built
 # without it.
-RUN apk add --no-cache bash curl jq yq openssh-client openssl busybox-extras
+# openssh-server, not just the client: the hosted deployment runs the
+# whole stack as one Pod, where the conductor has no Docker socket and
+# reaches this container over ssh instead (ENGINE=ssh). Idle and unused
+# under compose, which never sets SSHD_LISTEN — see start.sh.
+RUN apk add --no-cache bash curl jq yq openssh-client openssh-server openssl busybox-extras
 RUN ARCH=$(uname -m); case "$ARCH" in x86_64) ARCH=amd64 ;; aarch64) ARCH=arm64 ;; esac \
     && curl -fsSL -o /usr/local/bin/kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-${ARCH}" \
     && curl -fsSL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl" \

--- a/images/k8s-env/bootstrap.sh
+++ b/images/k8s-env/bootstrap.sh
@@ -18,11 +18,52 @@ fi
 BANK=${BANK:?BANK env var or /shared/bank required}
 BANK_DIR="/banks/${BANK}"
 [ -f "${BANK_DIR}/exam.yaml" ] || { echo "no exam.yaml in ${BANK_DIR}"; exit 1; }
-[ -f /shared/bank ] || printf '%s' "${BANK}" > /shared/bank
+# Same shape as the bank above — a value that may or may not be in the
+# environment — for a different reason. NODE_IMAGE is a build-time
+# constant delivered as an image ENV, and an ENV only reaches processes
+# descended from PID 1. A hosted reset re-runs this script over ssh
+# (ENGINE=ssh in the conductor), where the environment is empty, and
+# `set -u` aborted the rebuild below *after* the old cluster was already
+# deleted. The Dockerfile writes the file; it is always right, and it does
+# not care how this script was started.
+NODE_IMAGE="${NODE_IMAGE:-$(cat /opt/sim/node-image)}"
+# Every file this script hands to another container is written to a
+# temporary name and renamed into place. `>` truncates first and fills
+# after, so a reader that polls for existence can — and does — open a
+# file that is real, zero bytes long, and about to be filled in.
+#
+# Under compose that window is unreachable: instance-1, instance-2 and
+# desktop all declare `depends_on: k8s-env: {condition: service_healthy}`,
+# so they do not start until this script has finished. A Pod has no
+# depends_on and starts all eight containers at once, which puts the
+# instances straight into the window. Measured, not theorised: a session
+# pod booted with instance-1 holding a 5574-byte kubeconfig and
+# instance-2 holding a 0-byte one, and kubectl on instance-2 then fell
+# back to its localhost:8080 default — the facilitator — and failed every
+# command with "invalid character '<'" for the rest of the exam.
+#
+# rename(2) within one filesystem is atomic, so a reader sees the old
+# file or the new one and never a half-written one. Cheap, and it removes
+# the startup-ordering assumption rather than documenting it.
+write_shared() {   # write_shared DEST  <content on stdin>
+  cat > "$1.tmp" && mv "$1.tmp" "$1"
+}
+
+[ -f /shared/bank ] || printf '%s' "${BANK}" | write_shared /shared/bank
 
 rm -f /shared/ready
 mkdir -p /shared/ssh
-[ -f /shared/ssh/id_ed25519 ] || ssh-keygen -t ed25519 -N '' -f /shared/ssh/id_ed25519 -q
+# Both halves of the keypair land by rename, public half first: the
+# private key is this block's own idempotence guard, and it is what the
+# desktop waits for, so it must be the last thing to appear. Once it is
+# there, both files are complete.
+if [ ! -f /shared/ssh/id_ed25519 ]; then
+  keytmp=$(mktemp -d /shared/ssh/.keygen.XXXXXX)
+  ssh-keygen -t ed25519 -N '' -f "${keytmp}/id_ed25519" -q
+  mv "${keytmp}/id_ed25519.pub" /shared/ssh/id_ed25519.pub
+  mv "${keytmp}/id_ed25519" /shared/ssh/id_ed25519
+  rmdir "${keytmp}"
+fi
 
 # Side-loads a manifest's images into the kind nodes from the DinD image
 # cache, which lives on a named volume and therefore survives resets. The
@@ -119,7 +160,7 @@ if ! kind get clusters 2>/dev/null | grep -qx sim; then
   kind create cluster --config /opt/sim/kind-config.yaml --image "${node_ref}"
   created=1
 fi
-kind get kubeconfig --name sim | sed 's#https://0\.0\.0\.0:6443#https://k8s-env:6443#' > /shared/kubeconfig
+kind get kubeconfig --name sim | sed 's#https://0\.0\.0\.0:6443#https://k8s-env:6443#' | write_shared /shared/kubeconfig
 kind export kubeconfig --name sim   # local admin access via ~/.kube/config
 
 # on warm restart the node containers auto-restart but the API server needs
@@ -237,7 +278,7 @@ if [ "$exam_type" = "mcq" ]; then
     echo " This is a multiple-choice exam: answer in the question panel."
     echo " The desktop is not needed for this bank."
     echo "=============================================================="
-  } > /shared/exam/motd
+  } | write_shared /shared/exam/motd
 else
   {
     echo "=============================================================="
@@ -256,7 +297,7 @@ else
     echo " Click any value in the question panel to copy it, then paste"
     echo " here with Ctrl+V."
     echo "=============================================================="
-  } > /shared/exam/motd
+  } | write_shared /shared/exam/motd
 fi
 
 phase finalize "Finishing up" 8

--- a/images/k8s-env/start.sh
+++ b/images/k8s-env/start.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 HELM_REPO_PORT=${HELM_REPO_PORT:-8879}
+# This script is PID 1, so it does have the image's ENV — unlike
+# bootstrap.sh when a hosted reset re-runs it over ssh. Resolved the same
+# way anyway, so there is one rule rather than two. See bootstrap.sh.
+NODE_IMAGE="${NODE_IMAGE:-$(cat /opt/sim/node-image)}"
 # shellcheck source=phase.sh
 . /opt/sim/phase.sh
 rm -f /shared/ready   # clear stale marker before healthcheck can see it
@@ -78,10 +82,45 @@ helm repo update >/dev/null 2>&1 || true
 # recreate-cluster phase can still exec a retry in here, which is what
 # the "New attempt" button drives. Exiting would take that away and
 # leave the candidate with nothing but a restart loop.
+# Only in the hosted deployment, where the stack is one Kubernetes Pod:
+# the conductor has no Docker socket there and execs in here over ssh
+# (ENGINE=ssh). Unset under compose, where the socket is the route and
+# nothing should be listening.
+#
+# The address is explicit because the Pod shares one network namespace
+# with the instances, which take 127.0.0.2 and 127.0.0.3. Binding
+# 0.0.0.0 here would take :22 on every address and lock them out.
+#
+# Called after bootstrap.sh because that is what generates the key pair
+# this authorises, and on the failure path too so a broken environment is
+# still reachable for diagnosis.
+start_control_sshd() {
+  [ -n "${SSHD_LISTEN:-}" ] || return 0
+  # -s, not -f, to match the instance and desktop entrypoints: an empty
+  # authorized_keys authorises nobody, and this would then start an sshd
+  # the conductor can never log into — a working-looking listener that
+  # refuses every connection. Unreachable now that bootstrap.sh renames
+  # the key into place, and kept because that is exactly the assumption
+  # this file should not be making again.
+  if [ ! -s /shared/ssh/id_ed25519.pub ]; then
+    echo "control sshd: no shared key yet, not starting" >&2
+    return 0
+  fi
+  mkdir -p /root/.ssh
+  cp /shared/ssh/id_ed25519.pub /root/.ssh/authorized_keys
+  chmod 700 /root/.ssh
+  chmod 600 /root/.ssh/authorized_keys
+  ssh-keygen -A >/dev/null 2>&1
+  /usr/sbin/sshd -e -o "ListenAddress=$SSHD_LISTEN" -o PermitRootLogin=prohibit-password \
+    && echo "control sshd on ${SSHD_LISTEN}:22"
+}
+
 if ! /opt/sim/bootstrap.sh; then
+  start_control_sshd
   echo "bootstrap failed; holding the container open so the failure is visible and retryable" >&2
   tail -f /dev/null
 fi
 
+start_control_sshd
 echo "k8s-env ready"
 tail -f /dev/null

--- a/site/index.html
+++ b/site/index.html
@@ -557,20 +557,22 @@
             <div class="limit">
               <dt>No accounts, and no authentication anywhere.</dt>
               <dd>
-                Permanently. This is a local single-user tool and a password
-                field would be theatre; the only real control is which interface
-                it binds to. Ports bind to all interfaces by default, so on a
-                network you do not control, start it with
-                <code>SIM_BIND=127.0.0.1 ./sim up</code> instead.
+                In the simulator, permanently. What you clone is a local
+                single-user tool and a password field would be theatre; the only
+                real control is which interface it binds to. Ports bind to all
+                interfaces by default, so on a network you do not control, start
+                it with <code>SIM_BIND=127.0.0.1 ./sim up</code> instead.
               </dd>
             </div>
             <div class="limit">
-              <dt>No hosted version.</dt>
+              <dt>Hosting it is your job, not ours.</dt>
               <dd>
-                There is nothing to sign up for and nothing is uploaded. Local
-                single-user is the permanent model, not a stage before a
-                service, so hosting, accounts and multi-user separation are out
-                of scope rather than unbuilt.
+                There is no service here to sign up for, and running this needs
+                nothing but Docker on your own machine. If you want to put it in
+                front of a group there is a Helm chart in the repository that
+                deploys sign-in, a capped pool of sessions and per-user history
+                — but a hands-on session is a privileged container, so that is a
+                decision about hardware you are willing to rebuild.
               </dd>
             </div>
             <div class="limit">
@@ -585,11 +587,10 @@
               <dd>
                 Graded attempts are kept — best score per exam, weakest
                 domains, progress along the five-certification path — but that
-                record is one candidate's, on one machine. It can describe your
-                progress and never a population's, so nothing here compares you
-                to other candidates. Training runs are not recorded at all:
-                practice with the solutions open would make every best score
-                meaningless.
+                record is one candidate's. It can describe your progress and
+                never a population's, so nothing here compares you to other
+                candidates. Training runs are not recorded at all: practice with
+                the solutions open would make every best score meaningless.
               </dd>
             </div>
             <div class="limit">

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -122,6 +122,11 @@ function stubFetch() {
         statusPolls++;
         return json(controlStatus);
       }
+      // A local facilitator JSON-404s any /api/* it does not have, and
+      // that 404 is how the SPA tells this product from the hosted one.
+      // Stubbed explicitly so every test in this file is unambiguously
+      // about the local app.
+      if (url.endsWith("/api/me")) return json({ error: "not found" }, 404);
       if (url.endsWith("/api/boot")) return json(readyBoot);
       if (url.endsWith("/api/session")) return json(idleSession);
       if (url.endsWith("/api/exam")) return json(exam);

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -29,6 +29,13 @@ import { ToastLayer } from "./components/Toast";
 import { TopProgress } from "./components/TopProgress";
 import { ScreenTransition } from "./components/ScreenTransition";
 import { toastStore } from "./components/toastStore";
+import { HostedBooting } from "./screens/HostedBooting";
+import { HostedSignIn } from "./screens/HostedSignIn";
+import { HostedStart } from "./screens/HostedStart";
+import { Review } from "./screens/Review";
+import { SessionChip } from "./components/SessionChip";
+import { useHosted } from "./lib/useHosted";
+import type { Me } from "./api";
 import { useRoute } from "./lib/useHashRoute";
 import { strings } from "./strings";
 
@@ -62,7 +69,121 @@ const PREPARE_POLL_MS = 1_000;
 // so every screen transition and every timer resync flows from one
 // source of truth. It also owns the control-job overlay, which must
 // survive the screen transitions a reset/switch causes.
+/** Who the candidate is, and how to re-ask. Absent in the local product. */
+export interface Hosted {
+  me: Me;
+  refresh: () => void;
+}
+
+/**
+ * The gate above everything.
+ *
+ * One request on load decides which product this is. It has to be a
+ * gate rather than a branch inside the app because the app below assumes
+ * an environment exists: its session poller, its boot poller and its
+ * control poller all address a facilitator, and in hosted mode there is
+ * no facilitator to address until a Pod has been built. Mounting them
+ * against a hub with no session would be three pollers 404ing in a loop
+ * behind a screen that cannot be right anyway.
+ *
+ * `local` renders SimApp with no props at all, which is the property
+ * that matters most here: `./sim up` is byte-identical, and the only
+ * trace of any of this in it is one 404 for /api/me at page load.
+ */
 export default function App() {
+  const { state, refresh } = useHosted();
+  const route = useRoute();
+
+  if (state.status === "unknown") {
+    return (
+      <>
+        <TopProgress />
+        <div className="loading-screen" role="status">
+          {state.error ? strings.app.cannotReach(state.error) : strings.app.loading}
+        </div>
+      </>
+    );
+  }
+  if (state.status === "local") {
+    return <SimApp />;
+  }
+
+  const { me } = state;
+  if (!me.authenticated) {
+    return <HostedSignIn me={me} />;
+  }
+
+  // A ready environment is the ordinary product with a header chip on
+  // top. Everything below this line is the same code a local candidate
+  // runs, reaching the same facilitator through the hub's proxy.
+  if (me.session?.state === "ready") {
+    return <SimApp hosted={{ me, refresh }} />;
+  }
+
+  return <HostedHome hosted={{ me, refresh }} route={route} />;
+}
+
+/**
+ * Signed in, with no usable environment: the lobby, the boot screen, and
+ * the two pages that do not need a Pod at all.
+ *
+ * Progress and a past attempt are answered by the hub out of its own
+ * store, so they work with no session running — which is the whole
+ * argument for hosted history. A candidate can read last week's exam
+ * back without spending a seat to do it.
+ */
+function HostedHome({ hosted, route }: { hosted: Hosted; route: ReturnType<typeof useRoute> }) {
+  const { me, refresh } = hosted;
+  const reviewId = route.segments[0] === "history" ? (route.segments[1] ?? null) : null;
+  const questionId = reviewId ? (route.segments[2] ?? null) : null;
+  const onProgress = route.segments[0] === "progress";
+
+  let screen;
+  if (reviewId) {
+    screen = <Review attemptId={reviewId} questionId={questionId} />;
+  } else if (onProgress) {
+    screen = <Progress catalogVersion={0} hosted />;
+  } else if (me.session) {
+    screen = <HostedBooting session={me.session} onChanged={refresh} />;
+  } else {
+    screen = <HostedStart me={me} onChanged={refresh} />;
+  }
+
+  const headerProps: Partial<AppHeaderProps> = reviewId
+    ? {
+        variant: "back",
+        back: { label: strings.review.back, to: "/progress" },
+        crumb: strings.review.crumb,
+      }
+    : {
+        crumb: onProgress ? strings.header.crumbProgress : strings.hosted.chipLabel,
+        nav: [
+          { label: strings.hosted.chipLabel, to: "/", current: !onProgress && !reviewId },
+          { label: strings.header.navProgress, to: "/progress", current: onProgress },
+        ],
+      };
+
+  return (
+    <>
+      <TopProgress />
+      <AppHeader {...headerProps}>
+        <SessionChip
+          login={me.user?.login ?? ""}
+          session={me.session}
+          onChanged={refresh}
+        />
+      </AppHeader>
+      <main>
+        <ScreenTransition screenKey={reviewId ? `review:${reviewId}` : onProgress ? "progress" : "lobby"}>
+          {screen}
+        </ScreenTransition>
+      </main>
+      <ToastLayer />
+    </>
+  );
+}
+
+function SimApp({ hosted }: { hosted?: Hosted } = {}) {
   const [session, setSession] = useState<SessionSnapshot | null>(null);
   const [fetchedAt, setFetchedAt] = useState<number>(() => Date.now());
   const [pollError, setPollError] = useState<string | null>(null);
@@ -425,8 +546,21 @@ export default function App() {
           nav,
         };
 
+  // A page about the candidate's RECORD rather than their environment.
+  // Above the session switch for the same reason the boot screen is: it
+  // is not a fourth session state, it is a different subject. Hosted
+  // only, and never over a running attempt — session.state is server
+  // truth and no bookmark may talk a candidate out of an exam that is
+  // counting down.
+  const reviewId =
+    hosted && route.segments[0] === "history" && session?.state !== "running"
+      ? (route.segments[1] ?? null)
+      : null;
+
   let screen = null;
-  if (booting) {
+  if (reviewId) {
+    screen = <Review attemptId={reviewId} questionId={route.segments[2] ?? null} />;
+  } else if (booting) {
     screen = <BootProgress boot={boot} onRetry={handleNewAttempt} />;
   } else if (!session) {
     screen = (
@@ -438,7 +572,7 @@ export default function App() {
     switch (session.state) {
       case "idle":
         screen = onProgress ? (
-          <Progress catalogVersion={catalogVersion} />
+          <Progress catalogVersion={catalogVersion} hosted={hosted !== undefined} />
         ) : modeBankId ? (
           <Mode
             bankId={modeBankId}
@@ -499,6 +633,23 @@ export default function App() {
           nothing to navigate to yet. */}
       {session && !booting && session.state !== "running" && (
         <AppHeader {...headerProps}>
+          {/* Hosted only. It carries the lease countdown, which is the one
+              thing about a hosted session a candidate cannot be left to
+              guess: the seat is taken back at the cap whatever they are
+              doing. Deliberately NOT rendered over a running exam — that
+              screen has its own topbar with its own clock, and a second
+              countdown beside it would be read as the exam's. One good
+              consequence and one recorded cost: there is no way to
+              destroy an environment mid-attempt by misclick, and a lease
+              that expires mid-attempt gives no warning. See
+              docs/follow-ups.md. */}
+          {hosted && (
+            <SessionChip
+              login={hosted.me.user?.login ?? ""}
+              session={hosted.me.session}
+              onChanged={hosted.refresh}
+            />
+          )}
           {/* A backgrounded rebuild used to run for 2-4 minutes with no
               indicator anywhere: the lobby behind it looked idle while the
               cluster it describes was being torn down. */}

--- a/ui/src/a11y.test.tsx
+++ b/ui/src/a11y.test.tsx
@@ -24,6 +24,10 @@ import { QuestionPanel } from "./components/QuestionPanel";
 import { ToastLayer } from "./components/Toast";
 import { McqExam } from "./screens/McqExam";
 import { McqAnswerReview } from "./components/McqAnswerReview";
+import { HostedBooting } from "./screens/HostedBooting";
+import { HostedSignIn } from "./screens/HostedSignIn";
+import { HostedStart } from "./screens/HostedStart";
+import { SessionChip } from "./components/SessionChip";
 import { SPLIT_QUERY } from "./lib/useMediaQuery";
 import { matchMediaMock } from "./test/setup";
 import { marksStore } from "./components/marksStore";
@@ -770,6 +774,81 @@ describe("axe: no WCAG violations", () => {
           options: ["CNI", "CSI", "CRI", "OCI"],
           multi: true,
         }}
+      />,
+    );
+    expect(await axe(container, AXE_OPTS)).toHaveNoViolations();
+  });
+
+  // ---- hosted mode ----
+  //
+  // Four surfaces a local candidate never sees, and the reason they are
+  // scanned here rather than trusted: every one of them was written
+  // after this suite existed, so none of them is covered by the App
+  // scans above, and the sign-in screen is the first thing a stranger
+  // ever meets.
+
+  test("hosted sign-in", async () => {
+    const { container } = render(
+      <HostedSignIn
+        me={{
+          authenticated: false,
+          authMode: "github",
+          loginURL: "/hub/auth/login",
+          seats: { practical: { used: 1, total: 3 } },
+        }}
+      />,
+    );
+    expect(await axe(container, AXE_OPTS)).toHaveNoViolations();
+  });
+
+  test("hosted lobby, with a place in the queue", async () => {
+    const { container } = render(
+      <HostedStart
+        me={{
+          authenticated: true,
+          authMode: "github",
+          user: { id: "1", login: "octocat" },
+          seats: { practical: { used: 3, total: 3 }, mcq: { used: 0, total: 30 } },
+          queue: { position: 2 },
+        }}
+        onChanged={() => {}}
+      />,
+    );
+    expect(await axe(container, AXE_OPTS)).toHaveNoViolations();
+  });
+
+  test("hosted boot screen", async () => {
+    const { container } = render(
+      <HostedBooting
+        session={{
+          kind: "practical",
+          pod: "sim-session-practical-1",
+          state: "starting",
+          startedAt: "2026-08-04T11:55:00Z",
+          expiresAt: "2026-08-04T21:55:00Z",
+          lastSeen: "2026-08-04T12:00:00Z",
+        }}
+        onChanged={() => {}}
+      />,
+    );
+    expect(await axe(container, AXE_OPTS)).toHaveNoViolations();
+  });
+
+  // The one hosted surface that lives inside the header, beside the
+  // theme toggle and a backgrounded-job chip.
+  test("session chip with a lease running out", async () => {
+    const { container } = render(
+      <SessionChip
+        login="octocat"
+        session={{
+          kind: "practical",
+          pod: "sim-session-practical-1",
+          state: "ready",
+          startedAt: "2026-08-04T11:00:00Z",
+          expiresAt: new Date(Date.now() + 5 * 60_000).toISOString(),
+          lastSeen: "2026-08-04T12:00:00Z",
+        }}
+        onChanged={() => {}}
       />,
     );
     expect(await axe(container, AXE_OPTS)).toHaveNoViolations();

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1138,3 +1138,204 @@ export async function importHistory(
   const body = (await res.json()) as { imported: number; skipped: number };
   return { ok: true, imported: body.imported, skipped: body.skipped };
 }
+
+// ---------------------------------------------------------------------
+// Hosted mode
+//
+// Everything below exists only when the SPA is served by the hub rather
+// than by a facilitator. `./sim up` never sees any of it: getMe() is the
+// one call that probes for a hub, and it answers null against a local
+// facilitator, which JSON-404s any /api/* it does not know. That is the
+// whole detection mechanism — no build flag, no second bundle, and one
+// request on load.
+
+/** Which flavour of session a hosted deployment can hand out. */
+export type SessionKind = "practical" | "mcq";
+
+/**
+ * Where a hosted session is in its life.
+ *
+ * `pending` and `starting` are distinct on purpose, and the difference
+ * matters to the person waiting: pending means a seat is held and
+ * someone else's environment is booting first, starting means their own
+ * Pod exists and is building. `failed` keeps the seat so they can read
+ * why before it is reaped.
+ */
+export type HostedSessionState = "pending" | "starting" | "ready" | "failed";
+
+/** One candidate's exam environment, as the hub describes it. */
+export interface HostedSession {
+  kind: SessionKind;
+  bank?: string;
+  pod: string;
+  state: HostedSessionState;
+  startedAt: string;
+  /** The hard cap. A session is taken back at this time whatever it is doing. */
+  expiresAt: string;
+  lastSeen: string;
+  error?: string;
+}
+
+/** How many of one flavour's seats are taken. */
+export interface Seats {
+  used: number;
+  total: number;
+}
+
+/**
+ * GET /api/me — identity, seat and queue position in one answer.
+ *
+ * 200 whether or not anyone is signed in, deliberately: the question the
+ * SPA is asking is "am I talking to a hub?", and a 401 would conflate
+ * "hosted, logged out" with "not hosted at all".
+ */
+export interface Me {
+  authenticated: boolean;
+  authMode: "github" | "header" | "none";
+  user?: { id: string; login: string };
+  /** Where to send someone who is not signed in. */
+  loginURL?: string;
+  /** The candidate's own session, absent when they have none. */
+  session?: HostedSession;
+  /** Their place in the queue, absent unless they are in one. */
+  queue?: { position: number };
+  /** Per-flavour capacity, keyed by SessionKind. */
+  seats?: Partial<Record<SessionKind, Seats>>;
+}
+
+/**
+ * Probe for a hub. Resolves to null when this is a local facilitator.
+ *
+ * Two ways to be local, and both are checked. A facilitator answers 404
+ * for an /api/* route it does not have; a proxy or a captive portal in
+ * front of one might answer 200 with something else entirely, and a body
+ * with no `authMode` in it is not a hub however healthy the status line
+ * looks. Guessing "hosted" wrongly puts a login screen in front of a
+ * local product that has no accounts.
+ *
+ * Network failures are thrown rather than swallowed: during a cold start
+ * the facilitator is not listening yet, and "not answering" is not the
+ * same answer as "not hosted".
+ */
+export async function getMe(signal?: AbortSignal): Promise<Me | null> {
+  const res = await request("/api/me", { signal });
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(await readError(res));
+  }
+  const body = (await res.json()) as Partial<Me>;
+  if (typeof body.authMode !== "string") return null;
+  return body as Me;
+}
+
+export type HostedStartResponse =
+  /** 202: a seat is held and the environment is being built. Poll /api/me. */
+  | { ok: true; starting: true; state: HostedSessionState }
+  /** 409: every seat of that flavour is taken. */
+  | { ok: true; queued: true; position: number; seats: Seats; error: string }
+  | { ok: false; error: string };
+
+/**
+ * POST /api/session/start with a flavour — hosted admission, not the
+ * start of an attempt.
+ *
+ * The same path does both, in that order: the hub grants a seat and
+ * boots a Pod, and only once that Pod answers does it forward the
+ * request to the facilitator inside it, which is what actually begins an
+ * exam. So this is only ever called when the candidate has no session —
+ * once they have one, the ordinary startSession() reaches the
+ * facilitator through the same door and configures the attempt properly.
+ *
+ * The 200 case is therefore not modelled here: reaching it would mean a
+ * ready Pod was handed a body naming a kind and no mode, and starting an
+ * unconfigured attempt is precisely what the caller must not do by
+ * accident.
+ */
+export async function startHostedSession(
+  kind: SessionKind,
+  signal?: AbortSignal,
+): Promise<HostedStartResponse> {
+  const res = await request("/api/session/start", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ kind }),
+    signal,
+  });
+  if (res.status === 409) {
+    const body = (await res.json()) as {
+      error: string;
+      queued?: boolean;
+      position?: number;
+      seats?: Seats;
+    };
+    if (body.queued) {
+      return {
+        ok: true,
+        queued: true,
+        position: body.position ?? 0,
+        seats: body.seats ?? { used: 0, total: 0 },
+        error: body.error,
+      };
+    }
+    return { ok: false, error: body.error };
+  }
+  if (!res.ok) {
+    return { ok: false, error: await readError(res) };
+  }
+  if (res.status === 202) {
+    const body = (await res.json()) as { state: HostedSessionState };
+    return { ok: true, starting: true, state: body.state };
+  }
+  // 200 from a Pod that was already ready. Treated as "you already have
+  // one" rather than parsed: the caller's next /api/me poll carries the
+  // session, and nothing here should try to interpret a facilitator
+  // response to a request the facilitator was never meant to see.
+  return { ok: true, starting: true, state: "ready" };
+}
+
+/**
+ * POST /hub/session/end — give up the seat and the Pod.
+ *
+ * Deliberately not /api/session/end, which is the facilitator's and ends
+ * the ATTEMPT: it grades the exam and writes the record while the
+ * environment stays up so the candidate can read their score. Ending the
+ * seat is a different act, and a candidate who confused the two would
+ * lose their results to a misclick.
+ */
+export async function endHostedSession(
+  signal?: AbortSignal,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const res = await request("/hub/session/end", { method: "POST", signal });
+  if (!res.ok) {
+    return { ok: false, error: await readError(res) };
+  }
+  return { ok: true };
+}
+
+/** POST /hub/auth/logout — clear the session cookie. */
+export async function logout(signal?: AbortSignal): Promise<void> {
+  await request("/hub/auth/logout", { method: "POST", signal });
+}
+
+/**
+ * GET /api/history/{attempt} — the full graded-results document of a
+ * past attempt.
+ *
+ * Hosted only, and it is worth saying why rather than leaving it as an
+ * absence. A local facilitator records the attempt SUMMARY in
+ * /state/history.json and nothing else; the results document lives in
+ * /session, which the next attempt overwrites. The hub keeps both,
+ * because its whole reason to exist is that a session Pod is disposable
+ * — so "read last Tuesday's exam back" is a thing only hosted mode can
+ * offer, not a feature the local product is missing.
+ */
+export async function getAttemptResults(
+  attempt: string,
+  signal?: AbortSignal,
+): Promise<Results> {
+  const res = await request(`/api/history/${encodeURIComponent(attempt)}`, { signal });
+  if (!res.ok) {
+    throw new Error(await readError(res));
+  }
+  return (await res.json()) as Results;
+}

--- a/ui/src/components/SessionChip.tsx
+++ b/ui/src/components/SessionChip.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { endHostedSession, logout, type HostedSession } from "../api";
+import { Dialog } from "./Dialog";
+import { formatClock } from "../lib/format";
+import { useTick } from "../lib/useTick";
+import { strings } from "../strings";
+
+interface SessionChipProps {
+  login: string;
+  /** Absent while the candidate has no environment: only sign-out shows. */
+  session?: HostedSession;
+  onChanged: () => void;
+}
+
+/** Under this much lease left, the countdown starts insisting. */
+const SOON_SECONDS = 15 * 60;
+
+/**
+ * Who you are, how long you have, and the two ways out.
+ *
+ * The countdown is the part that earns its place: a hosted session has a
+ * hard cap and is taken back at it whatever the candidate is doing, so
+ * the one thing they cannot be left to guess is how long that is. It is
+ * recomputed from the server's `expiresAt` on every tick rather than
+ * decremented, so a throttled background tab resyncs instead of drifting.
+ */
+export function SessionChip({ login, session, onChanged }: SessionChipProps) {
+  const [confirming, setConfirming] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const expires = session ? Date.parse(session.expiresAt) : NaN;
+  const live = session !== undefined && !Number.isNaN(expires);
+  const now = useTick(live);
+  const secondsLeft = live ? Math.max(0, Math.round((expires - now) / 1000)) : 0;
+  const soon = live && secondsLeft <= SOON_SECONDS;
+
+  const end = async () => {
+    setBusy(true);
+    setError(null);
+    const result = await endHostedSession();
+    setBusy(false);
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+    setConfirming(false);
+    onChanged();
+  };
+
+  const signOut = async () => {
+    await logout().catch(() => undefined);
+    // A full reload rather than a state update. Signing out invalidates a
+    // cookie that every open fetch and the desktop's WebSocket are
+    // carrying, and there is no partial version of that.
+    window.location.assign("/");
+  };
+
+  return (
+    <>
+      <div className="session-chip">
+        <span className="session-chip-user">{login}</span>
+        {live && (
+          <span
+            className="session-chip-clock"
+            data-soon={soon || undefined}
+            // Announced only when it starts mattering. A clock in a live
+            // region that re-reads every second is unusable with a screen
+            // reader on, and for most of a ten-hour lease it is not news.
+            role={soon ? "status" : undefined}
+          >
+            {secondsLeft === 0
+              ? strings.hosted.chipExpired
+              : soon
+                ? strings.hosted.chipEndingSoon(formatClock(secondsLeft))
+                : strings.hosted.chipTimeLeft(formatClock(secondsLeft))}
+          </span>
+        )}
+        {session && (
+          <button type="button" className="btn btn-quiet" onClick={() => setConfirming(true)}>
+            {strings.hosted.endSession}
+          </button>
+        )}
+        <button type="button" className="btn btn-quiet" onClick={() => void signOut()}>
+          {strings.hosted.signOut}
+        </button>
+      </div>
+
+      {confirming && (
+        <Dialog title={strings.hosted.endConfirmTitle} onClose={() => setConfirming(false)}>
+          <p>{strings.hosted.endConfirmBody}</p>
+          {error && <p className="error-text">{strings.hosted.endFailed(error)}</p>}
+          <div className="confirm-actions">
+            <button
+              type="button"
+              className="btn"
+              onClick={() => setConfirming(false)}
+              disabled={busy}
+            >
+              {strings.hosted.endCancel}
+            </button>
+            <button
+              type="button"
+              className="btn btn-danger"
+              onClick={() => void end()}
+              disabled={busy}
+            >
+              {strings.hosted.endConfirm}
+            </button>
+          </div>
+        </Dialog>
+      )}
+    </>
+  );
+}

--- a/ui/src/components/TaskVerdicts.tsx
+++ b/ui/src/components/TaskVerdicts.tsx
@@ -58,7 +58,14 @@ interface Row {
  * column strip is therefore aria-hidden decoration and every cell that
  * would be ambiguous alone carries its own name instead.
  */
-export function TaskVerdicts({ questions }: { questions: QuestionResult[] }) {
+export function TaskVerdicts({
+  questions,
+  basePath = "/results",
+}: {
+  questions: QuestionResult[];
+  /** Where a row's "open" link points. See Explain's basePath. */
+  basePath?: string;
+}) {
   const [filter, setFilter] = useState<Filter>("all");
   // The flags are the candidate's own, from the attempt that just ended.
   // Subscribing to the version counter rather than the sets themselves:
@@ -159,7 +166,13 @@ export function TaskVerdicts({ questions }: { questions: QuestionResult[] }) {
           <span>{strings.score.colVerdict}</span>
         </div>
         {visible.map((row) => (
-          <TaskRow key={row.question.id} row={row} weighted={weighted} timed={timed} />
+          <TaskRow
+            key={row.question.id}
+            row={row}
+            weighted={weighted}
+            timed={timed}
+            basePath={basePath}
+          />
         ))}
         {visible.length === 0 && <p className="tv-empty">{strings.score.filterEmpty}</p>}
       </div>
@@ -190,7 +203,17 @@ export const VERDICT_WORD: Record<Verdict, string> = {
   failed: strings.score.verdictFailed,
 };
 
-function TaskRow({ row, weighted, timed }: { row: Row; weighted: boolean; timed: boolean }) {
+function TaskRow({
+  row,
+  weighted,
+  timed,
+  basePath,
+}: {
+  row: Row;
+  weighted: boolean;
+  timed: boolean;
+  basePath: string;
+}) {
   const { question, n, verdict, flagged } = row;
 
   // mcq results carry the option texts; hands-on results never do. That
@@ -261,7 +284,7 @@ function TaskRow({ row, weighted, timed }: { row: Row; weighted: boolean; timed:
             back button all work without this component importing a
             router. */}
         <p className="tv-more">
-          <a className="tv-open" href={`#/results/${question.id}`}>
+          <a className="tv-open" href={`#${basePath}/${question.id}`}>
             {strings.score.openExplain(n)}
             <Icon name="chevron-right" />
           </a>

--- a/ui/src/lib/useHosted.ts
+++ b/ui/src/lib/useHosted.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getMe, type Me } from "../api";
+
+/**
+ * Which product this browser is talking to, and — when it is the hosted
+ * one — who the candidate is and what they have.
+ *
+ * `unknown` is a real state and not a loading flicker to be skipped: a
+ * facilitator that is still starting has not said it is local yet, and
+ * rendering the local app on that assumption puts an exam selector in
+ * front of someone who has not signed in. Every screen waits.
+ */
+export type HostedState =
+  | { status: "unknown"; error: string | null }
+  | { status: "local" }
+  | { status: "hosted"; me: Me };
+
+/**
+ * How often /api/me is re-asked.
+ *
+ * Fast while something is expected to change on its own — a Pod booting,
+ * a place in a queue moving — and slow otherwise, where it is only
+ * keeping the lease countdown honest and noticing a session reaped from
+ * under the tab. It is also the hub's idle signal: the reaper takes back
+ * a seat nobody has asked about, so a tab left open on the lobby with no
+ * poll at all would look abandoned.
+ */
+const POLL_ACTIVE_MS = 2_000;
+const POLL_IDLE_MS = 20_000;
+/** Retry cadence before the first answer, when nothing is known yet. */
+const POLL_RETRY_MS = 3_000;
+
+function cadenceFor(me: Me): number {
+  if (me.queue) return POLL_ACTIVE_MS;
+  if (me.session && me.session.state !== "ready") return POLL_ACTIVE_MS;
+  return POLL_IDLE_MS;
+}
+
+/**
+ * Poll GET /api/me.
+ *
+ * Stops permanently once it answers `local`. That is not an optimisation
+ * — it is the property that keeps `./sim up` byte-identical: a local
+ * facilitator must never see a repeating request for a route it does not
+ * have, filling its log with 404s for a hub that is not there.
+ */
+export function useHosted(): { state: HostedState; refresh: () => void } {
+  const [state, setState] = useState<HostedState>({ status: "unknown", error: null });
+  const [nonce, setNonce] = useState(0);
+  // Survives the effect re-running, which is the point: refresh() must
+  // not be able to restart a poll that has already established there is
+  // no hub to poll.
+  const local = useRef(false);
+
+  const refresh = useCallback(() => setNonce((n) => n + 1), []);
+
+  useEffect(() => {
+    if (local.current) return;
+    let stopped = false;
+    let timer = 0;
+
+    // The next delay is computed from the answer just received rather
+    // than from `state`, so this effect does not depend on the value it
+    // sets — which would re-run it on every poll and turn the timer into
+    // a busy loop.
+    const tick = async () => {
+      let next = POLL_RETRY_MS;
+      try {
+        const me = await getMe();
+        if (stopped) return;
+        if (me === null) {
+          local.current = true;
+          setState({ status: "local" });
+          return;
+        }
+        setState({ status: "hosted", me });
+        next = cadenceFor(me);
+      } catch (err) {
+        // Expected during a cold start, and expected again for a moment
+        // whenever the hub is redeployed. The error is only shown while
+        // nothing is known yet: once identity has arrived, a failed poll
+        // leaves the last answer on screen rather than blanking a
+        // signed-in candidate back to a sign-in page.
+        if (stopped) return;
+        setState((prev) =>
+          prev.status === "unknown" ? { status: "unknown", error: String(err) } : prev,
+        );
+      }
+      if (!stopped) timer = window.setTimeout(tick, next);
+    };
+
+    tick();
+    return () => {
+      stopped = true;
+      window.clearTimeout(timer);
+    };
+  }, [nonce]);
+
+  return { state, refresh };
+}

--- a/ui/src/screens/Explain.tsx
+++ b/ui/src/screens/Explain.tsx
@@ -68,9 +68,19 @@ interface ExplainProps {
   results: Results;
   /** The `<id>` from `#/results/<id>`, which may name nothing at all. */
   questionId: string;
+  /**
+   * The route this screen's own links hang off, with no trailing slash.
+   *
+   * "/results" is the attempt that just ended, which is where this screen
+   * has always lived. Hosted mode reads a PAST attempt back at
+   * "/history/<attemptId>" and renders the identical component under it,
+   * so the base cannot be a constant — every step and back link here
+   * would jump out of the record and into the live session.
+   */
+  basePath?: string;
 }
 
-export function Explain({ results, questionId }: ExplainProps) {
+export function Explain({ results, questionId, basePath = "/results" }: ExplainProps) {
   const index = results.questions.findIndex((q) => q.id === questionId);
   const question = index === -1 ? null : results.questions[index];
 
@@ -112,7 +122,7 @@ export function Explain({ results, questionId }: ExplainProps) {
     // so the page still announces what it is.
     return (
       <div className="explain">
-        <BackLink />
+        <BackLink basePath={basePath} />
         <div className="explain-card explain-unknown">
           <h1 className="explain-title">{strings.explain.unknownTask}</h1>
         </div>
@@ -144,7 +154,7 @@ export function Explain({ results, questionId }: ExplainProps) {
 
   return (
     <div className="explain">
-      <BackLink />
+      <BackLink basePath={basePath} />
 
       <article className="explain-card">
         <header className="explain-head">
@@ -170,14 +180,14 @@ export function Explain({ results, questionId }: ExplainProps) {
           {(prev !== null || next !== null) && (
             <nav className="explain-nav" aria-label={strings.explain.navLabel}>
               {prev !== null && (
-                <a className="btn explain-step" href={`#/results/${prev.id}`}>
+                <a className="btn explain-step" href={`#${basePath}/${prev.id}`}>
                   <Icon name="chevron-left" />
                   <span className="sr-only">{strings.explain.prevLabel}: </span>
                   {strings.explain.prevTask(index)}
                 </a>
               )}
               {next !== null && (
-                <a className="btn explain-step" href={`#/results/${next.id}`}>
+                <a className="btn explain-step" href={`#${basePath}/${next.id}`}>
                   <span className="sr-only">{strings.explain.nextLabel}: </span>
                   {strings.explain.nextTask(index + 2)}
                   <Icon name="chevron-right" />
@@ -244,9 +254,9 @@ export function Explain({ results, questionId }: ExplainProps) {
   );
 }
 
-function BackLink() {
+function BackLink({ basePath }: { basePath: string }) {
   return (
-    <a className="explain-back" href="#/results">
+    <a className="explain-back" href={`#${basePath}`}>
       <Icon name="chevron-left" />
       {strings.explain.backToResults}
     </a>

--- a/ui/src/screens/Hosted.test.tsx
+++ b/ui/src/screens/Hosted.test.tsx
@@ -1,0 +1,398 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import App from "../App";
+import type { Me } from "../api";
+
+// The hosted tier, from the outside: what a browser sees when the SPA is
+// served by the hub instead of by a facilitator.
+//
+// Every test here drives App itself rather than the screens underneath,
+// because the thing worth pinning down is the GATE — which product this
+// is, and which of five states the candidate is in. A test that mounted
+// HostedStart directly would pass whether or not App ever renders it.
+
+const now = Date.UTC(2026, 7, 4, 12, 0, 0);
+
+function me(overrides: Partial<Me> = {}): Me {
+  return {
+    authenticated: true,
+    authMode: "github",
+    user: { id: "583231", login: "octocat" },
+    seats: { practical: { used: 1, total: 3 }, mcq: { used: 0, total: 30 } },
+    ...overrides,
+  };
+}
+
+/** A ready local environment, so the ordinary app can mount over a hub. */
+const localStubs: Record<string, unknown> = {
+  "/api/session": {
+    state: "idle",
+    bank: "ckad-mock-01",
+    startedAt: "",
+    durationSeconds: 7200,
+    remainingSeconds: 0,
+    endReason: "",
+    mode: "exam",
+    untimed: false,
+  },
+  "/api/boot": {
+    state: "ready",
+    phase: "ready",
+    label: "Environment ready",
+    detail: "",
+    error: "",
+    step: 8,
+    totalSteps: 8,
+    startedAt: "",
+  },
+  "/api/exam": {
+    name: "ckad-mock-01",
+    title: "CKAD Mock Exam 01",
+    durationSeconds: 7200,
+    passingScore: 66,
+    questions: [],
+  },
+  "/api/catalog": {
+    active: "ckad-mock-01",
+    exams: [
+      {
+        id: "ckad-mock-01",
+        title: "CKAD Mock Exam 01",
+        examType: "hands-on",
+        available: true,
+        progress: { attempts: 0, counted: 0, passed: false, weakDomains: [] },
+      },
+    ],
+    summary: { attempts: 0, passedCount: 0, trackCount: 5, weakDomains: [] },
+  },
+  "/api/control/status": { busy: false },
+};
+
+/** One graded attempt, as the hub keeps it. */
+const attemptRecord = {
+  id: "8da8fa50",
+  bank: "ckad-mock-01",
+  certification: "CKAD",
+  examTitle: "CKAD Mock Exam 01",
+  examType: "hands-on",
+  mode: "exam",
+  startedAt: "2026-08-01T09:00:00Z",
+  gradedAt: "2026-08-01T11:00:00Z",
+  questionCount: 1,
+  earned: 8,
+  total: 10,
+  percent: 80,
+  passingScore: 66,
+  passed: true,
+  counted: true,
+  domains: [{ domain: "Observability", earned: 8, total: 10 }],
+};
+
+const attemptResults = {
+  bank: "ckad-mock-01",
+  gradedAt: "2026-08-01T11:00:00Z",
+  earned: 8,
+  total: 10,
+  percent: 80,
+  passingScore: 66,
+  passed: true,
+  mode: "exam",
+  questions: [
+    {
+      id: "q01",
+      title: "Expose the deployment",
+      domain: "Observability",
+      verdict: "correct",
+      earned: 8,
+      total: 10,
+      checks: [],
+    },
+  ],
+  domains: [{ domain: "Observability", earned: 8, total: 10, weightPct: 100, questionCount: 1 }],
+};
+
+interface Posted {
+  url: string;
+  body: string;
+}
+
+let posted: Posted[];
+let identity: Me | null;
+/** Status for the next POST /api/session/start, and what it answers with. */
+let startAnswer: { status: number; body: unknown };
+
+function stubFetch() {
+  posted = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const json = (body: unknown, status = 200) =>
+        new Response(JSON.stringify(body), { status });
+
+      if (init?.method === "POST") {
+        posted.push({ url, body: String(init.body ?? "") });
+      }
+      if (url.endsWith("/api/me")) {
+        // A local facilitator JSON-404s any /api/* it does not know, and
+        // that 404 IS the detection mechanism.
+        return identity === null
+          ? json({ error: "not found" }, 404)
+          : json(identity);
+      }
+      if (url.endsWith("/api/session/start") && init?.method === "POST") {
+        return json(startAnswer.body, startAnswer.status);
+      }
+      if (url.endsWith("/hub/session/end")) return new Response(null, { status: 204 });
+      if (url.endsWith("/api/history")) {
+        return json({
+          attempts: [attemptRecord],
+          summary: { attempts: 1, passedCount: 1, trackCount: 5, weakDomains: [] },
+        });
+      }
+      if (url.includes("/api/history/")) return json(attemptResults);
+      for (const [path, body] of Object.entries(localStubs)) {
+        if (url.endsWith(path)) return json(body);
+      }
+      return json({});
+    }),
+  );
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true, now });
+  identity = me();
+  startAnswer = { status: 202, body: { starting: true, state: "pending" } };
+  stubFetch();
+  window.location.hash = "";
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  window.location.hash = "";
+});
+
+// The property the whole design rests on: `./sim up` is byte-identical,
+// and the only trace of hosted mode in it is one 404 at page load.
+test("a facilitator that 404s /api/me gets the local app and no sign-in", async () => {
+  identity = null;
+  render(<App />);
+
+  expect(await screen.findByRole("heading", { name: /path to kubestronaut/i })).toBeTruthy();
+  expect(screen.queryByRole("link", { name: /continue with github/i })).toBeNull();
+});
+
+// Something in front of a facilitator answering 200 with its own body is
+// not a hub, however healthy the status line looks. Guessing "hosted"
+// wrongly puts a login screen over a product that has no accounts.
+test("a 200 that is not the hub's shape is still read as local", async () => {
+  identity = { notAHub: true } as unknown as Me;
+  render(<App />);
+
+  expect(await screen.findByRole("heading", { name: /path to kubestronaut/i })).toBeTruthy();
+});
+
+test("a signed-out visitor gets the sign-in screen and the seat count", async () => {
+  identity = {
+    authenticated: false,
+    authMode: "github",
+    loginURL: "/hub/auth/login",
+    seats: { practical: { used: 1, total: 3 } },
+  };
+  render(<App />);
+
+  const link = await screen.findByRole("link", { name: /continue with github/i });
+  expect(link.getAttribute("href")).toBe("/hub/auth/login");
+  // Capacity before sign-in, on purpose: someone deciding whether to
+  // create an account is entitled to know there is somewhere to sit.
+  expect(screen.getByText(/2 of 3 hands-on seats free/i)).toBeTruthy();
+});
+
+// AUTH_MODE=header behind a proxy that did not identify anyone. There is
+// genuinely nothing to sign in to, and a button that 404s is worse.
+test("no login URL means no sign-in button", async () => {
+  identity = { authenticated: false, authMode: "header" };
+  render(<App />);
+
+  expect(await screen.findByRole("alert")).toBeTruthy();
+  expect(screen.queryByRole("link", { name: /continue with github/i })).toBeNull();
+});
+
+test("signed in with no session, the lobby offers a flavour and posts a kind", async () => {
+  const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+  render(<App />);
+
+  expect(await screen.findByRole("heading", { name: /ready when you are, octocat/i })).toBeTruthy();
+  expect(screen.getByRole("heading", { name: /hands-on exam/i })).toBeTruthy();
+  expect(screen.getByText("2 of 3 free")).toBeTruthy();
+  expect(screen.getByText("30 of 30 free")).toBeTruthy();
+
+  await user.click(screen.getAllByRole("button", { name: "Start" })[0]);
+
+  await waitFor(() => {
+    const start = posted.find((p) => p.url.endsWith("/api/session/start"));
+    expect(start).toBeTruthy();
+    // A kind, and deliberately no mode: this call is admission, not the
+    // start of an attempt. The facilitator inside the Pod configures
+    // that later, through the same door.
+    expect(JSON.parse(start!.body)).toEqual({ kind: "practical" });
+  });
+});
+
+// A deployment with no MCQ seats does not offer MCQ. The hub refuses it
+// anyway; a disabled card explaining an option that does not exist here
+// is a worse way to learn that.
+test("a flavour with no seats configured is not offered at all", async () => {
+  identity = me({ seats: { practical: { used: 0, total: 3 } } });
+  render(<App />);
+
+  expect(await screen.findByRole("heading", { name: /hands-on exam/i })).toBeTruthy();
+  expect(screen.queryByRole("heading", { name: /multiple choice/i })).toBeNull();
+});
+
+test("a full pool answers 409 with a place in the queue", async () => {
+  const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+  startAnswer = {
+    status: 409,
+    body: {
+      error: "every practical seat is in use",
+      queued: true,
+      position: 2,
+      seats: { used: 3, total: 3 },
+      kind: "practical",
+    },
+  };
+  render(<App />);
+
+  await screen.findByRole("heading", { name: /ready when you are/i });
+  await user.click(screen.getAllByRole("button", { name: "Start" })[0]);
+  // What the hub does next: the place is in the identity from now on, so
+  // a reload lands back on it.
+  identity = me({ queue: { position: 2 } });
+
+  const dialog = await screen.findByRole("dialog");
+  expect(dialog.textContent).toMatch(/number 2 in the queue/i);
+  // The hold is the mechanism, and it is why the page must stay open.
+  expect(dialog.textContent).toMatch(/held briefly/i);
+
+  await user.click(screen.getByRole("button", { name: /wait here/i }));
+  // Dismissing the interruption must not lose the state: a place in a
+  // queue is standing information, and the page keeps saying so.
+  await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  expect(screen.getByText(/number 2 in the queue/i)).toBeTruthy();
+});
+
+// The two waits mean different things to the person waiting, so they say
+// different things. Boots are serialised because two at once make both
+// slow rather than either fast.
+test("pending and starting are different screens", async () => {
+  identity = me({
+    session: {
+      kind: "practical",
+      pod: "sim-session-practical-583231",
+      state: "pending",
+      startedAt: new Date(now - 30_000).toISOString(),
+      expiresAt: new Date(now + 36_000_000).toISOString(),
+      lastSeen: new Date(now).toISOString(),
+    },
+  });
+  const { unmount } = render(<App />);
+  expect(await screen.findByRole("heading", { name: /waiting for a slot/i })).toBeTruthy();
+  unmount();
+
+  identity = me({
+    session: {
+      kind: "practical",
+      pod: "sim-session-practical-583231",
+      state: "starting",
+      startedAt: new Date(now - 30_000).toISOString(),
+      expiresAt: new Date(now + 36_000_000).toISOString(),
+      lastSeen: new Date(now).toISOString(),
+    },
+  });
+  render(<App />);
+  expect(await screen.findByRole("heading", { name: /building your environment/i })).toBeTruthy();
+});
+
+test("a failed boot keeps the seat, says why, and offers both ways out", async () => {
+  identity = me({
+    session: {
+      kind: "practical",
+      pod: "sim-session-practical-583231",
+      state: "failed",
+      startedAt: new Date(now - 600_000).toISOString(),
+      expiresAt: new Date(now + 36_000_000).toISOString(),
+      lastSeen: new Date(now).toISOString(),
+      error: "boot timed out after 20m0s",
+    },
+  });
+  render(<App />);
+
+  expect(await screen.findByRole("heading", { name: /did not start/i })).toBeTruthy();
+  expect(screen.getByText(/boot timed out after 20m0s/)).toBeTruthy();
+  expect(screen.getByRole("button", { name: /try again/i })).toBeTruthy();
+  expect(screen.getByRole("button", { name: /give up this seat/i })).toBeTruthy();
+});
+
+test("a ready session renders the ordinary app with a lease countdown over it", async () => {
+  identity = me({
+    session: {
+      kind: "practical",
+      pod: "sim-session-practical-583231",
+      state: "ready",
+      startedAt: new Date(now - 600_000).toISOString(),
+      expiresAt: new Date(now + 2 * 3600_000).toISOString(),
+      lastSeen: new Date(now).toISOString(),
+    },
+  });
+  render(<App />);
+
+  // The exam selector: the same screen a local candidate sees, reaching
+  // the same facilitator through the hub's proxy.
+  expect(await screen.findByRole("heading", { name: /path to kubestronaut/i })).toBeTruthy();
+  expect(screen.getByText("octocat")).toBeTruthy();
+  expect(screen.getByText("2:00:00 left")).toBeTruthy();
+});
+
+// The whole argument for hosted history: a record you can read without
+// spending a seat to do it.
+test("a past attempt opens from the dashboard with no environment running", async () => {
+  const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+  window.location.hash = "#/progress";
+  render(<App />);
+
+  const row = await screen.findByRole("link", { name: /review the ckad attempt/i });
+  await user.click(row);
+
+  expect(await screen.findByText(/expose the deployment/i)).toBeTruthy();
+  // Said before anything else, because everything below it is identical
+  // to the screen shown at the end of a live exam and is not one.
+  expect(screen.getByText(/this is a record, not a live session/i)).toBeTruthy();
+});
+
+// Deep-dive links inside a past attempt must stay inside it. The same
+// component renders the live results screen, where they point at
+// /results — following those from a record would jump into a session
+// that may not exist.
+test("the deep dive inside a past attempt links back into the record", async () => {
+  window.location.hash = "#/history/8da8fa50";
+  render(<App />);
+
+  const open = await screen.findByRole("link", { name: /open/i });
+  expect(open.getAttribute("href")).toBe("#/history/8da8fa50/q01");
+});
+
+// Import is refused by the hub with a 501, and the reason is a property
+// of hosted history rather than a missing feature: this is the durable
+// copy, and accepting an arbitrary document would let it hold attempts
+// that were never graded. Export stays — it still imports into a local
+// `./sim`.
+test("the hosted dashboard exports but does not import", async () => {
+  window.location.hash = "#/progress";
+  render(<App />);
+
+  expect(await screen.findByRole("link", { name: /export/i })).toBeTruthy();
+  expect(screen.queryByRole("button", { name: /^import$/i })).toBeNull();
+});

--- a/ui/src/screens/HostedBooting.tsx
+++ b/ui/src/screens/HostedBooting.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { endHostedSession, startHostedSession, type HostedSession } from "../api";
+import { PendingBar } from "../components/Pending";
+import { formatElapsed } from "../lib/format";
+import { useTick } from "../lib/useTick";
+import { strings } from "../strings";
+
+interface HostedBootingProps {
+  session: HostedSession;
+  onChanged: () => void;
+}
+
+/**
+ * A seat is held and the environment is not up yet.
+ *
+ * Two waiting states, and they say different things because they mean
+ * different things to the person waiting. `pending` is "nothing is wrong,
+ * someone else is booting first" — the hub builds Pods one at a time
+ * because boot is CPU-bound and two at once makes both slow. `starting`
+ * is their own Pod, building a real two-node cluster.
+ *
+ * The elapsed counter is the signal that works without motion: it ticks
+ * identically whether or not the candidate accepts animation, and the bar
+ * beneath it is the enhancement. Same rule as the grading screen.
+ */
+export function HostedBooting({ session, onChanged }: HostedBootingProps) {
+  const [busy, setBusy] = useState(false);
+  const failed = session.state === "failed";
+  const now = useTick(!failed);
+  const started = Date.parse(session.startedAt);
+  const elapsed = Number.isNaN(started) ? 0 : now - started;
+
+  const retry = async () => {
+    setBusy(true);
+    // End first, then ask again: a failed session still holds its seat so
+    // the candidate can read why, and starting without giving that up
+    // would simply hand back the same failed session.
+    await endHostedSession().catch(() => undefined);
+    await startHostedSession(session.kind).catch(() => undefined);
+    setBusy(false);
+    onChanged();
+  };
+
+  const giveUp = async () => {
+    setBusy(true);
+    await endHostedSession().catch(() => undefined);
+    setBusy(false);
+    onChanged();
+  };
+
+  if (failed) {
+    return (
+      <div className="page hosted-screen">
+        <h1>{strings.hosted.bootFailedTitle}</h1>
+        {session.error && <p className="error-text">{session.error}</p>}
+        <div className="score-actions">
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={() => void retry()}
+            disabled={busy}
+          >
+            {strings.hosted.bootRetry}
+          </button>
+          <button type="button" className="btn" onClick={() => void giveUp()} disabled={busy}>
+            {strings.hosted.bootGiveUp}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const pending = session.state === "pending";
+  const title = pending ? strings.hosted.bootPendingTitle : strings.hosted.bootStartingTitle;
+
+  return (
+    <div className="page hosted-screen hosted-booting">
+      <h1>{title}</h1>
+      <p>{pending ? strings.hosted.bootPendingBody : strings.hosted.bootStartingBody}</p>
+      <div className="score-loading-progress">
+        <PendingBar label={title} />
+        {/* aria-hidden and tabular, matching the control overlay: a clock
+            that re-announces every second buries the line that changed. */}
+        <p className="score-loading-elapsed" aria-hidden="true">
+          {strings.hosted.bootElapsed(formatElapsed(elapsed))}
+        </p>
+      </div>
+      <button type="button" className="btn" onClick={() => void giveUp()} disabled={busy}>
+        {strings.hosted.bootGiveUp}
+      </button>
+    </div>
+  );
+}

--- a/ui/src/screens/HostedSignIn.tsx
+++ b/ui/src/screens/HostedSignIn.tsx
@@ -1,0 +1,56 @@
+import type { Me } from "../api";
+import { strings } from "../strings";
+
+/**
+ * The one screen a signed-out visitor sees.
+ *
+ * It exists only in hosted mode. The local product has no accounts and
+ * gains none — this is served by the hub, in front of a facilitator that
+ * still has no authentication of any kind and never learns that any of
+ * this happened.
+ *
+ * Seat counts before sign-in, deliberately: someone deciding whether to
+ * create an account here is entitled to know whether there is anywhere
+ * to sit. It is a capacity number, not a fact about anyone.
+ */
+export function HostedSignIn({ me }: { me: Me }) {
+  const seats = me.seats?.practical;
+
+  return (
+    <div className="page hosted-screen">
+      <header className="page-head">
+        <div>
+          <h1>{strings.hosted.signInTitle}</h1>
+          <p className="page-lead">{strings.hosted.signInLead}</p>
+        </div>
+      </header>
+
+      <div className="hosted-card">
+        {me.loginURL ? (
+          <>
+            {/* A link and not a fetch: the OAuth flow is a redirect to
+                GitHub and back, and there is nothing for JavaScript to
+                do in the middle of it. */}
+            <a className="btn btn-primary hosted-signin" href={me.loginURL}>
+              {strings.hosted.signInGitHub}
+            </a>
+            {seats && (
+              <p className="hosted-seats" role="status">
+                {strings.hosted.signInSeats(seats.used, seats.total)}
+              </p>
+            )}
+          </>
+        ) : (
+          // AUTH_MODE=header or none, reached without the header being
+          // set. There is genuinely no login here, and offering a button
+          // that 404s would be worse than saying so.
+          <p className="hosted-unavailable" role="alert">
+            {strings.hosted.signInUnavailable}
+          </p>
+        )}
+      </div>
+
+      <p className="hosted-local">{strings.hosted.signInLocal}</p>
+    </div>
+  );
+}

--- a/ui/src/screens/HostedStart.tsx
+++ b/ui/src/screens/HostedStart.tsx
@@ -1,0 +1,182 @@
+import { useState } from "react";
+import {
+  endHostedSession,
+  startHostedSession,
+  type Me,
+  type SessionKind,
+  type Seats,
+} from "../api";
+import { Dialog } from "../components/Dialog";
+import { strings } from "../strings";
+
+interface HostedStartProps {
+  me: Me;
+  /** Re-ask /api/me now, rather than waiting out the poll interval. */
+  onChanged: () => void;
+}
+
+/** One flavour's card: what it is, what it costs, and the button. */
+interface Flavour {
+  kind: SessionKind;
+  title: string;
+  body: string;
+  seats: Seats | undefined;
+}
+
+/**
+ * The hosted lobby: signed in, no session yet.
+ *
+ * It offers a FLAVOUR, not a bank, and that is not a simplification. In
+ * hosted mode the bank each flavour runs is a deployment value — the
+ * chart's `sessions.practical.bank` — because the candidate has no
+ * environment yet and therefore nothing to ask for a bank list from. The
+ * exam selector they know is inside the session, served by their own
+ * facilitator, and they reach it the moment their Pod answers.
+ */
+export function HostedStart({ me, onChanged }: HostedStartProps) {
+  const [starting, setStarting] = useState<SessionKind | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  // Two separate things, and conflating them was the bug worth avoiding:
+  // `queued` is the standing fact — this candidate is in a queue — and
+  // `dialog` is whether the interruption announcing it is on screen.
+  // Dismissing the dialog must not lose the place, and the place must
+  // survive the seconds before /api/me next answers with `queue` in it.
+  const [queued, setQueued] = useState<{ position: number } | null>(null);
+  const [dialog, setDialog] = useState(false);
+  // The server's number wins once it has one: the queue moves while this
+  // page sits open, and the 409's position is only true at the moment it
+  // was issued.
+  const place = me.queue?.position ?? queued?.position ?? 0;
+
+  const leaveQueue = async () => {
+    setQueued(null);
+    setDialog(false);
+    // The hub treats a queued user with no session as a dequeue, so this
+    // is the same call that ends a running one. Failures are not raised:
+    // the worst case is a place kept in a queue the candidate stopped
+    // watching, and the hold expires on its own.
+    await endHostedSession().catch(() => undefined);
+    onChanged();
+  };
+
+  const start = async (kind: SessionKind) => {
+    setStarting(kind);
+    setError(null);
+    try {
+      const result = await startHostedSession(kind);
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      if ("queued" in result) {
+        setQueued({ position: result.position });
+        setDialog(true);
+        onChanged();
+        return;
+      }
+      // 202: a seat is held and a Pod is being built. Nothing more to do
+      // here — the identity poll is already watching, and it switches
+      // this screen out for the boot screen on its next tick.
+      onChanged();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setStarting(null);
+    }
+  };
+
+  const offered: Flavour[] = [
+    {
+      kind: "practical",
+      title: strings.hosted.practicalTitle,
+      body: strings.hosted.practicalBody,
+      seats: me.seats?.practical,
+    },
+    {
+      kind: "mcq",
+      title: strings.hosted.mcqTitle,
+      body: strings.hosted.mcqBody,
+      seats: me.seats?.mcq,
+    },
+  ];
+  // A flavour a deployment gave no seats to is not offered at all. The
+  // hub refuses it anyway, and a disabled card explaining an option this
+  // deployment does not have would be a worse way to find that out.
+  const flavours = offered.filter((f) => f.seats !== undefined);
+
+  return (
+    <div className="page hosted-screen">
+      <header className="page-head">
+        <div>
+          <h1>{strings.hosted.startTitle(me.user?.login ?? "")}</h1>
+          <p className="page-lead">{strings.hosted.startLead}</p>
+        </div>
+      </header>
+
+      {error && (
+        <p className="progress-notice" role="alert">
+          {strings.hosted.startFailed(error)}
+        </p>
+      )}
+
+      {/* Standing state, not an interruption: it survives the dialog
+          being dismissed and updates as the queue moves. */}
+      {place > 0 && (
+        <div className="hosted-queue" role="status">
+          <p className="hosted-queue-place">{strings.hosted.queueBody(place)}</p>
+          <p className="hosted-queue-hold">{strings.hosted.queueHold}</p>
+          <button type="button" className="btn" onClick={() => void leaveQueue()}>
+            {strings.hosted.queueLeave}
+          </button>
+        </div>
+      )}
+
+      <ul className="hosted-flavours">
+        {flavours.map((f) => {
+          const full = f.seats !== undefined && f.seats.used >= f.seats.total;
+          return (
+            <li key={f.kind}>
+              <article className="hosted-flavour" data-full={full || undefined}>
+                <h2>{f.title}</h2>
+                <p>{f.body}</p>
+                <p className="hosted-flavour-seats">
+                  {f.seats === undefined
+                    ? null
+                    : full
+                      ? strings.hosted.seatsFull(f.seats.total)
+                      : strings.hosted.seatsFree(f.seats.used, f.seats.total)}
+                </p>
+                {/* Enabled even when full, deliberately. The answer to a
+                    full pool is a place in the queue, and a greyed-out
+                    button offers no way to ask for one. */}
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  onClick={() => void start(f.kind)}
+                  disabled={starting !== null}
+                >
+                  {starting === f.kind ? strings.hosted.starting : strings.hosted.start}
+                </button>
+              </article>
+            </li>
+          );
+        })}
+      </ul>
+
+      {dialog && place > 0 && (
+        <Dialog title={strings.hosted.queueTitle} onClose={() => setDialog(false)}>
+          <p>{strings.hosted.queueBody(place)}</p>
+          <p>{strings.hosted.queueHold}</p>
+          <div className="confirm-actions">
+            <button type="button" className="btn" onClick={() => void leaveQueue()}>
+              {strings.hosted.queueLeave}
+            </button>
+            <button type="button" className="btn btn-primary" onClick={() => setDialog(false)}>
+              {strings.hosted.queueWait}
+            </button>
+          </div>
+        </Dialog>
+      )}
+    </div>
+  );
+}

--- a/ui/src/screens/Progress.tsx
+++ b/ui/src/screens/Progress.tsx
@@ -27,11 +27,29 @@ interface ProgressProps {
    * panel's drill button can do anything at all.
    */
   catalogVersion: number;
+  /**
+   * Served by the hub rather than by a facilitator, which changes three
+   * things on this screen: history outlives every environment (so the
+   * lead saying it lives in a state volume would be wrong), each row can
+   * be opened because the hub keeps the whole graded document, and there
+   * is nothing to import into — hosted history is the durable copy, not
+   * a fragile one that needs a backup.
+   */
+  hosted?: boolean;
 }
 
 /** Everything one render of this screen needs, fetched together. */
 interface Dashboard {
-  catalog: CatalogResponse;
+  /**
+   * The bank list, or null when there is no environment to ask.
+   *
+   * Never null locally. In hosted mode the catalog is the session Pod's —
+   * it names the banks THAT environment can load — so before a session
+   * exists there is no honest answer, and the path cards it feeds are
+   * simply not drawn. The attempt record below them is the hub's and is
+   * always there, which is the half that matters without a seat.
+   */
+  catalog: CatalogResponse | null;
   history: HistoryResponse;
   /**
    * The LOADED bank's curriculum, or null when /api/exam did not answer.
@@ -136,7 +154,7 @@ function timeCell(record: AttemptRecord): string {
   return record.durationSeconds ? strings.progress.noScore : strings.progress.untimed;
 }
 
-export function Progress({ catalogVersion }: ProgressProps) {
+export function Progress({ catalogVersion, hosted = false }: ProgressProps) {
   const [erasing, setErasing] = useState(false);
   // Which destructive/slow action is in flight, so every other one is
   // held rather than racing it. One value, not one flag each: two of
@@ -151,7 +169,7 @@ export function Progress({ catalogVersion }: ProgressProps) {
   const state = useAsync<Dashboard>(
     async (signal) => {
       const [catalog, history, exam] = await Promise.all([
-        getCatalog(signal),
+        getCatalog(signal).catch(() => null),
         getHistory(signal),
         getExam(signal).catch(() => null),
       ]);
@@ -214,7 +232,9 @@ export function Progress({ catalogVersion }: ProgressProps) {
       <header className="page-head">
         <div>
           <h1>{strings.progress.title}</h1>
-          <p className="page-lead">{strings.progress.lead}</p>
+          <p className="page-lead">
+            {hosted ? strings.progress.leadHosted : strings.progress.lead}
+          </p>
         </div>
         <div className="progress-actions">
           {/* A link, not a fetch: the browser saves the document under the
@@ -226,7 +246,16 @@ export function Progress({ catalogVersion }: ProgressProps) {
           {/* The button is the control; the input is the mechanism. A file
               picker is the only way a browser can hand a document back,
               and an export with no way in would be a one-way door — but
-              the visible vocabulary of this screen stays buttons. */}
+              the visible vocabulary of this screen stays buttons.
+
+              Not offered in hosted mode, where the hub refuses it with a
+              501: this record is the durable copy rather than the
+              fragile one, and accepting an arbitrary attempt document
+              would let a history that survives on purpose hold entries
+              that were never graded. Export stays, because an export
+              from here still imports into a local `./sim`. */}
+          {!hosted && (
+            <>
           <button
             type="button"
             className="btn"
@@ -244,6 +273,8 @@ export function Progress({ catalogVersion }: ProgressProps) {
             aria-label={strings.progress.importPick}
             onChange={(e) => void handleFile(e.target.files?.[0])}
           />
+            </>
+          )}
           <button
             type="button"
             className="btn btn-danger"
@@ -292,21 +323,31 @@ export function Progress({ catalogVersion }: ProgressProps) {
           // certification cannot be drilled from here whatever the rollup
           // says — and a button that started a run over domains the loaded
           // bank has never heard of would draw nothing at all.
+          // A drill is started against the LOADED bank, so it needs both
+          // a curriculum to check the domains against and a catalog to
+          // name. Hosted mode before a session has neither.
           const curriculum = new Set((exam?.domains ?? []).map((d) => d.name));
-          const drillable = weak.map((w) => w.domain).filter((d) => curriculum.has(d));
+          const drillable =
+            catalog === null ? [] : weak.map((w) => w.domain).filter((d) => curriculum.has(d));
           // Whether "these" covers the whole visible list. When it does
           // not, the button has to say so: the rows it will skip are on
           // screen, directly above it.
           const partial = drillable.length > 0 && drillable.length < weak.length;
-          const activeExam = catalog.exams.find((e) => e.id === catalog.active);
+          const activeExam = catalog?.exams.find((e) => e.id === catalog.active);
 
           return (
             <>
-              <ul className="path-cards" aria-label={strings.progress.pathLabel}>
-                {catalog.exams.map((e) => (
-                  <PathCard key={e.id} exam={e} />
-                ))}
-              </ul>
+              {/* The path cards describe what THIS environment can load.
+                  With no environment there is nothing truthful to draw,
+                  and a row of empty cards would read as "you have never
+                  attempted anything" — which the table below disproves. */}
+              {catalog && (
+                <ul className="path-cards" aria-label={strings.progress.pathLabel}>
+                  {catalog.exams.map((e) => (
+                    <PathCard key={e.id} exam={e} />
+                  ))}
+                </ul>
+              )}
 
               <div className="progress-body">
                 <section className="history-panel">
@@ -335,7 +376,24 @@ export function Progress({ catalogVersion }: ProgressProps) {
                             {attempts.map((a) => (
                               <tr key={a.id}>
                                 <th scope="row" className="history-exam">
-                                  {a.certification || a.examTitle || a.bank}
+                                  {/* Hosted only: the hub keeps the whole
+                                      graded document, a local facilitator
+                                      keeps only this row. A link that
+                                      404s would be worse than none. */}
+                                  {hosted ? (
+                                    <a
+                                      className="history-open"
+                                      href={`#/history/${a.id}`}
+                                      aria-label={strings.progress.reviewRow(
+                                        a.certification || a.examTitle || a.bank,
+                                        formatAttemptDate(a.gradedAt),
+                                      )}
+                                    >
+                                      {a.certification || a.examTitle || a.bank}
+                                    </a>
+                                  ) : (
+                                    (a.certification || a.examTitle || a.bank)
+                                  )}
                                 </th>
                                 <td className="history-mode">{modeCell(a)}</td>
                                 <td className="history-date">{formatAttemptDate(a.gradedAt)}</td>
@@ -423,7 +481,7 @@ export function Progress({ catalogVersion }: ProgressProps) {
                     <button
                       type="button"
                       className="btn weak-drill"
-                      onClick={() => navigate(drillHref(catalog.active, drillable))}
+                      onClick={() => catalog && navigate(drillHref(catalog.active, drillable))}
                     >
                       {partial ? strings.progress.drillSome(drillable.length) : strings.progress.drill}
                     </button>

--- a/ui/src/screens/Review.tsx
+++ b/ui/src/screens/Review.tsx
@@ -1,0 +1,95 @@
+import { getAttemptResults, type Results } from "../api";
+import { Async } from "../components/Async";
+import { DomainBreakdown } from "../components/DomainBreakdown";
+import { ResultsBanner } from "../components/ResultsBanner";
+import { TaskVerdicts } from "../components/TaskVerdicts";
+import { formatAttemptDate } from "../lib/attemptHistory";
+import { useAsync } from "../lib/useAsync";
+import { strings } from "../strings";
+import { Explain } from "./Explain";
+
+interface ReviewProps {
+  /** The attempt id from `#/history/<attemptId>`. */
+  attemptId: string;
+  /** The question from `#/history/<attemptId>/<questionId>`, if any. */
+  questionId: string | null;
+}
+
+/**
+ * A past attempt, read back whole.
+ *
+ * Hosted only, and the reason is a property of the local product rather
+ * than a gap in it: a local facilitator records the attempt SUMMARY in
+ * its state volume and keeps the full graded document in /session, which
+ * the next attempt overwrites. The hub keeps both, because it exists
+ * precisely so that nothing important dies with a Pod.
+ *
+ * Rendered by the same three components the end-of-exam screen uses, and
+ * that is the point — a score means the same thing in October as it did
+ * in August, so it should not be a different screen. The only thing this
+ * adds is the line saying which of the two you are looking at.
+ */
+export function Review({ attemptId, questionId }: ReviewProps) {
+  const state = useAsync<Results>((signal) => getAttemptResults(attemptId, signal), [attemptId]);
+
+  return (
+    <Async
+      state={state}
+      loading={<p className="page-loading">{strings.review.loading}</p>}
+      error={(message, reload) => (
+        <div className="catalog-error" role="alert">
+          <p className="catalog-error-body">{strings.review.loadFailed(message)}</p>
+          <button type="button" className="btn" onClick={reload}>
+            {strings.review.retry}
+          </button>
+        </div>
+      )}
+    >
+      {(results) =>
+        questionId ? (
+          <div className="score-screen explain-screen">
+            {/* Keyed by the id for the same reason Score keys it: stepping
+                to the next task must be a fresh mount, or the previous
+                task's solution sits under the next task's title while its
+                fetch is still in flight. */}
+            <Explain
+              key={questionId}
+              results={results}
+              questionId={questionId}
+              basePath={`/history/${attemptId}`}
+            />
+          </div>
+        ) : (
+          <div className="score-screen">
+            <div className="results-card">
+              {/* Said before the banner, because everything below this
+                  line is pixel-identical to the screen shown at the end
+                  of a live exam and is not one. */}
+              <p className="review-note" role="status">
+                {strings.review.banner(formatAttemptDate(results.gradedAt))}
+              </p>
+              <ResultsBanner results={results} endReason="" />
+              <div className="results-body">
+                <aside className="results-aside">
+                  <DomainBreakdown
+                    questions={results.questions}
+                    domains={results.domains}
+                    passingScore={results.passingScore}
+                  />
+                </aside>
+                {/* No "new attempt" and no drill button: this screen ends
+                    nothing and starts nothing. The lobby is where a next
+                    session begins, and it is one click away in the
+                    header. */}
+                <TaskVerdicts
+                  questions={results.questions}
+                  basePath={`/history/${attemptId}`}
+                />
+              </div>
+            </div>
+          </div>
+        )
+      }
+    </Async>
+  );
+}

--- a/ui/src/strings.ts
+++ b/ui/src/strings.ts
@@ -1194,6 +1194,11 @@ export const strings = {
     // No backticks: this is a plain string rendered as text, not markdown,
     // so a pair of them arrives on screen as a pair of them.
     lead: "Every attempt this environment has graded. Kept in its own volume rather than in this browser, so a reset, a bank switch and a purge all leave it where it is.",
+    // The hosted record. It is the durable copy by construction — the
+    // environment it was taken in is destroyed on purpose — so it says
+    // that rather than naming a volume the candidate cannot see.
+    leadHosted:
+      "Every attempt you have finished here. Kept against your account rather than in the environment, so it outlives every session you start. Open one to read it back in full.",
     export: "Export",
     // Both hints describe a button, so both belong ON the button rather
     // than in the page flow. Rendered on this screen as the accessible
@@ -1308,5 +1313,111 @@ export const strings = {
     loadFailed: (detail: string) =>
       `Couldn't load your history (${detail}). It is served by the facilitator from its state volume; check it with \`docker compose ps facilitator\`.`,
     retry: "Retry",
+    // Hosted only. A row links to the attempt it describes, because the
+    // hub keeps the whole graded document and not just the summary line.
+    reviewRow: (exam: string, date: string) => `Review the ${exam} attempt from ${date}`,
+  },
+
+  // Everything a hosted deployment adds, and nothing a local one shows.
+  //
+  // `./sim up` never renders a single string in this group: the SPA asks
+  // GET /api/me once on load, a facilitator 404s it, and the whole
+  // surface below stays out of the tree. Copy here therefore talks about
+  // seats, queues and sign-in — none of which exist in the local product
+  // and none of which should leak into it.
+  hosted: {
+    // The sign-in screen.
+    signInTitle: "Sign in to sit an exam",
+    // Says what an account is FOR. Nobody signs into a practice exam for
+    // fun; they do it because the record is the point.
+    signInLead:
+      "A hosted session gives you a real cluster for a few hours. Signing in is how your attempts stay yours — every graded exam is kept against your account, and it outlives the environment it was taken in.",
+    signInGitHub: "Continue with GitHub",
+    signInSeats: (used: number, total: number) =>
+      used >= total
+        ? `All ${total} hands-on seats are in use right now — you can still join the queue.`
+        : `${total - used} of ${total} hands-on seats free.`,
+    // No login to offer. AUTH_MODE=header sits behind someone else's
+    // proxy, and if it did not identify you, this app cannot.
+    signInUnavailable:
+      "This deployment identifies you through the proxy in front of it, and that proxy did not say who you are. There is nothing to sign in to here.",
+    // The local product, stated plainly on the way in. It is uncapped and
+    // it is the reference; hosting is the try-it-out tier.
+    signInLocal:
+      "Prefer no caps and no queue? The whole thing runs on your own machine — clone the repository and run ./sim up.",
+
+    // The lobby: signed in, no session yet.
+    startTitle: (login: string) => `Ready when you are, ${login}`,
+    startLead:
+      "Pick what to sit. A hands-on session builds a real two-node cluster and takes a few minutes to come up; multiple choice is ready immediately.",
+    practicalTitle: "Hands-on exam",
+    practicalBody:
+      "A two-node cluster, two shells and a desktop with a browser, in your own environment. This is the full simulator.",
+    mcqTitle: "Multiple choice",
+    mcqBody:
+      "Answered in this browser. No cluster, no waiting, and it works on a phone.",
+    seatsFree: (used: number, total: number) => `${total - used} of ${total} free`,
+    seatsFull: (total: number) => `all ${total} in use`,
+    start: "Start",
+    starting: "Starting…",
+    startFailed: (detail: string) => `Could not start a session: ${detail}`,
+
+    // The queue dialog, raised by the 409.
+    queueTitle: "Every seat is taken",
+    queueBody: (position: number) =>
+      position === 1
+        ? "You are next. The moment a seat is given up, yours starts building."
+        : `You are number ${position} in the queue.`,
+    // The hold is the mechanism and it is worth stating: a browser that
+    // closed an hour ago must not keep a seat warm, so the offer has to
+    // be claimed.
+    queueHold:
+      "Keep this page open. When a seat reaches you it is held briefly — if nothing claims it, it passes to the next person.",
+    queueLeave: "Leave the queue",
+    queueWait: "Wait here",
+
+    // Booting. The two states differ for the person waiting, so they say
+    // different things.
+    bootPendingTitle: "Waiting for a slot",
+    bootPendingBody:
+      "Your seat is held. Environments are built one at a time — building two at once makes both slow rather than making either fast.",
+    bootStartingTitle: "Building your environment",
+    bootStartingBody:
+      "A two-node Kubernetes cluster, the exam images and 22 tasks' worth of setup. It usually takes three to six minutes; nothing is lost if you close this tab.",
+    bootElapsed: (elapsed: string) => `${elapsed} so far`,
+    bootFailedTitle: "Your environment did not start",
+    bootRetry: "Try again",
+    bootGiveUp: "Give up this seat",
+
+    // The header chip.
+    chipLabel: "Session",
+    chipTimeLeft: (left: string) => `${left} left`,
+    // Said out loud once the end is close enough to plan around.
+    chipEndingSoon: (left: string) => `Ends in ${left}`,
+    chipExpired: "Session over",
+    endSession: "End session",
+    endConfirmTitle: "End this session?",
+    // The distinction that matters most on this screen. Ending the seat
+    // destroys the environment; it does not throw away a graded attempt.
+    endConfirmBody:
+      "Your environment is destroyed and the seat goes back to the pool. Attempts you have already finished stay in your history — this only ends the environment.",
+    endConfirm: "End session",
+    endCancel: "Keep working",
+    endFailed: (detail: string) => `Could not end your session: ${detail}`,
+    signOut: "Sign out",
+  },
+
+  // Reading a past attempt back, whole. Hosted only: the hub is the one
+  // thing that keeps a graded results document after the environment
+  // that produced it is gone.
+  review: {
+    back: "Progress",
+    crumb: "Past attempt",
+    loading: "Loading that attempt…",
+    loadFailed: (detail: string) => `Couldn't load that attempt: ${detail}`,
+    retry: "Retry",
+    // Said on the page, because everything below it looks exactly like
+    // the screen shown at the end of a live exam and is not one.
+    banner: (date: string) => `Sat on ${date}. This is a record, not a live session.`,
   },
 } as const;

--- a/ui/src/theme.css
+++ b/ui/src/theme.css
@@ -5958,3 +5958,213 @@
     margin-left: 0;
   }
 }
+
+/* ---------------------------------------------------------------------
+   Hosted mode
+
+   Nothing below renders in the local product. The whole surface — sign
+   in, the lobby, the queue, the boot screen, the header chip — exists
+   only when the SPA is served by the hub, and `./sim up` never reaches
+   any of these selectors.
+
+   It borrows the page vocabulary rather than inventing one: the same
+   card, the same border, the same spacing scale as the exam selector.
+   A hosted deployment is the same product with a door in front of it,
+   and a lobby that looked like a different application would say
+   otherwise. */
+
+.hosted-screen {
+  max-width: 56rem;
+}
+
+.hosted-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-6);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-l);
+}
+
+/* An anchor styled as the primary button. Anchors do not inherit the
+   button's line box, so the two would otherwise sit at different
+   heights on the same row. */
+.hosted-signin {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+}
+
+.hosted-seats,
+.hosted-flavour-seats {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--text-s);
+}
+
+.hosted-unavailable {
+  margin: 0;
+  color: var(--text-body);
+}
+
+.hosted-local {
+  margin-top: var(--space-5);
+  color: var(--text-muted);
+  font-size: var(--text-s);
+}
+
+/* Two cards, side by side where there is room and stacked where there
+   is not. auto-fit rather than a breakpoint: the second card appears
+   only when a deployment sells that flavour, so the count is not known
+   here. */
+.hosted-flavours {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  gap: var(--space-4);
+  margin: var(--space-5) 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.hosted-flavour {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-5);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-l);
+}
+
+/* A full pool is not an error and not a disabled card: the button still
+   works, and what it gets you is a place in the queue. Dashed, the same
+   language a not-yet-available exam speaks. */
+.hosted-flavour[data-full] {
+  background: var(--bg);
+  border-style: dashed;
+}
+
+.hosted-flavour h2 {
+  margin: 0;
+  font-size: var(--text-l);
+}
+
+.hosted-flavour p {
+  margin: 0;
+  color: var(--text-body);
+}
+
+/* Standing state rather than an interruption, so it reads as part of
+   the page: the warn palette, which is the product's "you are waiting
+   on something outside your control" colour. */
+.hosted-queue {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+  padding: var(--space-4);
+  background: var(--warn-soft);
+  border: 1px solid var(--warn-border);
+  border-radius: var(--radius-m);
+}
+
+.hosted-queue-place {
+  margin: 0;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.hosted-queue-hold {
+  margin: 0;
+  color: var(--text-body);
+  font-size: var(--text-s);
+}
+
+.hosted-booting {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-4);
+}
+
+/* The header chip: identity, the lease, and the two ways out. */
+.session-chip {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.session-chip-user {
+  color: var(--text-secondary);
+  font-size: var(--text-s);
+}
+
+/* Tabular, so a countdown does not reflow the row it sits in every
+   second. */
+.session-chip-clock {
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-pill);
+  background: var(--neutral-soft);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--text-s);
+  font-variant-numeric: tabular-nums;
+}
+
+/* The word already changed from "left" to "Ends in" — this is the
+   second channel, never the only one. */
+.session-chip-clock[data-soon] {
+  background: var(--warn-soft);
+  color: var(--warn-strong);
+}
+
+/* A button that carries no weight of its own: it lives in the header
+   beside a theme toggle, and two filled buttons up there would compete
+   with the page's own primary action. */
+.btn-quiet {
+  padding: var(--space-1) var(--space-2);
+  background: transparent;
+  border-color: transparent;
+  color: var(--text-secondary);
+  font-size: var(--text-s);
+}
+
+.btn-quiet:hover:not(:disabled) {
+  background: var(--surface-hover);
+  border-color: var(--border);
+}
+
+/* A history row that opens. Underlined rather than coloured alone: the
+   table's other cells are text, and a link that differs only by hue is
+   not a link to everyone. */
+.history-open {
+  color: var(--text);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.history-open:hover {
+  color: var(--accent-strong);
+}
+
+/* Said before the banner, because everything under it is pixel-identical
+   to the screen shown at the end of a live exam and is not one. */
+.review-note {
+  margin: 0 0 var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  background: var(--surface-raised);
+  border-radius: var(--radius-m);
+  color: var(--text-secondary);
+  font-size: var(--text-s);
+}
+
+@media (max-width: 40rem) {
+  .session-chip-user {
+    display: none;
+  }
+}


### PR DESCRIPTION
## What this changes

A hosted tier. Thirteen commits, readable in order: the exam stack becomes
one Kubernetes Pod, a fourth Go module learns to hand those Pods out, a
chart installs both, and the UI grows the five screens that only exist
when someone else is running the simulator for you.

`./sim up` is untouched — no caps, no new required configuration, no new
env var with a default that changes behaviour. Everything hosted mode
adds is off unless something sets it.

**1. `feat(deploy):` the eight compose services become one Pod.**
Splitting them would need RWX storage that `local-path` cannot provide,
so they share a netns and an emptyDir. Three gaps only became visible by
writing the spec: compose service names are hostnames in 13+ files
*including bank content* (`q09` has candidates `podman push` to
`registry:5000`), so `hostAliases` is mandatory; both instances bind
sshd on `:22` and collide in one netns, fixed by a new `SSHD_LISTEN` per
instance on its own loopback address, so `ssh instance-1` and
`evaluate.sshArgs` are unchanged; and `/banks` has no host to bind from,
so banks now ship as their own image staged in by an init container —
which also means a bank update no longer rebuilds the facilitator.

**The bug that cost the most, and generalises.** The images were written
against compose's *startup ordering*, not just its networking. Every
consumer of `/shared` declares `depends_on: k8s-env: service_healthy`,
so nothing ever read that volume while `bootstrap.sh` was writing it. A
Pod has no `depends_on` — all eight containers start at once — which
exposed every truncate-then-fill write as a real race. Measured:
instance-1 got a 5574-byte kubeconfig, instance-2 got a **0-byte** one,
and its kubectl silently fell back to `localhost:8080`, which in a
shared netns is the facilitator serving HTML. Eleven of ckad-mock-01's
twenty-two questions grade on instance-2, so half the exam was
unscoreable and nothing reported it. Fixed by renaming into place — the
pattern `phase.sh` and `history.go` already use — with a CI gate.

**2. `fix(control):` an operation that cannot finish must not begin.**
Found by a live reset failing. Reset and switch each wipe the instances
several phases *before* a restart step the ssh engine cannot perform, so
a hosted switch left `/shared/bank` on the new bank while docs-proxy and
the facilitator still served the old one. `control.canRestart()` now
refuses up front, via an optional interface — an Engine that says
nothing is assumed capable, so Docker and every test fake are untouched.

**3. `feat(hub):` identity, seats, session Pods, and a proxy.** A fourth
Go module, stdlib only, no `go.sum`. GitHub OAuth or a trusted header or
nothing; HMAC cookies; one JSON file per user on a PVC using the
facilitator's atomic-rename pattern; hand-rolled Pod REST calls against
the projected SA token, the way `conductor/internal/docker` already
hand-rolls three Docker Engine calls; a FIFO queue with a time-boxed
hold so a vanished user does not burn a seat; and serialised Pod
creation, which is load-bearing rather than polite — one measured boot
took a 4-core node to 3090m, so two boots on one node do not take turns,
they both crawl.

The facilitator keeps its "no authentication anywhere" property
literally. It is simply never reachable except through the hub. That is
what keeps `./sim up` honest.

**4. `harden(control):` the conductor listens on a socket, not a port.**
One Pod netns dissolves compose's `controlnet: internal: true`, so the
candidate's own shell could otherwise reach the control API on
localhost. `CONTROL_SOCKET` moves it to a unix socket in an emptyDir
mounted into the facilitator and conductor only. TCP remains the compose
path, unchanged.

**5. `feat(history):` a graded attempt outlives the Pod.**
`HISTORY_WEBHOOK_URL` posts each record plus the full results blob to
the hub as it is written; unset is today's behaviour exactly. The ticket
a Pod presents is signed with a key *derived* from `COOKIE_KEY` rather
than the key itself, so a ticket read out of a Pod spec can never be
spent as that candidate's login.

**6. `feat(deploy):` a chart.** The Pod manifests moved into it —
`.Files.Get` only reaches inside a chart, and the alternative was two
copies that agree until they don't. They are still plain manifests;
`kubectl apply -f` works on either. The chart `fromYaml`s one and
rewrites exactly four things: first-party images and pull policy,
namespace, placement, per-container resources. Everything else reaches
the API server as written, which is the point — a typed PodSpec would
drop a field added upstream and the symptom would be a session missing a
volume.

**7. `feat(ui):` five screens that only exist hosted.** Sign-in, lobby,
queue, boot progress, and `#/history/<id>` rendering a stored attempt
through the existing `Score`/`Explain` components. `GET /api/me` is the
whole detection seam: a local facilitator JSON-404s unknown `/api/*`, so
there is no build flag and no second bundle.

**8. `docs:` four documents said this would never exist.** PRODUCT.md,
SECURITY.md, `docs/follow-ups.md` and the landing page all stated hosting
was permanently out of scope. Rewritten to keep the constraint that
actually held — no authentication *in the simulator* — and drop the one
that didn't. `docs/hosting.md` is new.

### Two bugs this found rather than introduced

- The hub's `GET /api/history` served the versioned, oldest-first
  *interchange* document where the UI reads the dashboard shape.
  `Progress.tsx` reads `summary.weakDomains` unchecked, so hosted
  history rendered a **blank** dashboard, not a wrong one. Two tests now
  pin the two shapes apart.
- `Progress` required a catalog, which belongs to the session Pod and
  does not exist before one runs.

### Rootless podman, and why nothing changed

`podman run` fails on an instance with `crun: mount 'proc' to 'proc':
Operation not permitted` — masked `/proc` paths trip the kernel's
`mount_too_revealing()`, which applies only to mounts made from inside a
new user namespace. Root podman creates none, so `sudo` works. Rootless
*build* succeeds, which is what makes it confusing. Identical under
compose, so not a hosting regression; `hints.md` and the graded
reference already say `sudo`. `procMount: Unmasked` would fix it and was
deliberately not adopted.

## Verification

CI is green (9 jobs, including a new `chart` job). Beyond it:

- **`tests/smoke.sh` passed twice.** Once against the Pod — plus a
  browser pass covering desktop streaming, both instances, `ENGINE=ssh`
  reseed, grading, hints and the docs proxy — and again at the branch
  head, because the first run predated the commits that touch
  `facilitator/cmd/facilitator/main.go` and the conductor client. Both:
  `SMOKE PASS (180/180 solved, 0/180 fresh, 180/180 resumed, 0 after
  reset)`, zero failed assertions. The second rebuilt every image from
  the branch (`./sim up --build`), so the socket-listening conductor and
  the webhook-capable facilitator are what it graded; the conductor
  isolation assertions still hold over compose's TCP path, which is the
  half of that change local mode keeps.
- **The chart↔hub join has its own gate.** helm proving the YAML parses
  and Go tests proving `render()` handles *a* Pod prove nothing about
  the join, so CI renders the chart and runs the hub's own `render()`
  over the output. Mutation-tested twice; both mutations were caught.
- `helm lint`, `helm template` over a values matrix (registry mirror,
  alternate namespace, tolerations, per-container resource merge,
  restricted ingress, HTTPRoute), `kubectl apply --dry-run=client` over
  every rendered resource, and four negative controls confirming the
  render-time `fail`s fire.
- The hub was run end to end with no cluster at all —
  `SESSION_UPSTREAM` in front of a live `./sim up` — including the
  desktop, whose RFB greeting arrives through the proxy as a binary
  WebSocket frame.
- Per-module `go test ./... && go vet ./...` for all four modules;
  `tsc --noEmit && npm run lint && npm test` (660 tests).

**Not yet verified, and deliberately so:** nothing here has run in a
real cluster, because the images it references do not exist until a
`v*` tag is pushed. Two GitHub accounts against a live deployment, the
queue, the idle reap and the NetworkPolicy check from inside a session
are the post-release list.

- [x] I ran `tests/smoke.sh` locally

See [docs/testing.md](https://github.com/Camilool8/kubestronaut-sim/blob/main/docs/testing.md).
