### PR TITLE
The hub serves the app it was only proxying

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,8 +266,10 @@ jobs:
       # excludes banks/ so it stays out of the facilitator's context.
       - name: banks
         run: docker build -f images/banks/Dockerfile -t sim-banks banks
+      # Root context, like the facilitator: the hub embeds ui/ so it can
+      # serve sign-in and the lobby before a session Pod exists.
       - name: hub
-        run: docker build -t sim-hub hub
+        run: docker build -f hub/Dockerfile -t sim-hub .
       # FROM scratch: there is no shell to check the image with, and a
       # broken binary in one would otherwise only surface at deploy time.
       - name: hub refuses to start misconfigured

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,8 +79,12 @@ jobs:
           # front of every session Pod. It is published here because it
           # ships from this repo and versions with the images it starts —
           # the pod template it renders is this repo's manifest.
+          #
+          # Context is the root, like the facilitator's and for the same
+          # reason: it embeds ui/, because the sign-in and lobby screens
+          # have to be served before any session Pod exists to serve them.
           - image: hub
-            context: hub
+            context: .
             file: hub/Dockerfile
     steps:
       - uses: actions/checkout@v7

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,12 @@ ui/dist/
 facilitator/internal/web/dist/*
 !facilitator/internal/web/dist/index.html
 
+# The hub embeds the same bundle for the same reason, and needs its own
+# copy: it serves the sign-in and lobby screens in the window before a
+# session Pod exists to serve them. Everything above applies here too.
+hub/internal/web/dist/*
+!hub/internal/web/dist/index.html
+
 # Runtime state: volumes, and the active-bank pointer the conductor owns
 # after first boot.
 shared/

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -17,7 +17,12 @@ Two things, and the second is created and destroyed on demand:
 - **The hub** — one Deployment, one Service, one PersistentVolumeClaim.
   It is the only process reachable from the internet. It does identity,
   seats, the queue, durable history, and a reverse proxy to each
-  candidate's own environment.
+  candidate's own environment. It also serves the exam UI itself, but
+  only until a session exists: sign-in, the lobby and the queue are
+  screens of the same app the facilitator serves, and there is no
+  facilitator to serve them from until a seat has been claimed. Once one
+  is running, the proxy takes over and a candidate is served by their
+  own Pod.
 - **A session Pod, per candidate** — the whole `./sim up` stack as a
   single Pod. Two flavours: `practical` (eight containers, a real
   two-node cluster) and `mcq` (a facilitator and 128Mi, no cluster).

--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -1,8 +1,22 @@
+# Built from the REPOSITORY ROOT, not from hub/ — the UI it embeds lives
+# at ui/. This is the same arrangement the facilitator has, for the same
+# reason, which is why the COPY paths below are all prefixed.
+FROM node:22-alpine AS ui-build
+WORKDIR /src/ui
+COPY ui/package.json ui/package-lock.json ./
+RUN npm ci
+COPY ui/ ./
+RUN npm run build
+
 FROM golang:1.24-alpine AS build
 WORKDIR /src
-COPY go.mod ./
-COPY cmd ./cmd
-COPY internal ./internal
+COPY hub/go.mod ./
+COPY hub/cmd ./cmd
+COPY hub/internal ./internal
+# Over the committed placeholder. The hub serves this bundle itself for
+# every request that arrives before a session Pod exists to serve it —
+# sign-in, the lobby, the queue — and proxies to the Pod once one does.
+COPY --from=ui-build /src/ui/dist/. ./internal/web/dist/
 RUN CGO_ENABLED=0 go build -o /hub ./cmd/hub
 # STATE_DIR's default, created here because a scratch image has no shell
 # to create it with and the hub runs as 65532. Without it the process

--- a/hub/cmd/hub/main.go
+++ b/hub/cmd/hub/main.go
@@ -39,6 +39,7 @@ import (
 	"kubestronaut-sim/hub/internal/kube"
 	"kubestronaut-sim/hub/internal/session"
 	"kubestronaut-sim/hub/internal/store"
+	"kubestronaut-sim/hub/internal/web"
 )
 
 func main() {
@@ -130,7 +131,7 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	srv := &api.Server{Auth: a, Store: st, BaseURL: baseURL, Ingest: ingest}
+	srv := &api.Server{Auth: a, Store: st, BaseURL: baseURL, Ingest: ingest, UI: web.FS()}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/hub/internal/api/api.go
+++ b/hub/internal/api/api.go
@@ -11,6 +11,7 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"io/fs"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -45,7 +46,12 @@ type Server struct {
 	// ticket lifted from a Pod spec is not a login — see auth.Derive.
 	// Nil leaves the route unregistered.
 	Ingest *auth.Signer
-	Logf   func(string, ...any)
+	// UI is the SPA the hub serves for itself, in the window before a
+	// candidate has a session Pod to be proxied to. Nil answers those
+	// requests with the JSON errors alone, which is what every route
+	// here did before there was a shell to serve. See shell.go.
+	UI   fs.FS
+	Logf func(string, ...any)
 
 	proxy *httputil.ReverseProxy
 }

--- a/hub/internal/api/proxy.go
+++ b/hub/internal/api/proxy.go
@@ -55,27 +55,50 @@ func (s *Server) newProxy() *httputil.ReverseProxy {
 type targetKey struct{}
 
 // handleProxy is the catch-all: anything the hub's own mux did not
-// claim belongs to the candidate's session.
+// claim belongs to the candidate's session — once there is one. Until
+// then it belongs to the shell, because the screens that start a session
+// are part of the app being asked for. Each of the three ways there can
+// be nothing to proxy to serves the shell to a browser and keeps its
+// JSON to everything else; see wantsShell.
 func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
-	sess, ok := s.requireUser(w, r)
-	if !ok {
+	sess, err := s.Auth.Current(r)
+	if err != nil {
+		// The most important of the three: this is a first visit. The
+		// sign-in screen is in the bundle below, and a JSON 401 here is
+		// the whole product being unreachable.
+		if s.wantsShell(r) {
+			s.serveShell(w, r)
+			return
+		}
+		writeError(w, http.StatusUnauthorized, "not signed in")
 		return
 	}
 	live, err := s.Sessions.Get(sess.UserID)
 	if errors.Is(err, session.ErrNoSession) {
 		// 404, not 502: there is nothing wrong, the candidate simply has
-		// no session yet. The SPA's own shell is served by the hub, so
-		// this is only reached for API calls made before starting.
+		// no session yet. They are signed in, so this is the lobby.
+		if s.wantsShell(r) {
+			s.serveShell(w, r)
+			return
+		}
 		writeError(w, http.StatusNotFound, "you have no session running — start one first")
 		return
 	}
 	if err != nil {
+		// Not diverted to the shell on purpose: something is actually
+		// broken, and an app that renders over it would poll a hub that
+		// cannot answer instead of showing what happened.
 		writeError(w, http.StatusInternalServerError, "could not find your session")
 		return
 	}
 	if live.Addr() == "" {
 		// 503 with Retry-After, because the answer really is "ask again":
-		// the Pod is booting and the SPA polls.
+		// the Pod is booting and the SPA polls. A candidate who reloads
+		// mid-boot still needs the app back, hence the shell.
+		if s.wantsShell(r) {
+			s.serveShell(w, r)
+			return
+		}
 		w.Header().Set("Retry-After", "5")
 		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
 			"error": "your exam environment is still starting",

--- a/hub/internal/api/shell.go
+++ b/hub/internal/api/shell.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"io/fs"
+	"net/http"
+	"strings"
+)
+
+// The shell is the SPA served by the hub itself, for every request that
+// arrives before there is a session Pod to proxy to.
+//
+// It exists because the screens that get a candidate INTO a session —
+// sign-in, the lobby, the queue, the boot progress — are screens of the
+// same bundle the facilitator serves, and the facilitator only runs
+// inside a session. Without this, a first-time visitor is told
+// {"error":"not signed in"} in raw JSON, and the page that would have
+// signed them in is inside the Pod that does not exist yet.
+
+// wantsShell reports whether a request the proxy cannot serve should be
+// answered with the app rather than a JSON error.
+//
+// The test is the path, deliberately not the Accept header. A browser
+// asks for text/html when it navigates, but the app's own asset requests
+// do not — and when nobody is signed in those assets have nowhere else to
+// come from, so an Accept-based rule would serve index.html and then 401
+// every script tag inside it.
+//
+// Everything under /api/ and /hub/ keeps its JSON contract exactly.
+// Handing index.html to a fetch() call would turn a clear 401 into a JSON
+// parse error somewhere else entirely, which is a worse bug than the one
+// this fixes.
+func (s *Server) wantsShell(r *http.Request) bool {
+	if s.UI == nil {
+		return false
+	}
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		return false
+	}
+	return !strings.HasPrefix(r.URL.Path, "/api/") && !strings.HasPrefix(r.URL.Path, "/hub/")
+}
+
+// serveShell serves the embedded UI: a real file when the request path
+// names one, otherwise index.html, so a client-side route like
+// /history/<id> loads the app instead of 404ing. This is the rule the
+// facilitator already applies to the same bundle.
+func (s *Server) serveShell(w http.ResponseWriter, r *http.Request) {
+	upath := strings.TrimPrefix(r.URL.Path, "/")
+	if upath == "" {
+		upath = "index.html"
+	}
+	if f, err := s.UI.Open(upath); err == nil {
+		f.Close()
+		http.FileServer(http.FS(s.UI)).ServeHTTP(w, r)
+		return
+	}
+
+	index, err := fs.ReadFile(s.UI, "index.html")
+	if err != nil {
+		http.Error(w, "index.html not found", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	w.Write(index)
+}

--- a/hub/internal/api/shell_test.go
+++ b/hub/internal/api/shell_test.go
@@ -1,0 +1,185 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// shellFS stands in for the embedded Vite build: an index and one hashed
+// asset, which is enough to tell "served the app" from "served index.html
+// to everything" apart.
+func shellFS() fstest.MapFS {
+	return fstest.MapFS{
+		"index.html":         {Data: []byte("<!doctype html><div id=root></div>")},
+		"assets/app-a1b2.js": {Data: []byte("console.log('app')")},
+	}
+}
+
+// withShell builds a hub that has seats and a bundle but no running
+// session — the state every candidate is in before they start one, and
+// the state a first-time visitor is in forever.
+func withShell(t *testing.T) *Server {
+	t.Helper()
+	s, _ := hosted(t, 1, nil)
+	s.UI = shellFS()
+	return s
+}
+
+func body(t *testing.T, w *httptest.ResponseRecorder) string {
+	t.Helper()
+	b, err := io.ReadAll(w.Result().Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+// The bug this file exists for. A visitor arriving at the hub for the
+// first time has no cookie and no session, and the screen that would
+// give them both is in the bundle — so a JSON 401 here is not a rude
+// error message, it is the entire product being unreachable.
+func TestTheRootServesTheAppWhenNobodyIsSignedIn(t *testing.T) {
+	s := withShell(t)
+
+	w := do(s, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, body(t, w))
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("Content-Type = %q, want text/html", ct)
+	}
+	if got := body(t, w); !strings.Contains(got, "id=root") {
+		t.Errorf("body = %q, want the app shell", got)
+	}
+}
+
+// The assets are the other half: they are requested without an
+// Accept: text/html header, so a rule written around Accept would serve
+// index.html and then 401 every script tag inside it.
+func TestAssetsAreServedBeforeAnyoneSignsIn(t *testing.T) {
+	s := withShell(t)
+
+	w := do(s, httptest.NewRequest(http.MethodGet, "/assets/app-a1b2.js", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if got := body(t, w); got != "console.log('app')" {
+		t.Errorf("body = %q, want the asset itself", got)
+	}
+}
+
+// A client-side route names no file. It must load the app, not 404,
+// or every hosted history link a candidate opens in a new tab breaks.
+func TestADeepLinkLoadsTheApp(t *testing.T) {
+	s := withShell(t)
+
+	w := do(s, httptest.NewRequest(http.MethodGet, "/history/2026-08-04T10-00-00Z", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if got := body(t, w); !strings.Contains(got, "id=root") {
+		t.Errorf("body = %q, want the app shell", got)
+	}
+}
+
+// The contract the shell must not break: /api/ and /hub/ are fetch()
+// surfaces. Handing them index.html turns a clear 401 into a JSON parse
+// error somewhere else entirely.
+func TestApiAndHubPathsKeepTheirJSONWhenNobodyIsSignedIn(t *testing.T) {
+	s := withShell(t)
+
+	for _, path := range []string{"/api/session/whatever", "/hub/nothing-here"} {
+		w := do(s, httptest.NewRequest(http.MethodGet, path, nil))
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("%s: status = %d, want 401", path, w.Code)
+		}
+		if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+			t.Errorf("%s: Content-Type = %q, want JSON", path, ct)
+		}
+	}
+}
+
+// Signed in, no seat claimed yet: this is the lobby, and the lobby is a
+// screen of the same bundle.
+func TestTheLobbyIsServedToASignedInUserWithNoSession(t *testing.T) {
+	s := withShell(t)
+	c := login(t, s, "u1", "candidate")
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.AddCookie(c)
+	w := do(s, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, body(t, w))
+	}
+	if got := body(t, w); !strings.Contains(got, "id=root") {
+		t.Errorf("body = %q, want the app shell", got)
+	}
+}
+
+// ...while the API still says what it always said, because the SPA
+// polling for a session it does not have needs the 404 to know that.
+func TestApiStillSays404ForASignedInUserWithNoSession(t *testing.T) {
+	s := withShell(t)
+	c := login(t, s, "u1", "candidate")
+
+	r := httptest.NewRequest(http.MethodGet, "/api/anything", nil)
+	r.AddCookie(c)
+	w := do(s, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+	if got := body(t, w); !strings.Contains(got, "no session running") {
+		t.Errorf("body = %q, want the no-session error", got)
+	}
+}
+
+// Once a Pod is up the proxy wins, so a candidate mid-exam is served by
+// their own session and not by whatever the hub happens to have embedded.
+// Both are the same build, but only one of them is the one their exam is
+// running against.
+func TestARunningSessionIsServedByItsPodNotTheHubsCopy(t *testing.T) {
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		io.WriteString(w, "<!doctype html><div id=root data-from=pod></div>")
+	})
+	s, _ := hosted(t, 1, upstream)
+	s.UI = shellFS()
+	c := login(t, s, "u1", "candidate")
+	if w := ready(t, s, c, `{}`); w.Code != http.StatusOK {
+		t.Fatalf("starting a session: %d %s", w.Code, body(t, w))
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.AddCookie(c)
+	w := do(s, r)
+
+	if got := body(t, w); !strings.Contains(got, "data-from=pod") {
+		t.Errorf("body = %q, want the Pod's own bundle", got)
+	}
+}
+
+// A hub built without a bundle answers exactly as it did before this
+// existed. Nothing silently degrades to a blank page.
+func TestNoBundleMeansTheOldJSONErrors(t *testing.T) {
+	s, _ := hosted(t, 1, nil)
+	s.UI = nil
+
+	w := do(s, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want JSON", ct)
+	}
+}

--- a/hub/internal/web/dist/index.html
+++ b/hub/internal/web/dist/index.html
@@ -1,0 +1,1 @@
+<!doctype html><title>kubestronaut-sim</title><p>UI not built — use the Docker image.</p>

--- a/hub/internal/web/web.go
+++ b/hub/internal/web/web.go
@@ -1,0 +1,47 @@
+// Package web embeds the built exam UI (Vite + React static assets) into
+// the hub binary.
+//
+// The facilitator embeds the same bundle and serves it to a candidate who
+// has a session Pod. The hub needs its own copy for the window before
+// that is true: sign-in, the lobby, the queue and the boot screen are all
+// screens of this SPA, and until one of them has started a session there
+// is no Pod to serve it from. A hub that only proxied would answer a
+// first-time visitor with a JSON error, and the screen that would have
+// let them fix that is inside the Pod they cannot yet have.
+//
+// Once a session is running the proxy takes over, so a candidate mid-exam
+// is served by their own Pod. The two copies are the same build: both
+// images are produced from one tag by one workflow.
+//
+// dist/index.html is committed as a placeholder ("UI not built — use the
+// Docker image.") so `go build`/`go test` succeed without running the node
+// build; the image's multi-stage Dockerfile overwrites dist/ with the
+// actual Vite build output before compiling the Go binary.
+package web
+
+import (
+	"embed"
+	"io/fs"
+)
+
+// Dist embeds every file under dist/, including dotfiles (the "all:"
+// pattern), so a real Vite build's hashed asset filenames and any hidden
+// config files it emits are never silently excluded.
+//
+//go:embed all:dist
+var Dist embed.FS
+
+// FS returns the embedded UI's file tree rooted at dist/ (i.e. with the
+// "dist" path prefix stripped), ready to be served directly as an
+// http.FileServer/http.Dir-style root.
+func FS() fs.FS {
+	sub, err := fs.Sub(Dist, "dist")
+	if err != nil {
+		// Dist is embedded from the literal "dist" directory at build
+		// time, so Sub can only fail here if that path constant itself
+		// were wrong — a build-time programming error, not a runtime
+		// condition callers should ever need to handle.
+		panic("web: " + err.Error())
+	}
+	return sub
+}


### PR DESCRIPTION
## The bug

A first visit to the deployed hub returned this, in a browser:

```
{"error":"not signed in"}
```

Signing in by hand at `/hub/auth/login` completed the OAuth flow and
redirected to `/`, which returned `{"error":"you have no session
running — start one first"}`. Also JSON. There is no HTML at any path on
`v0.1.0`, so the hosted tier has no reachable UI at all.

The catch-all is `mux.HandleFunc("/", s.handleProxy)`, and the hub has no
static handler of any kind — no `go:embed`, no `FileServer`, and a `FROM
scratch` image holding one binary and a CA bundle. The screens that get a
candidate *into* a session — sign-in, the lobby, the queue, boot progress
— are screens of the SPA the **facilitator** serves, and the facilitator
only runs inside a session Pod that cannot exist until the lobby has
granted a seat. `proxy.go:67` already said *"The SPA's own shell is served
by the hub"*. It was assumed, not built.

**Why every test passed.** The hub was only ever exercised with
`SESSION_UPSTREAM` in front of a live `./sim up`, with the session started
before browsing. A real facilitator was always behind the proxy serving
the bundle, so the two conditions that expose this — no Pod yet, and a
browser asking for a document — never occurred together until it ran on a
cluster. This is the deployment-only class the release PR explicitly
listed as unverified.

## The fix

The hub embeds the same bundle, the way the facilitator already does, and
serves it at each of the three points where there is nothing to proxy to:
not signed in, signed in with no session, and Pod still booting. Once a
Pod is up the proxy wins again, so a candidate mid-exam is served by their
own session and not by whatever the hub happens to have compiled in.

Two decisions worth stating:

- **The split is by path, not by `Accept`.** A browser asks for
  `text/html` when it navigates, but the app's own asset requests do not —
  and when nobody is signed in those assets have nowhere else to come
  from. An `Accept`-based rule would serve `index.html` and then 401 every
  script tag inside it.
- **`/api/` and `/hub/` keep their JSON contract exactly.** Handing
  `index.html` to a `fetch()` trades a clear 401 for a JSON parse error
  somewhere else entirely, which is a worse bug than the one being fixed.

The Dockerfile now builds from the repository root, because `ui/` is
there — the arrangement `facilitator/Dockerfile` already has. That is why
both workflows that build this image change with it.

## Verification

- **Eight new tests, four of them mutation-tested.** Removing the
  diversion, dropping the `/api/` guard, dropping the `index.html`
  fallback, and letting the hub's copy shadow a running Pod's are each
  caught by a different test. All four mutations were caught; a test that
  cannot fail is not a test.
- **The image was checked as an image, not as a binary** — the lesson from
  the `mkdir /state: permission denied` bug on this same image. Built,
  run, and driven over HTTP: a 1200-byte real `index.html` (not the
  84-byte placeholder), `/assets/index-*.js` at 468 KB and
  `/assets/index-*.css` at 95 KB with correct content types, `/history/x`
  loading the app, `/api/nope` still answering JSON, `/api/me` still 200.
- The `FROM scratch` misconfiguration guard still holds: `docker run -e
  AUTH_MODE=github` still refuses to start and still names
  `GITHUB_CLIENT_ID`.
- `go vet ./... && go test ./...` clean across the hub module.

Not verified here, and it cannot be: this has not run in the cluster,
because `v0.1.1` does not exist until a tag is pushed. Signing in with a
real GitHub account, claiming a seat, and the queue are what this unblocks
rather than what it proves.
