### PR TITLE
A seat constrained the Pod, but nothing constrained the exam

### DIFF
--- a/facilitator/cmd/facilitator/main.go
+++ b/facilitator/cmd/facilitator/main.go
@@ -177,7 +177,13 @@ func runServer() error {
 	// Default-off, and the only thing in this process that knows a world
 	// outside the Pod exists. Unset under compose, which is every local
 	// run: no mirror, no request, no behaviour change.
-	mir := newMirror(os.Getenv("HISTORY_WEBHOOK_URL"), os.Getenv("HISTORY_WEBHOOK_TOKEN"), log.Printf)
+	mir := newMirror(
+		os.Getenv("HISTORY_WEBHOOK_URL"),
+		os.Getenv("HISTORY_WEBHOOK_TOKEN"),
+		cfg.bankDir,
+		ex,
+		log.Printf,
+	)
 	if mir != nil {
 		log.Printf("attempts will also be posted to %s", os.Getenv("HISTORY_WEBHOOK_URL"))
 	}

--- a/facilitator/cmd/facilitator/mirror.go
+++ b/facilitator/cmd/facilitator/mirror.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"kubestronaut-sim/facilitator/internal/evaluate"
+	"kubestronaut-sim/facilitator/internal/exam"
 	"kubestronaut-sim/facilitator/internal/history"
 )
 
@@ -54,22 +55,30 @@ type mirror struct {
 	token  string
 	client *http.Client
 	logf   func(string, ...any)
+	// bankDir and ex are what makes the stored copy self-contained: the
+	// reference solutions live in the bank, the bank lives in this Pod,
+	// and the Pod is the thing the stored copy has to outlive. See
+	// withSolutions.
+	bankDir string
+	ex      *exam.Exam
 	// sleep is overridable so the retry can be tested without waiting.
 	sleep func(time.Duration)
 }
 
 // newMirror returns nil when HISTORY_WEBHOOK_URL is unset, which is the
 // only configuration `./sim up` has ever had.
-func newMirror(rawURL, token string, logf func(string, ...any)) *mirror {
+func newMirror(rawURL, token, bankDir string, ex *exam.Exam, logf func(string, ...any)) *mirror {
 	if rawURL == "" {
 		return nil
 	}
 	return &mirror{
-		url:    rawURL,
-		token:  token,
-		client: &http.Client{Timeout: mirrorTimeout},
-		logf:   logf,
-		sleep:  time.Sleep,
+		url:     rawURL,
+		token:   token,
+		client:  &http.Client{Timeout: mirrorTimeout},
+		logf:    logf,
+		bankDir: bankDir,
+		ex:      ex,
+		sleep:   time.Sleep,
 	}
 }
 
@@ -78,12 +87,16 @@ func newMirror(rawURL, token string, logf func(string, ...any)) *mirror {
 // The results document is sent whole rather than summarised because it
 // is what the review screen renders: the per-check artifacts carry the
 // actual, the expected and the why, and a summary would leave a hosted
-// candidate with a score and no explanation of it.
+// candidate with a score and no explanation of it. The reference
+// solutions are attached HERE, on the way out and on a copy, for the
+// same reason and one more — they are the half that says what right
+// looked like, and they do not otherwise survive the Pod.
 func (m *mirror) post(ctx context.Context, rec history.Record, res *evaluate.Results) error {
+	stored := withSolutions(res, m.ex, m.bankDir, m.logf)
 	body, err := json.Marshal(struct {
 		Record  history.Record    `json:"record"`
 		Results *evaluate.Results `json:"results"`
-	}{rec, res})
+	}{rec, stored})
 	if err != nil {
 		return fmt.Errorf("history mirror: encode: %w", err)
 	}

--- a/facilitator/cmd/facilitator/mirror_test.go
+++ b/facilitator/cmd/facilitator/mirror_test.go
@@ -17,7 +17,7 @@ import (
 // so a test of three attempts costs no seconds.
 func quietMirror(t *testing.T, url, token string) *mirror {
 	t.Helper()
-	m := newMirror(url, token, func(string, ...any) {})
+	m := newMirror(url, token, "", nil, func(string, ...any) {})
 	m.sleep = func(time.Duration) {}
 	return m
 }
@@ -71,6 +71,41 @@ func TestMirrorPostsTheRecordAndTheFullResults(t *testing.T) {
 	for _, forbidden := range []string{"user", "uid", "login"} {
 		if strings.Contains(strings.ToLower(string(raw)), `"`+forbidden+`"`) {
 			t.Errorf("the posted body names a %q; identity must come from the ticket alone", forbidden)
+		}
+	}
+}
+
+// The wiring, end to end: what leaves this process is the SELF-CONTAINED
+// document. The bank goes away with the Pod, so a stored attempt that
+// pointed at it for the reference solution would be a review that can
+// only ever say what went wrong.
+func TestMirrorPostsTheReferenceSolutionsWithTheAttempt(t *testing.T) {
+	var body struct {
+		Results struct {
+			Questions []struct {
+				ID       string `json:"id"`
+				Solution string `json:"solution"`
+			} `json:"questions"`
+		} `json:"results"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	m := newMirror(srv.URL, "tok", bankWithSolutions(t, "q01", "q02"), recorderExam(), func(string, ...any) {})
+	m.sleep = func(time.Duration) {}
+	if err := m.post(t.Context(), historyRecord(), gradedResults()); err != nil {
+		t.Fatalf("post: %v", err)
+	}
+
+	if len(body.Results.Questions) != 2 {
+		t.Fatalf("questions = %d, want 2", len(body.Results.Questions))
+	}
+	for _, q := range body.Results.Questions {
+		if q.Solution == "" {
+			t.Errorf("%s was stored with no reference solution", q.ID)
 		}
 	}
 }
@@ -154,7 +189,7 @@ func TestMirrorDoesNotRetryARejectedTicket(t *testing.T) {
 // Unset is what `./sim up` runs, and it must produce no mirror at all —
 // not a mirror that posts nowhere.
 func TestNoWebhookURLMeansNoMirror(t *testing.T) {
-	if m := newMirror("", "tok", nil); m != nil {
+	if m := newMirror("", "tok", "", nil, nil); m != nil {
 		t.Errorf("newMirror with no URL returned %+v", m)
 	}
 }

--- a/facilitator/cmd/facilitator/solutions.go
+++ b/facilitator/cmd/facilitator/solutions.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"kubestronaut-sim/facilitator/internal/evaluate"
+	"kubestronaut-sim/facilitator/internal/exam"
+)
+
+// withSolutions returns a COPY of a graded document whose questions
+// carry the bank's reference solution.
+//
+// It exists for one caller — the history mirror — and the copy is the
+// point. A hosted attempt is read back weeks later, from a hub, long
+// after the Pod that held the bank was deleted; without the solution
+// travelling with it, a stored attempt can show a candidate every check
+// they failed and nothing whatsoever about what passing looked like.
+// Live, the same text is one fetch away from the bank on disk, so the
+// running product asks for it instead and this function is not involved.
+//
+// Nothing here mutates res. The document it is handed is the one the
+// session manager is serving on GET /api/results at that moment, and a
+// solution written into it would be a solution served from it — see the
+// note on evaluate.QuestionResult.Solution for why that door has to stay
+// shut. Only the Questions slice is rebuilt; everything else is copied
+// by value with the struct.
+//
+// A question whose solution.md cannot be read is skipped rather than
+// failing the mirror: one unreadable file must not cost the candidate
+// the whole attempt. The result is simply a stored question with no
+// solution, which the review screen already renders — that is what every
+// attempt stored before this existed looks like.
+func withSolutions(res *evaluate.Results, ex *exam.Exam, bankDir string, logf func(string, ...any)) *evaluate.Results {
+	if res == nil || bankDir == "" {
+		return res
+	}
+
+	docs := map[string][]evaluate.Doc{}
+	if ex != nil {
+		for _, q := range ex.Questions {
+			if len(q.Docs) == 0 {
+				continue
+			}
+			list := make([]evaluate.Doc, 0, len(q.Docs))
+			for _, d := range q.Docs {
+				list = append(list, evaluate.Doc{Label: d.Label, URL: d.URL})
+			}
+			docs[q.ID] = list
+		}
+	}
+
+	out := *res
+	out.Questions = make([]evaluate.QuestionResult, len(res.Questions))
+	copy(out.Questions, res.Questions)
+	for i := range out.Questions {
+		id := out.Questions[i].ID
+		// filepath.Join cleans the path, so an id containing "../" cannot
+		// climb out of the bank — but ids come from a bank the operator
+		// installed, not from a request, so this is belt and braces.
+		md, err := os.ReadFile(filepath.Join(bankDir, id, "solution.md"))
+		if err != nil {
+			logf("history mirror: no reference solution stored for %s: %v", id, err)
+			continue
+		}
+		out.Questions[i].Solution = string(md)
+		out.Questions[i].Docs = docs[id]
+	}
+	return &out
+}

--- a/facilitator/cmd/facilitator/solutions_test.go
+++ b/facilitator/cmd/facilitator/solutions_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"kubestronaut-sim/facilitator/internal/exam"
+)
+
+// bankWithSolutions writes a bank directory holding a solution.md for
+// each id given, and returns its path.
+func bankWithSolutions(t *testing.T, ids ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, id := range ids {
+		if err := os.MkdirAll(filepath.Join(dir, id), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", id, err)
+		}
+		body := "# " + id + "\n\nRun `kubectl apply -f " + id + ".yaml`.\n"
+		if err := os.WriteFile(filepath.Join(dir, id, "solution.md"), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", id, err)
+		}
+	}
+	return dir
+}
+
+func quiet(string, ...any) {}
+
+// The reason this exists at all: a stored attempt is read back after the
+// Pod that held the bank is gone, so the reference solution has to
+// travel with it or the review screen can only ever say what went wrong.
+func TestStoredAttemptsCarryTheReferenceSolution(t *testing.T) {
+	dir := bankWithSolutions(t, "q01", "q02")
+
+	got := withSolutions(gradedResults(), recorderExam(), dir, quiet)
+
+	if len(got.Questions) != 2 {
+		t.Fatalf("Questions = %d, want 2", len(got.Questions))
+	}
+	for _, q := range got.Questions {
+		want := "# " + q.ID + "\n\nRun `kubectl apply -f " + q.ID + ".yaml`.\n"
+		if q.Solution != want {
+			t.Errorf("%s solution = %q, want %q", q.ID, q.Solution, want)
+		}
+	}
+}
+
+// The live document is what GET /api/results serves, including a
+// training-mode practice grade taken MID-session — which is exactly
+// where the solution endpoint answers 403. Writing a solution into it
+// would hand one out through the door that is meant to be shut.
+func TestEnrichingLeavesTheLiveDocumentAlone(t *testing.T) {
+	dir := bankWithSolutions(t, "q01", "q02")
+	live := gradedResults()
+
+	got := withSolutions(live, recorderExam(), dir, quiet)
+
+	for _, q := range live.Questions {
+		if q.Solution != "" {
+			t.Errorf("live %s carries a solution: %q", q.ID, q.Solution)
+		}
+	}
+	if &got.Questions[0] == &live.Questions[0] {
+		t.Error("the copy shares its Questions backing array with the live document")
+	}
+	if got.Bank != live.Bank || got.Earned != live.Earned || got.Percent != live.Percent {
+		t.Error("the copy did not carry the rest of the document over")
+	}
+}
+
+// A bank author attached upstream reading to a question; it is served
+// with the solution live, so it has to be stored with the solution too.
+func TestStoredAttemptsCarryTheQuestionDocs(t *testing.T) {
+	dir := bankWithSolutions(t, "q01", "q02")
+	ex := recorderExam()
+	ex.Questions[0].Docs = []exam.Doc{{Label: "Ingress path types", URL: "https://kubernetes.io/docs/x"}}
+
+	got := withSolutions(gradedResults(), ex, dir, quiet)
+
+	first := got.Questions[0]
+	if first.ID != ex.Questions[0].ID {
+		t.Fatalf("first question = %s, want %s", first.ID, ex.Questions[0].ID)
+	}
+	if len(first.Docs) != 1 || first.Docs[0].URL != "https://kubernetes.io/docs/x" {
+		t.Errorf("Docs = %+v", first.Docs)
+	}
+	if len(got.Questions[1].Docs) != 0 {
+		t.Errorf("q02 gained docs it never declared: %+v", got.Questions[1].Docs)
+	}
+}
+
+// One unreadable file must not cost the candidate the attempt. The
+// question simply stores without a solution, which is what every attempt
+// recorded before this existed looks like — and the review screen
+// already renders that.
+func TestAMissingSolutionFileDoesNotLoseTheAttempt(t *testing.T) {
+	dir := bankWithSolutions(t, "q01")
+
+	got := withSolutions(gradedResults(), recorderExam(), dir, quiet)
+
+	if len(got.Questions) != 2 {
+		t.Fatalf("Questions = %d, want 2", len(got.Questions))
+	}
+	if got.Questions[0].Solution == "" {
+		t.Error("q01 lost its solution because q02 had none")
+	}
+	if got.Questions[1].Solution != "" {
+		t.Errorf("q02 solution = %q, want empty", got.Questions[1].Solution)
+	}
+}
+
+// `./sim up` sets no BANK_DIR in some direct/dev runs, and a nil results
+// document reaches here from a grade that produced nothing.
+func TestEnrichingIsANoOpWithoutABank(t *testing.T) {
+	live := gradedResults()
+	if got := withSolutions(live, recorderExam(), "", quiet); got != live {
+		t.Error("withSolutions copied the document with no bank dir to read")
+	}
+	if got := withSolutions(nil, recorderExam(), "/nope", quiet); got != nil {
+		t.Errorf("withSolutions(nil) = %+v, want nil", got)
+	}
+}

--- a/facilitator/internal/evaluate/evaluate.go
+++ b/facilitator/internal/evaluate/evaluate.go
@@ -234,6 +234,33 @@ type QuestionResult struct {
 	Correct  []int    `json:"correct,omitempty"`
 	Options  []string `json:"options,omitempty"`
 	Multi    bool     `json:"multi,omitempty"`
+
+	// Solution and Docs are the bank's reference solution for this
+	// question, and they are set on ONE copy of the document only: the
+	// one posted to a history mirror (cmd/facilitator/solutions.go).
+	//
+	// Grading never fills them, /session/results.json never carries them,
+	// and GET /api/results never serves them. That is not tidiness — the
+	// live document is also what a training-mode practice grade produces,
+	// mid-session, and the solution endpoint is gated precisely there.
+	// Attaching a solution to the live results would hand it out through
+	// the one door that is meant to be shut.
+	//
+	// Why they are attached to the mirrored copy at all: a stored attempt
+	// is read back long after its Pod is gone, and the reference solution
+	// lives in the bank, inside that Pod. Without this the review screen
+	// could show what a candidate got wrong and nothing about what right
+	// looked like — which is the half that teaches.
+	Solution string `json:"solution,omitempty"`
+	Docs     []Doc  `json:"docs,omitempty"`
+}
+
+// Doc is one piece of upstream reading a bank attached to a question.
+// Mirrors the shape GET /api/questions/{id}/solution serves live, so the
+// review screen renders a stored attempt through the same component.
+type Doc struct {
+	Label string `json:"label"`
+	URL   string `json:"url"`
 }
 
 // CheckResult is one validate.d check's graded outcome.

--- a/hub/internal/api/seat_test.go
+++ b/hub/internal/api/seat_test.go
@@ -1,0 +1,174 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"kubestronaut-sim/hub/internal/auth"
+	"kubestronaut-sim/hub/internal/session"
+)
+
+// The catalog a session Pod serves: every bank the banks image staged,
+// which is all of them, whatever kind of Pod is asking. That is the
+// condition this gate exists for.
+func catalogHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/catalog" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"active": "kcna-mock",
+			"exams": []map[string]any{
+				{"id": "ckad-mock-01", "examType": "hands-on"},
+				{"id": "ckad-mock-02", "examType": "hands-on"},
+				{"id": "kcna-mock", "examType": "mcq"},
+			},
+		})
+	})
+}
+
+// seatOfKind is a candidate holding one seat of the given flavour, with
+// their Pod up. The returned server IS that Pod: closing it is how a test
+// makes a live session unreachable, which is what a facilitator
+// mid-restart looks like from here.
+func seatOfKind(t *testing.T, kind session.Kind) (*Server, *http.Cookie, *httptest.Server) {
+	t.Helper()
+	s, _ := newServer(t, auth.ModeGitHub)
+	pod := httptest.NewServer(catalogHandler())
+	t.Cleanup(pod.Close)
+	u, err := url.Parse(pod.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, port := u.Hostname(), atoi(u.Port())
+	bank := "ckad-mock-01"
+	if kind == session.MCQ {
+		bank = "kcna-mock"
+	}
+	s.Sessions = session.New(&session.Static{Host: host}, session.Config{
+		Flavours: map[session.Kind]session.Flavour{
+			kind: {Seats: 1, Template: session.Template(podTemplate), Bank: bank},
+		},
+		Port: port,
+		Logf: func(string, ...any) {},
+	})
+	s.DefaultKind = kind
+	s.UI = shellFS()
+
+	c := login(t, s, "u1", "candidate")
+	if w := ready(t, s, c, `{}`); w.Code != http.StatusOK {
+		t.Fatalf("starting a %s session: %d %s", kind, w.Code, body(t, w))
+	}
+	return s, c, pod
+}
+
+func switchTo(s *Server, c *http.Cookie, bank string) *httptest.ResponseRecorder {
+	r := httptest.NewRequest(http.MethodPost, "/api/control/switch",
+		strings.NewReader(`{"bank":"`+bank+`"}`))
+	r.AddCookie(c)
+	return do(s, r)
+}
+
+// The bug. An MCQ seat is two containers and no cluster; switching its
+// bank does not switch its template, so a hands-on exam chosen here
+// booted the hands-on bank into a Pod with no instances and no desktop,
+// graded every check 0 with "could not resolve hostname instance-1", and
+// recorded it as a real attempt.
+func TestAnMcqSeatRefusesAHandsOnExam(t *testing.T) {
+	s, c, _ := seatOfKind(t, session.MCQ)
+
+	w := switchTo(s, c, "ckad-mock-01")
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", w.Code, body(t, w))
+	}
+	if got := body(t, w); !strings.Contains(got, "cannot run that exam") {
+		t.Errorf("body = %q, want the seat refusal", got)
+	}
+}
+
+// The mirror, so the gate is not accidentally one-directional: a
+// hands-on seat has no business rebuilding itself onto a question bank
+// either, and the reason is the same one in reverse.
+func TestAPracticalSeatRefusesAnMcqExam(t *testing.T) {
+	s, c, _ := seatOfKind(t, session.Practical)
+
+	w := switchTo(s, c, "kcna-mock")
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", w.Code, body(t, w))
+	}
+}
+
+// Refused before anything is destroyed: the session must survive intact,
+// which is the rule canRestart() enforces for an operation that cannot
+// finish.
+func TestARefusedSwitchLeavesTheSessionRunning(t *testing.T) {
+	s, c, _ := seatOfKind(t, session.MCQ)
+
+	switchTo(s, c, "ckad-mock-01")
+
+	live, err := s.Sessions.Get("u1")
+	if err != nil {
+		t.Fatalf("the session is gone: %v", err)
+	}
+	if live.State != session.Ready {
+		t.Errorf("state = %q, want the session still ready", live.State)
+	}
+}
+
+// Same kind, different bank: a practical seat may move between hands-on
+// exams, because the Pod that needs is the one it already has. The gate
+// is on the flavour, not on the bank the seat happened to start with.
+func TestAPracticalSeatMayMoveBetweenHandsOnExams(t *testing.T) {
+	s, c, _ := seatOfKind(t, session.Practical)
+
+	w := switchTo(s, c, "ckad-mock-02")
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202: %s", w.Code, body(t, w))
+	}
+}
+
+// An exam no catalog knows is a 404, not a rebuild onto a bank that does
+// not exist.
+func TestAnUnknownExamIsRefused(t *testing.T) {
+	s, c, _ := seatOfKind(t, session.MCQ)
+
+	w := switchTo(s, c, "cks-mock-01")
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404: %s", w.Code, body(t, w))
+	}
+}
+
+// Fail closed. Not knowing whether a hands-on bank is about to be booted
+// into a Pod with no cluster is not a reason to try it and find out.
+func TestAnUnreadableCatalogRefusesTheSwitch(t *testing.T) {
+	s, c, pod := seatOfKind(t, session.MCQ)
+	pod.Close()
+
+	w := switchTo(s, c, "ckad-mock-01")
+
+	if w.Code == http.StatusAccepted {
+		t.Fatalf("an unreadable catalog let the switch through: %s", body(t, w))
+	}
+}
+
+// A reset carries no bank and never reaches the gate.
+func TestAResetIsUnaffected(t *testing.T) {
+	s, c, _ := seatOfKind(t, session.MCQ)
+
+	r := httptest.NewRequest(http.MethodPost, "/api/control/reset", strings.NewReader(`{}`))
+	r.AddCookie(c)
+	w := do(s, r)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202: %s", w.Code, body(t, w))
+	}
+}

--- a/hub/internal/api/session.go
+++ b/hub/internal/api/session.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"kubestronaut-sim/hub/internal/session"
 )
@@ -135,7 +137,99 @@ func (s *Server) handleSwitch(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "body must be JSON with a non-empty \"bank\"")
 		return
 	}
+	user, ok := s.requireUser(w, r)
+	if !ok {
+		return
+	}
+	// The gate, and the only route that needs it: reset passes no bank,
+	// and every other way into recycle would have to add one. A new
+	// caller that lets a candidate name an exam has to come through here.
+	if !s.seatCanRun(w, user.UserID, body.Bank) {
+		return
+	}
 	s.recycle(w, r, body.Bank)
+}
+
+// seatCanRun reports whether this candidate's seat is the flavour their
+// chosen exam needs, writing the refusal itself when it is not.
+//
+// The authority on what an exam needs is the bank, and the bank is in
+// the session Pod — the hub has no /banks of its own — so this asks the
+// candidate's own facilitator. That is one request against a Pod the
+// proxy is already talking to, and it happens BEFORE anything is
+// destroyed: a switch that wipes the session and then discovers it
+// cannot finish is precisely the failure canRestart() exists to prevent.
+//
+// Every uncertain answer refuses. Not knowing whether a hands-on bank is
+// about to be booted into a Pod with no cluster is not a reason to try
+// it and find out.
+func (s *Server) seatCanRun(w http.ResponseWriter, user, bank string) bool {
+	live, err := s.Sessions.Get(user)
+	switch {
+	case errors.Is(err, session.ErrNoSession):
+		writeError(w, http.StatusNotFound, "you have no session to switch")
+		return false
+	case err != nil:
+		s.logf("hub: seat check for %s: %v", user, err)
+		writeError(w, http.StatusInternalServerError, "could not find your session")
+		return false
+	}
+	if live.Addr() == "" {
+		writeError(w, http.StatusConflict, "wait until your environment is ready before changing exams")
+		return false
+	}
+
+	kind, found, err := s.bankKind(live.Addr(), bank)
+	if err != nil {
+		s.logf("hub: reading the catalog for %s: %v", user, err)
+		writeError(w, http.StatusBadGateway, "could not check whether this seat can run that exam")
+		return false
+	}
+	if !found {
+		writeError(w, http.StatusNotFound, "no such exam")
+		return false
+	}
+	if kind != live.Kind {
+		writeError(w, http.StatusConflict,
+			"this seat cannot run that exam — end this session and start the other kind")
+		return false
+	}
+	return true
+}
+
+// bankKind asks a session Pod's facilitator what flavour of seat an exam
+// needs. The catalog is the same document the exam picker renders, so
+// the answer the hub enforces is the one the candidate was shown.
+func (s *Server) bankKind(addr, bank string) (session.Kind, bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+addr+"/api/catalog", nil)
+	if err != nil {
+		return "", false, err
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", false, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return "", false, fmt.Errorf("catalog: %s", res.Status)
+	}
+	var catalog struct {
+		Exams []struct {
+			ID       string `json:"id"`
+			ExamType string `json:"examType"`
+		} `json:"exams"`
+	}
+	if err := json.NewDecoder(io.LimitReader(res.Body, maxBody)).Decode(&catalog); err != nil {
+		return "", false, err
+	}
+	for _, e := range catalog.Exams {
+		if e.ID == bank {
+			return session.KindOf(e.ExamType), true, nil
+		}
+	}
+	return "", false, nil
 }
 
 // recycle answers reset and switch in the conductor's 202-plus-job

--- a/hub/internal/api/shell.go
+++ b/hub/internal/api/shell.go
@@ -36,6 +36,15 @@ func (s *Server) wantsShell(r *http.Request) bool {
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
 		return false
 	}
+	// A WebSocket handshake is a GET, and the desktop stream is not
+	// under /api/. Answering one with 200 and an HTML body fails it as
+	// code 1006 — "connection closed abnormally" — which tells the
+	// candidate's console nothing about the Pod still booting. The 503
+	// with Retry-After that the proxy would otherwise send is the honest
+	// answer, and the one the SPA's reconnect loop is written against.
+	if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+		return false
+	}
 	return !strings.HasPrefix(r.URL.Path, "/api/") && !strings.HasPrefix(r.URL.Path, "/hub/")
 }
 

--- a/hub/internal/api/shell_test.go
+++ b/hub/internal/api/shell_test.go
@@ -183,3 +183,25 @@ func TestNoBundleMeansTheOldJSONErrors(t *testing.T) {
 		t.Errorf("Content-Type = %q, want JSON", ct)
 	}
 }
+
+// A WebSocket handshake is a GET that is not under /api/, so the shell
+// would otherwise answer the desktop stream with an HTML page and the
+// browser would report code 1006 — an abnormal close with no reason,
+// while the Pod was merely still booting.
+func TestAWebSocketUpgradeIsNeverAnsweredWithHTML(t *testing.T) {
+	s := withShell(t)
+	c := login(t, s, "u1", "candidate")
+
+	r := httptest.NewRequest(http.MethodGet, "/desktop/websockify", nil)
+	r.Header.Set("Upgrade", "websocket")
+	r.Header.Set("Connection", "Upgrade")
+	r.AddCookie(c)
+	w := do(s, r)
+
+	if ct := w.Header().Get("Content-Type"); strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("Content-Type = %q: a stream handshake was answered with the app", ct)
+	}
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want the proxy's own 404 for a session that does not exist", w.Code)
+	}
+}

--- a/hub/internal/session/session.go
+++ b/hub/internal/session/session.go
@@ -215,6 +215,27 @@ var ErrNoSession = errors.New("session: no session")
 // ErrBusy is a second control operation while one is in flight.
 var ErrBusy = errors.New("session: another control operation is in flight")
 
+// KindOf maps a bank's declared examType onto the flavour of seat that
+// can run it.
+//
+// A seat is a Pod template: an MCQ seat has two containers and no
+// cluster. Switching a session's bank does NOT switch its template, so a
+// hands-on exam chosen from an MCQ seat booted the hands-on bank into a
+// Pod with no instances and no desktop — every grader check returned
+// "could not resolve hostname instance-1", scored 0, and was recorded as
+// a real attempt. The catalog inside a session lists every bank the
+// banks image staged, which is all of them, so the seat is the thing
+// that has to say no.
+//
+// An empty examType is hands-on, which is the facilitator's own default
+// (exam.TypeHandsOn) and must stay in step with it.
+func KindOf(examType string) Kind {
+	if examType == "mcq" {
+		return MCQ
+	}
+	return Practical
+}
+
 // Manager is the whole hosted tier's admission control.
 type Manager struct {
 	cfg  Config
@@ -527,7 +548,6 @@ func (m *Manager) Recycle(user, bank string) (Job, error) {
 	if !haveFlavour {
 		return Job{}, fmt.Errorf("%w: %s", ErrNoSuchKind, e.Kind)
 	}
-
 	op, phases := "reset", []Phase{
 		{ID: "stop", Label: "Stop the current session"},
 		{ID: "start", Label: "Start a clean session"},

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -583,6 +583,7 @@ function SimApp({ hosted }: { hosted?: Hosted } = {}) {
           <Exams
             onControlStart={runControlAction}
             catalogVersion={catalogVersion}
+            seatKind={hosted?.me.session?.kind}
             onBanksLoaded={handleBanksLoaded}
           />
         );

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -319,6 +319,23 @@ export interface QuestionResult {
   correct?: number[];
   options?: string[];
   multi?: boolean;
+  /**
+   * The bank's reference solution, on a STORED attempt only.
+   *
+   * A live result never carries one and must not: the same document is
+   * what a mid-session practice grade produces, and the solution
+   * endpoint is gated exactly there. Live, the explanation screen asks
+   * for it (`GET /api/questions/{id}/solution`) once the attempt has
+   * ended.
+   *
+   * A hosted attempt is read back after the Pod holding the bank is
+   * gone, so the facilitator attaches these on the way to the hub — see
+   * facilitator/cmd/facilitator/solutions.go. Absent on every attempt
+   * stored before that existed, which is why it is optional and why the
+   * screen still has something to say when it is missing.
+   */
+  solution?: string;
+  docs?: SolutionDoc[];
 }
 
 export interface Results {

--- a/ui/src/components/AppHeader.tsx
+++ b/ui/src/components/AppHeader.tsx
@@ -1,28 +1,10 @@
 import type { ReactNode } from "react";
+import { BrandMark } from "./BrandMark";
 import { Icon } from "./Icon";
 import { InfoButton } from "./InfoButton";
 import { ThemeToggle } from "./ThemeToggle";
 import { navigate } from "../lib/useHashRoute";
 import { strings } from "../strings";
-
-// The product mark, at header scale.
-//
-// A mirror of ui/public/favicon.svg — same geometry, same three colours,
-// scaled to the 26px the header draws it at. The colours are literal
-// rather than var(): this is a filled multi-colour drawing, not a
-// currentColor glyph, and it must read identically in both themes for
-// the same reason the machine surfaces do. tokens.css names this file as
-// one of the mark's mirrors.
-function BrandMark() {
-  return (
-    <svg className="brand-mark" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
-      <rect width="32" height="32" rx="9" fill="#101728" />
-      <circle cx="16" cy="16" r="8.3" fill="none" stroke="#6f9cf8" strokeWidth="1.6" />
-      <circle cx="25.1" cy="6.9" r="3.2" fill="#8fd6a8" />
-      <circle cx="6.9" cy="25.1" r="2.1" fill="#e8c46a" />
-    </svg>
-  );
-}
 
 /** One entry in the header's right-hand navigation. */
 export interface NavItem {

--- a/ui/src/components/BrandMark.tsx
+++ b/ui/src/components/BrandMark.tsx
@@ -1,0 +1,24 @@
+/**
+ * The product mark.
+ *
+ * A mirror of ui/public/favicon.svg — same geometry, same three colours.
+ * The colours are literal rather than var(): this is a filled
+ * multi-colour drawing, not a currentColor glyph, and it must read
+ * identically in both themes for the same reason the machine surfaces do.
+ * tokens.css names this file as one of the mark's mirrors.
+ *
+ * It lives here rather than inside AppHeader because it is drawn at two
+ * scales now — 26px in the header, and large above the sign-in card,
+ * which is the only screen in the product with no header to carry it.
+ * Size is the caller's, through the class.
+ */
+export function BrandMark({ className = "brand-mark" }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+      <rect width="32" height="32" rx="9" fill="#101728" />
+      <circle cx="16" cy="16" r="8.3" fill="none" stroke="#6f9cf8" strokeWidth="1.6" />
+      <circle cx="25.1" cy="6.9" r="3.2" fill="#8fd6a8" />
+      <circle cx="6.9" cy="25.1" r="2.1" fill="#e8c46a" />
+    </svg>
+  );
+}

--- a/ui/src/components/DesktopRequired.test.tsx
+++ b/ui/src/components/DesktopRequired.test.tsx
@@ -64,4 +64,34 @@ describe("DesktopRequired", () => {
     );
     expect(screen.getByRole("button", { name: "End Exam" })).toBeInTheDocument();
   });
+
+  // Reachable is not enough on the device this screen exists for. Below
+  // three paragraphs and a requirements list, on a phone, the only way to
+  // submit a still-running exam is off the bottom of the screen — which
+  // is what a candidate arriving here is actually looking for.
+  test("the running session's controls come before the explanation, not after it", () => {
+    render(
+      <DesktopRequired verdict="narrow">
+        <button>End Exam</button>
+      </DesktopRequired>,
+    );
+
+    const submit = screen.getByRole("button", { name: "End Exam" });
+    const why = screen.getByText(/side by side with the questions/i);
+    expect(submit.compareDocumentPosition(why) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  // The override is the one control that belongs after the reasons: it
+  // is "I have read why this will not work", not a way out of an exam.
+  test("continue anyway stays last", () => {
+    render(
+      <DesktopRequired verdict="narrow">
+        <button>End Exam</button>
+      </DesktopRequired>,
+    );
+
+    const anyway = screen.getByRole("button", { name: /continue anyway/i });
+    const why = screen.getByText(/side by side with the questions/i);
+    expect(why.compareDocumentPosition(anyway) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
 });

--- a/ui/src/components/DesktopRequired.tsx
+++ b/ui/src/components/DesktopRequired.tsx
@@ -34,7 +34,17 @@ export function gateOverridden(): boolean {
 
 interface DesktopRequiredProps {
   verdict: GateVerdict;
-  /** Rendered underneath the explanation while a session is running. */
+  /**
+   * The running attempt's clock and its submit control.
+   *
+   * Rendered FIRST, immediately under the heading. It used to sit below
+   * the explanation and the requirements list, which on a phone put the
+   * only way to submit an exam that is still being timed below the fold
+   * — three paragraphs of why this device cannot run the exam, read by
+   * someone whose actual question is "how do I get out of this". The
+   * explanation is why they are here; the clock is what they can do
+   * about it, and it goes first.
+   */
   children?: React.ReactNode;
 }
 
@@ -55,6 +65,7 @@ export function DesktopRequired({ verdict, children }: DesktopRequiredProps) {
     <div className="desktop-required">
       <div className="desktop-required-card">
         <h1>{strings.mobile.title}</h1>
+        {children}
         <p>{strings.mobile.why}</p>
         <ul className="desktop-required-needs">
           {strings.mobile.requirements.map((r) => (
@@ -62,9 +73,11 @@ export function DesktopRequired({ verdict, children }: DesktopRequiredProps) {
           ))}
         </ul>
         <p className="desktop-required-still">{strings.mobile.stillAvailable}</p>
-        {children}
+        {/* Last, and that is the right place for it: it is the "I have
+            read why this will not work" action, not an escape from a
+            running exam. */}
         {verdict === "narrow" && (
-          <button className="btn" onClick={continueAnyway}>
+          <button className="btn desktop-required-anyway" onClick={continueAnyway}>
             {strings.mobile.continueAnyway}
           </button>
         )}

--- a/ui/src/components/Icon.tsx
+++ b/ui/src/components/Icon.tsx
@@ -17,11 +17,12 @@ import type { ReactNode } from "react";
 // rather than imported, which keeps the offline promise absolute —
 // nothing about an icon can fail to arrive.
 //
-// The brand mark is deliberately NOT in this set. It is a filled,
-// multi-colour drawing on its own field (see BrandMark in AppHeader and
-// its mirror in ui/public/favicon.svg); these are monochrome outlines
-// that take `currentColor`, and mixing the two systems in one file would
-// invite a call site to tint the mark.
+// Brand marks are deliberately NOT in this set — neither this product's
+// (BrandMark.tsx, a filled multi-colour drawing on its own field, mirrored
+// in ui/public/favicon.svg) nor anyone else's (the GitHub mark, drawn in
+// HostedSignIn beside the button it belongs to). These are monochrome
+// outlines on a 24 grid that take `currentColor`, and mixing a logo into
+// them would invite a call site to restyle one.
 //
 // The <svg> hardcodes aria-hidden and takes no label prop, deliberately.
 // Every glyph in this product already sits beside .sr-only text or an

--- a/ui/src/screens/Exams.test.tsx
+++ b/ui/src/screens/Exams.test.tsx
@@ -79,11 +79,16 @@ function mockApi() {
 }
 
 const noop = () => {};
-const renderExams = (catalogVersion = 0, onControlStart = noop as never) =>
+const renderExams = (
+  catalogVersion = 0,
+  onControlStart = noop as never,
+  seatKind?: "practical" | "mcq",
+) =>
   render(
     <Exams
       catalogVersion={catalogVersion}
       onControlStart={onControlStart}
+      seatKind={seatKind}
       onBanksLoaded={noop}
     />,
   );
@@ -338,5 +343,47 @@ describe("choosing an exam", () => {
     );
     await waitFor(() => expect(screen.getByRole("heading", { name: "CKAD" })).toBeInTheDocument());
     expect(window.location.hash).toBe("");
+  });
+});
+
+// A hosted seat IS a Pod template. The multiple-choice one is a
+// facilitator and 128Mi with no cluster in it, so a hands-on exam started
+// from that seat booted the bank into an environment with no instances
+// and no desktop: every task graded zero against "could not resolve
+// hostname instance-1", and it was recorded as a real attempt. The
+// catalog cannot tell — every bank is staged into every session — so this
+// screen is where the seat has to be honoured.
+describe("a hosted seat", () => {
+  test("offers only the exams that seat can actually run", async () => {
+    renderExams(0, noop as never, "mcq");
+    await screen.findByRole("heading", { name: "KCNA" });
+
+    expect(within(cardFor("KCNA")).getByRole("button", { name: "Choose a mode" })).toBeTruthy();
+    expect(within(cardFor("CKAD")).queryByRole("button")).toBeNull();
+  });
+
+  test("says which seat a hands-on exam needs, rather than calling it unavailable", async () => {
+    renderExams(0, noop as never, "mcq");
+    await screen.findByRole("heading", { name: "CKAD" });
+
+    const card = cardFor("CKAD");
+    expect(within(card).getByText("Not in this seat")).toBeTruthy();
+    expect(within(card).getByText(/end this session and start a practical one/i)).toBeTruthy();
+  });
+
+  test("the mirror: a hands-on seat is not offered the question bank", async () => {
+    renderExams(0, noop as never, "practical");
+    await screen.findByRole("heading", { name: "CKAD" });
+
+    expect(within(cardFor("CKAD")).getByRole("button", { name: "Choose a mode" })).toBeTruthy();
+    expect(within(cardFor("KCNA")).queryByRole("button")).toBeNull();
+  });
+
+  test("changes nothing locally, where there is no seat and every exam is yours", async () => {
+    renderExams();
+    await screen.findByRole("heading", { name: "CKAD" });
+
+    expect(within(cardFor("CKAD")).getByRole("button", { name: "Choose a mode" })).toBeTruthy();
+    expect(within(cardFor("KCNA")).getByRole("button", { name: "Choose a mode" })).toBeTruthy();
   });
 });

--- a/ui/src/screens/Exams.tsx
+++ b/ui/src/screens/Exams.tsx
@@ -6,6 +6,7 @@ import {
   type CatalogExam,
   type ControlActionResponse,
   type BanksResponse,
+  type SessionKind,
 } from "../api";
 import { Async } from "../components/Async";
 import { CertMark, hasCertMark } from "../components/CertMark";
@@ -192,7 +193,7 @@ function ExamCard({ bank, onChoose }: { bank: CatalogExam; onChoose: () => void 
   );
 }
 
-function SoonCard({ bank }: { bank: BankEntry }) {
+function SoonCard({ bank, badge }: { bank: BankEntry; badge?: string }) {
   return (
     <li>
       <article className="exam-card exam-card-soon" data-engine="soon">
@@ -203,7 +204,7 @@ function SoonCard({ bank }: { bank: BankEntry }) {
             <p>{examSubtitle(bank)}</p>
           </div>
           <span className="exam-badge">
-            {bank.comingSoon ? strings.exams.soon : strings.exams.unavailable}
+            {badge ?? (bank.comingSoon ? strings.exams.soon : strings.exams.unavailable)}
           </span>
         </div>
         {/* The reason is the entire point of rendering an exam nobody can
@@ -214,10 +215,52 @@ function SoonCard({ bank }: { bank: BankEntry }) {
   );
 }
 
+/**
+ * The seat a hosted candidate is sitting in, or undefined when this is
+ * the local product and every exam is theirs to choose.
+ *
+ * A seat is a Pod template. The multiple-choice one is a facilitator and
+ * 128Mi with no cluster in it, so a hands-on exam started there boots the
+ * bank into an environment with no instances and no desktop: every task
+ * grades zero against "could not resolve hostname instance-1", and the
+ * attempt is recorded as if it counted.
+ *
+ * The catalog cannot make this distinction itself — the banks image
+ * stages every bank into every session, so all of them are `available`
+ * from inside any Pod. The hub refuses the switch too, and that refusal
+ * is the one that matters; this is so nobody is offered it first.
+ */
+function seatFor(
+  exams: CatalogExam[],
+  seat: SessionKind | undefined,
+): { offered: CatalogExam[]; wrongSeat: Set<string> } {
+  const wrongSeat = new Set<string>();
+  if (!seat) return { offered: exams, wrongSeat };
+  const offered = exams.map((bank) => {
+    if (!bank.available) return bank;
+    const needs = bank.examType === "mcq" ? "mcq" : "practical";
+    if (needs === seat) return bank;
+    wrongSeat.add(bank.id);
+    return {
+      ...bank,
+      available: false,
+      // Not "coming soon": it exists, it is finished, and someone in the
+      // other seat is sitting it right now.
+      comingSoon: false,
+      note: strings.exams.wrongSeatNote(
+        needs === "mcq" ? strings.exams.engineMcq : strings.exams.enginePractical,
+      ),
+    };
+  });
+  return { offered, wrongSeat };
+}
+
 interface ExamsProps {
   // Bumped by App whenever a control job finishes: a completed switch
   // changes which bank is active while this screen stays mounted.
   catalogVersion: number;
+  // The hosted seat, if this is a hosted session. Undefined locally.
+  seatKind?: SessionKind;
   // Takes the *starter*, not its result, so the switch runs inside App's
   // runControlAction — the wrapper that turns both a refused job
   // ({ok:false}) and a rejected fetch into a toast.
@@ -244,7 +287,7 @@ interface ExamsProps {
  * same "Choose a mode" verb but a card that is not the active bank goes
  * through a confirmation first.
  */
-export function Exams({ catalogVersion, onControlStart, onBanksLoaded }: ExamsProps) {
+export function Exams({ catalogVersion, seatKind, onControlStart, onBanksLoaded }: ExamsProps) {
   const [confirm, setConfirm] = useState<CatalogExam | null>(null);
   const [switching, setSwitching] = useState(false);
   // The bank a switch was started FOR, so the mode screen it was meant
@@ -322,8 +365,12 @@ export function Exams({ catalogVersion, onControlStart, onBanksLoaded }: ExamsPr
         )}
       >
         {(loaded) => {
-          const live = loaded.exams.filter((b) => b.available);
-          const soon = loaded.exams.filter((b) => !b.available);
+          // Only the two lists below are seat-aware. The coverage figure
+          // above counts certifications passed on the path, which is a
+          // fact about the candidate and not about the Pod they are in.
+          const { offered, wrongSeat } = seatFor(loaded.exams, seatKind);
+          const live = offered.filter((b) => b.available);
+          const soon = offered.filter((b) => !b.available);
           return (
             <>
               <header className="page-head">
@@ -370,7 +417,11 @@ export function Exams({ catalogVersion, onControlStart, onBanksLoaded }: ExamsPr
               {soon.length > 0 && (
                 <ul className="exam-grid exam-grid-soon" aria-label={strings.exams.soonListLabel}>
                   {soon.map((b) => (
-                    <SoonCard key={b.id} bank={b} />
+                    <SoonCard
+                      key={b.id}
+                      bank={b}
+                      badge={wrongSeat.has(b.id) ? strings.exams.wrongSeat : undefined}
+                    />
                   ))}
                 </ul>
               )}

--- a/ui/src/screens/Explain.test.tsx
+++ b/ui/src/screens/Explain.test.tsx
@@ -629,3 +629,36 @@ describe("Explain for a multiple-choice question", () => {
     expect(panes()).toHaveLength(0);
   });
 });
+
+// Reading back a stored attempt. The reference solution is part of the
+// bank and the bank is in a session Pod, so a saved attempt simply does
+// not contain one — and asking anyway is worse than not having it: with a
+// session running it would answer from whichever exam is loaded NOW,
+// which need not be the exam being reviewed.
+describe("a historical attempt", () => {
+  test("does not ask a session for the reference solution", async () => {
+    const asked: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        asked.push(String(input));
+        return new Response(JSON.stringify({}), { status: 200 });
+      }),
+    );
+
+    render(<Explain results={attempt([withEvidence])} questionId="q19" live={false} />);
+
+    await screen.findByRole("heading", { level: 1 });
+    expect(asked.filter((url) => url.includes("/solution"))).toHaveLength(0);
+  });
+
+  test("says where reference solutions live, and does not report an error", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({}), { status: 200 })));
+
+    render(<Explain results={attempt([withEvidence])} questionId="q19" live={false} />);
+
+    expect(await screen.findByText(/Reference solutions live in the exam environment/i)).toBeTruthy();
+    expect(document.querySelector(".explain-solution .error-text")).toBeNull();
+  });
+});
+

--- a/ui/src/screens/Explain.test.tsx
+++ b/ui/src/screens/Explain.test.tsx
@@ -630,11 +630,12 @@ describe("Explain for a multiple-choice question", () => {
   });
 });
 
-// Reading back a stored attempt. The reference solution is part of the
-// bank and the bank is in a session Pod, so a saved attempt simply does
-// not contain one — and asking anyway is worse than not having it: with a
-// session running it would answer from whichever exam is loaded NOW,
-// which need not be the exam being reviewed.
+// Reading back a stored attempt. The solution travels WITH the attempt
+// (the facilitator attaches it on the way to the hub) because the bank
+// lives in a session Pod and the whole point of a stored attempt is that
+// it outlives one. Nothing here may ask a session for it: with a session
+// running, that would answer from whichever exam is loaded NOW, which
+// need not be the exam being reviewed.
 describe("a historical attempt", () => {
   test("does not ask a session for the reference solution", async () => {
     const asked: string[] = [];
@@ -652,13 +653,59 @@ describe("a historical attempt", () => {
     expect(asked.filter((url) => url.includes("/solution"))).toHaveLength(0);
   });
 
-  test("says where reference solutions live, and does not report an error", async () => {
+  test("renders the solution stored with the attempt", async () => {
+    const asked: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        asked.push(String(input));
+        return new Response(JSON.stringify({}), { status: 200 });
+      }),
+    );
+    const stored = {
+      ...withEvidence,
+      solution: "Set the target port to 8080 and re-apply the Service.",
+      docs: [{ label: "Service targetPort", url: "https://kubernetes.io/docs/x" }],
+    };
+
+    render(<Explain results={attempt([stored])} questionId="q19" live={false} />);
+
+    expect(await screen.findByText(/Set the target port to 8080/)).toBeTruthy();
+    // The attempt's own docs, from the same stored document.
+    expect(screen.getByRole("link", { name: /Service targetPort/ })).toBeTruthy();
+    expect(asked.filter((url) => url.includes("/solution"))).toHaveLength(0);
+    expect(document.querySelector(".explain-solution .error-text")).toBeNull();
+  });
+
+  test("an attempt stored before solutions were kept says so, and reports no error", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({}), { status: 200 })));
 
     render(<Explain results={attempt([withEvidence])} questionId="q19" live={false} />);
 
-    expect(await screen.findByText(/Reference solutions live in the exam environment/i)).toBeTruthy();
+    expect(await screen.findByText(/saved before reference solutions were kept/i)).toBeTruthy();
     expect(document.querySelector(".explain-solution .error-text")).toBeNull();
+  });
+
+  // A live attempt must never render a solution out of its own results
+  // document. The same document is what a mid-session practice grade
+  // produces, and the solution endpoint answers 403 in exactly that
+  // state — so the refusal is the case that matters: the screen must
+  // report it, not fall back to a copy that was never meant to be there.
+  test("a live screen never shows a solution carried in the results, even when the fetch is refused", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) =>
+        String(input).includes("/solution")
+          ? new Response(JSON.stringify({ error: "solutions are available once the session has ended" }), { status: 403 })
+          : new Response(JSON.stringify({}), { status: 200 }),
+      ),
+    );
+    const leaky = { ...withEvidence, solution: "Never render me." };
+
+    render(<Explain results={attempt([leaky])} questionId="q19" />);
+
+    expect(await screen.findByText(/solutions are available once the session has ended/i)).toBeTruthy();
+    expect(screen.queryByText("Never render me.")).toBeNull();
   });
 });
 

--- a/ui/src/screens/Explain.tsx
+++ b/ui/src/screens/Explain.tsx
@@ -78,9 +78,19 @@ interface ExplainProps {
    * would jump out of the record and into the live session.
    */
   basePath?: string;
+  /**
+   * Whether a live exam environment is behind this screen.
+   *
+   * False when reading back a stored attempt. The reference solution is
+   * part of the bank, and the bank is in a session Pod — so there is
+   * nothing to ask when no session is running, and asking anyway when one
+   * IS running is worse than useless: it would answer from whichever exam
+   * is loaded now, which need not be the exam being reviewed.
+   */
+  live?: boolean;
 }
 
-export function Explain({ results, questionId, basePath = "/results" }: ExplainProps) {
+export function Explain({ results, questionId, basePath = "/results", live = true }: ExplainProps) {
   const index = results.questions.findIndex((q) => q.id === questionId);
   const question = index === -1 ? null : results.questions[index];
 
@@ -100,7 +110,7 @@ export function Explain({ results, questionId, basePath = "/results" }: ExplainP
   const [solutionError, setSolutionError] = useState<string | null>(null);
   const known = question !== null;
   useEffect(() => {
-    if (!known) return;
+    if (!known || !live) return;
     const call = new AbortController();
     getSolution(questionId, call.signal)
       .then((r) => {
@@ -114,7 +124,7 @@ export function Explain({ results, questionId, basePath = "/results" }: ExplainP
         if (!call.signal.aborted) setSolutionError(String(err));
       });
     return () => call.abort();
-  }, [questionId, known]);
+  }, [questionId, known, live]);
 
   if (question === null) {
     // A bookmark from an earlier draw, or a hand-typed fragment. It must
@@ -241,6 +251,11 @@ export function Explain({ results, questionId, basePath = "/results" }: ExplainP
           <div className="explain-solution-body">
             {solution !== null ? (
               <Markdown>{solution.markdown}</Markdown>
+            ) : !live ? (
+              // Not an error: nothing failed, and a red line saying a
+              // fetch went wrong would read as a broken page rather than
+              // as the boundary of what a saved attempt contains.
+              <p className="explain-note">{strings.explain.solutionHistorical}</p>
             ) : solutionError !== null ? (
               <p className="error-text">{strings.explain.solutionFailed(solutionError)}</p>
             ) : (

--- a/ui/src/screens/Explain.tsx
+++ b/ui/src/screens/Explain.tsx
@@ -81,11 +81,12 @@ interface ExplainProps {
   /**
    * Whether a live exam environment is behind this screen.
    *
-   * False when reading back a stored attempt. The reference solution is
-   * part of the bank, and the bank is in a session Pod — so there is
-   * nothing to ask when no session is running, and asking anyway when one
-   * IS running is worse than useless: it would answer from whichever exam
-   * is loaded now, which need not be the exam being reviewed.
+   * False when reading back a stored attempt, and then the solution is
+   * READ OUT OF THE ATTEMPT rather than fetched: the facilitator stored
+   * it with the document precisely so this screen still works with no
+   * Pod in existence. Asking a session for it instead would be worse
+   * than useless — it would answer from whichever exam is loaded now,
+   * which need not be the exam being reviewed.
    */
   live?: boolean;
 }
@@ -93,6 +94,13 @@ interface ExplainProps {
 export function Explain({ results, questionId, basePath = "/results", live = true }: ExplainProps) {
   const index = results.questions.findIndex((q) => q.id === questionId);
   const question = index === -1 ? null : results.questions[index];
+  // What a stored attempt carries, in the shape the live fetch returns,
+  // so everything below this line renders one document and not two.
+  // Absent on attempts recorded before solutions were stored with them.
+  const stored: SolutionDetail | null =
+    !live && question?.solution
+      ? { id: question.id, markdown: question.solution, docs: question.docs }
+      : null;
 
   // Eagerly, and not behind the disclosure the verdict row uses. The
   // attempt is over, so there is no answer left to protect (that is
@@ -139,6 +147,10 @@ export function Explain({ results, questionId, basePath = "/results", live = tru
       </div>
     );
   }
+
+  // One of the two, never both: the fetch does not run when `stored` can
+  // exist, and `stored` is null whenever a session is behind the screen.
+  const shown = solution ?? stored;
 
   const verdict = verdictOf(question.verdict, question.earned, question.total);
   // mcq results carry the option texts and hands-on results never do, so
@@ -249,12 +261,13 @@ export function Explain({ results, questionId, basePath = "/results", live = tru
               re-acquire; reserving the shortest solution's worth of room
               means the arrival fills a space that was already there. */}
           <div className="explain-solution-body">
-            {solution !== null ? (
-              <Markdown>{solution.markdown}</Markdown>
+            {shown !== null ? (
+              <Markdown>{shown.markdown}</Markdown>
             ) : !live ? (
+              // An attempt stored before solutions travelled with them.
               // Not an error: nothing failed, and a red line saying a
               // fetch went wrong would read as a broken page rather than
-              // as the boundary of what a saved attempt contains.
+              // as the boundary of what this saved attempt contains.
               <p className="explain-note">{strings.explain.solutionHistorical}</p>
             ) : solutionError !== null ? (
               <p className="error-text">{strings.explain.solutionFailed(solutionError)}</p>
@@ -262,7 +275,7 @@ export function Explain({ results, questionId, basePath = "/results", live = tru
               <p className="explain-note">{strings.explain.solutionLoading}</p>
             )}
           </div>
-          {solution !== null && <SolutionDocs docs={solution.docs} />}
+          {shown !== null && <SolutionDocs docs={shown.docs} />}
         </section>
       </article>
     </div>

--- a/ui/src/screens/Hosted.test.tsx
+++ b/ui/src/screens/Hosted.test.tsx
@@ -208,6 +208,31 @@ test("a signed-out visitor gets the sign-in screen and the seat count", async ()
   // Capacity before sign-in, on purpose: someone deciding whether to
   // create an account is entitled to know there is somewhere to sit.
   expect(screen.getByText(/2 of 3 hands-on seats free/i)).toBeTruthy();
+  // What pressing it actually costs, said first. The hub requests no
+  // OAuth scopes at all, and "Continue with GitHub" is a phrase people
+  // have learned to read as "grant this app my repositories".
+  expect(screen.getByText(/No permissions are requested/i)).toBeTruthy();
+});
+
+// It is the only screen in the product with no header, so it is the only
+// one that has to carry the header's furniture itself — otherwise a
+// visitor's first impression is a heading alone in the top-left corner of
+// an empty page, with no mark, no wordmark and no way to set the theme.
+test("the sign-in screen carries the product's own chrome", async () => {
+  identity = {
+    authenticated: false,
+    authMode: "github",
+    loginURL: "/hub/auth/login",
+    seats: { practical: { used: 1, total: 3 } },
+  };
+  render(<App />);
+
+  await screen.findByRole("link", { name: /continue with github/i });
+  expect(document.querySelector(".signin-mark")).toBeTruthy();
+  expect(screen.getByText("kubestronaut")).toBeTruthy();
+  expect(screen.getByRole("button", { name: /theme/i })).toBeTruthy();
+  // The GitHub mark rides the button it belongs to.
+  expect(document.querySelector(".signin-github .signin-github-mark")).toBeTruthy();
 });
 
 // AUTH_MODE=header behind a proxy that did not identify anyone. There is
@@ -250,6 +275,21 @@ test("a flavour with no seats configured is not offered at all", async () => {
 
   expect(await screen.findByRole("heading", { name: /hands-on exam/i })).toBeTruthy();
   expect(screen.queryByRole("heading", { name: /multiple choice/i })).toBeNull();
+});
+
+// The button stays enabled when every seat is taken — the queue is the
+// answer to a full pool, and a greyed-out button offers no way to ask
+// for one — so it has to say what the click will actually produce.
+test("a full flavour offers the queue rather than promising a session", async () => {
+  identity = me({
+    seats: { practical: { used: 3, total: 3 }, mcq: { used: 0, total: 30 } },
+  });
+  render(<App />);
+
+  const queue = await screen.findByRole("button", { name: /join the queue/i });
+  expect(queue).toBeEnabled();
+  // The flavour that is not full still says Start.
+  expect(screen.getByRole("button", { name: "Start" })).toBeTruthy();
 });
 
 test("a full pool answers 409 with a place in the queue", async () => {

--- a/ui/src/screens/HostedBooting.tsx
+++ b/ui/src/screens/HostedBooting.tsx
@@ -72,11 +72,19 @@ export function HostedBooting({ session, onChanged }: HostedBootingProps) {
 
   const pending = session.state === "pending";
   const title = pending ? strings.hosted.bootPendingTitle : strings.hosted.bootStartingTitle;
+  // The queue reads the same whatever is being queued for; the build does
+  // not. A multiple-choice seat has no cluster to build and is up in
+  // seconds, so the hands-on copy would be describing someone else's wait.
+  const body = pending
+    ? strings.hosted.bootPendingBody
+    : session.kind === "mcq"
+      ? strings.hosted.bootStartingBodyMcq
+      : strings.hosted.bootStartingBody;
 
   return (
     <div className="page hosted-screen hosted-booting">
       <h1>{title}</h1>
-      <p>{pending ? strings.hosted.bootPendingBody : strings.hosted.bootStartingBody}</p>
+      <p>{body}</p>
       <div className="score-loading-progress">
         <PendingBar label={title} />
         {/* aria-hidden and tabular, matching the control overlay: a clock

--- a/ui/src/screens/HostedSignIn.tsx
+++ b/ui/src/screens/HostedSignIn.tsx
@@ -15,6 +15,10 @@ import { strings } from "../strings";
  */
 export function HostedSignIn({ me }: { me: Me }) {
   const seats = me.seats?.practical;
+  // The other flavour is not a footnote: it is thirty seats that need no
+  // cluster, and a visitor who reads "all 3 seats in use" and leaves was
+  // told something true about a third of what is on offer.
+  const mcq = me.seats?.mcq;
 
   return (
     <div className="page hosted-screen">
@@ -36,7 +40,8 @@ export function HostedSignIn({ me }: { me: Me }) {
             </a>
             {seats && (
               <p className="hosted-seats" role="status">
-                {strings.hosted.signInSeats(seats.used, seats.total)}
+                {strings.hosted.signInSeats(seats.used, seats.total)}{" "}
+                {mcq && strings.hosted.signInSeatsMcq(mcq.total - mcq.used)}
               </p>
             )}
           </>

--- a/ui/src/screens/HostedSignIn.tsx
+++ b/ui/src/screens/HostedSignIn.tsx
@@ -1,5 +1,33 @@
 import type { Me } from "../api";
+import { BrandMark } from "../components/BrandMark";
+import { ThemeToggle } from "../components/ThemeToggle";
 import { strings } from "../strings";
+
+/**
+ * The GitHub mark, drawn here rather than added to the icon set.
+ *
+ * It is a third-party logo: filled, on a fixed 16 grid, and not ours to
+ * restyle. Icon.tsx is a set of monochrome 24-grid outlines that any call
+ * site may tint and scale, and a logo in that drawer would eventually be
+ * treated as one of them. It takes `currentColor` so it sits correctly on
+ * the button in both themes, which is the one liberty GitHub's brand
+ * guidance allows and the only one taken.
+ */
+function GitHubMark() {
+  return (
+    <svg
+      className="signin-github-mark"
+      viewBox="0 0 16 16"
+      width="1.15em"
+      height="1.15em"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+    </svg>
+  );
+}
 
 /**
  * The one screen a signed-out visitor sees.
@@ -9,9 +37,18 @@ import { strings } from "../strings";
  * still has no authentication of any kind and never learns that any of
  * this happened.
  *
+ * It is the only screen in the product with NO HEADER, which is what made
+ * the first draft of it look like a different application: a left-aligned
+ * page heading floating at the top of an empty viewport, with the product
+ * mark, the wordmark and the theme control — all of them header furniture
+ * everywhere else — simply missing. So this screen carries its own. The
+ * mark and wordmark move to the top of the card, the theme toggle keeps
+ * the corner it has on every other screen, and the whole thing is
+ * centred: a door, not a truncated page.
+ *
  * Seat counts before sign-in, deliberately: someone deciding whether to
- * create an account here is entitled to know whether there is anywhere
- * to sit. It is a capacity number, not a fact about anyone.
+ * create an account here is entitled to know whether there is anywhere to
+ * sit. It is a capacity number, not a fact about anyone.
  */
 export function HostedSignIn({ me }: { me: Me }) {
   const seats = me.seats?.practical;
@@ -19,43 +56,67 @@ export function HostedSignIn({ me }: { me: Me }) {
   // cluster, and a visitor who reads "all 3 seats in use" and leaves was
   // told something true about a third of what is on offer.
   const mcq = me.seats?.mcq;
+  const mcqLine = mcq ? strings.hosted.signInSeatsMcq(mcq.total - mcq.used) : "";
 
   return (
-    <div className="page hosted-screen">
-      <header className="page-head">
-        <div>
-          <h1>{strings.hosted.signInTitle}</h1>
-          <p className="page-lead">{strings.hosted.signInLead}</p>
-        </div>
-      </header>
-
-      <div className="hosted-card">
-        {me.loginURL ? (
-          <>
-            {/* A link and not a fetch: the OAuth flow is a redirect to
-                GitHub and back, and there is nothing for JavaScript to
-                do in the middle of it. */}
-            <a className="btn btn-primary hosted-signin" href={me.loginURL}>
-              {strings.hosted.signInGitHub}
-            </a>
-            {seats && (
-              <p className="hosted-seats" role="status">
-                {strings.hosted.signInSeats(seats.used, seats.total)}{" "}
-                {mcq && strings.hosted.signInSeatsMcq(mcq.total - mcq.used)}
-              </p>
-            )}
-          </>
-        ) : (
-          // AUTH_MODE=header or none, reached without the header being
-          // set. There is genuinely no login here, and offering a button
-          // that 404s would be worse than saying so.
-          <p className="hosted-unavailable" role="alert">
-            {strings.hosted.signInUnavailable}
-          </p>
-        )}
+    <div className="signin">
+      {/* The theme is the visitor's before the account is, and this is
+          the only screen where no header offers it. */}
+      <div className="signin-chrome">
+        <ThemeToggle />
       </div>
 
-      <p className="hosted-local">{strings.hosted.signInLocal}</p>
+      <main className="signin-main">
+        <div className="signin-card">
+          <div className="signin-brand">
+            <BrandMark className="signin-mark" />
+            <span className="signin-wordmark">
+              {strings.header.wordmark}
+              <span className="signin-wordmark-tail">{strings.header.wordmarkTail}</span>
+            </span>
+          </div>
+
+          <h1 className="signin-title">{strings.hosted.signInTitle}</h1>
+          <p className="signin-lead">{strings.hosted.signInLead}</p>
+
+          {me.loginURL ? (
+            <>
+              {/* A link and not a fetch: the OAuth flow is a redirect to
+                  GitHub and back, and there is nothing for JavaScript to
+                  do in the middle of it. */}
+              <a className="btn btn-primary signin-github" href={me.loginURL}>
+                <GitHubMark />
+                {strings.hosted.signInGitHub}
+              </a>
+              {/* What the button actually does, said before it is pressed.
+                  The hub requests NO OAuth scopes (hub/internal/auth:
+                  GitHub), which is the difference between signing in and
+                  granting an app your repositories — and a visitor cannot
+                  read that comment. */}
+              <p className="signin-scope">{strings.hosted.signInScope}</p>
+
+              {seats && (
+                <p className="signin-seats" role="status">
+                  <span className="signin-seats-dot" data-full={seats.used >= seats.total || undefined} aria-hidden="true" />
+                  <span>
+                    {strings.hosted.signInSeats(seats.used, seats.total)}
+                    {mcqLine && <span className="signin-seats-mcq">{mcqLine}</span>}
+                  </span>
+                </p>
+              )}
+            </>
+          ) : (
+            // AUTH_MODE=header or none, reached without the header being
+            // set. There is genuinely no login here, and offering a button
+            // that 404s would be worse than saying so.
+            <p className="signin-unavailable" role="alert">
+              {strings.hosted.signInUnavailable}
+            </p>
+          )}
+        </div>
+
+        <p className="signin-local">{strings.hosted.signInLocal}</p>
+      </main>
     </div>
   );
 }

--- a/ui/src/screens/HostedStart.tsx
+++ b/ui/src/screens/HostedStart.tsx
@@ -7,6 +7,7 @@ import {
   type Seats,
 } from "../api";
 import { Dialog } from "../components/Dialog";
+import { Icon, type IconName } from "../components/Icon";
 import { strings } from "../strings";
 
 interface HostedStartProps {
@@ -21,6 +22,13 @@ interface Flavour {
   title: string;
   body: string;
   seats: Seats | undefined;
+  /**
+   * The tile glyph, in the exam selector's vocabulary — this lobby is
+   * the same product one step earlier, so its cards are that card.
+   * A hands-on seat is the one that needs a keyboard (it is what the
+   * mobile gate says too); multiple choice is a grid of options.
+   */
+  icon: IconName;
 }
 
 /**
@@ -91,12 +99,14 @@ export function HostedStart({ me, onChanged }: HostedStartProps) {
       title: strings.hosted.practicalTitle,
       body: strings.hosted.practicalBody,
       seats: me.seats?.practical,
+      icon: "keyboard",
     },
     {
       kind: "mcq",
       title: strings.hosted.mcqTitle,
       body: strings.hosted.mcqBody,
       seats: me.seats?.mcq,
+      icon: "grid",
     },
   ];
   // A flavour a deployment gave no seats to is not offered at all. The
@@ -137,26 +147,41 @@ export function HostedStart({ me, onChanged }: HostedStartProps) {
           return (
             <li key={f.kind}>
               <article className="hosted-flavour" data-full={full || undefined}>
-                <h2>{f.title}</h2>
-                <p>{f.body}</p>
-                <p className="hosted-flavour-seats">
-                  {f.seats === undefined
-                    ? null
-                    : full
-                      ? strings.hosted.seatsFull(f.seats.total)
-                      : strings.hosted.seatsFree(f.seats.used, f.seats.total)}
-                </p>
-                {/* Enabled even when full, deliberately. The answer to a
-                    full pool is a place in the queue, and a greyed-out
-                    button offers no way to ask for one. */}
-                <button
-                  type="button"
-                  className="btn btn-primary"
-                  onClick={() => void start(f.kind)}
-                  disabled={starting !== null}
-                >
-                  {starting === f.kind ? strings.hosted.starting : strings.hosted.start}
-                </button>
+                <div className="hosted-flavour-head">
+                  <span className="exam-avatar hosted-flavour-tile" aria-hidden="true">
+                    <Icon name={f.icon} />
+                  </span>
+                  <div className="hosted-flavour-name">
+                    <h2>{f.title}</h2>
+                    <p className="hosted-flavour-seats">
+                      {f.seats === undefined
+                        ? null
+                        : full
+                          ? strings.hosted.seatsFull(f.seats.total)
+                          : strings.hosted.seatsFree(f.seats.used, f.seats.total)}
+                    </p>
+                  </div>
+                </div>
+                <p className="hosted-flavour-body">{f.body}</p>
+                {/* Enabled even when full, deliberately, and it says what
+                    it will actually do. The answer to a full pool is a
+                    place in the queue: a greyed-out button offers no way
+                    to ask for one, and one labelled "Start" promises a
+                    session that is not what the click produces. */}
+                <div className="hosted-flavour-actions">
+                  <button
+                    type="button"
+                    className="btn btn-primary"
+                    onClick={() => void start(f.kind)}
+                    disabled={starting !== null}
+                  >
+                    {starting === f.kind
+                      ? strings.hosted.starting
+                      : full
+                        ? strings.hosted.startQueue
+                        : strings.hosted.start}
+                  </button>
+                </div>
               </article>
             </li>
           );

--- a/ui/src/screens/Review.tsx
+++ b/ui/src/screens/Review.tsx
@@ -57,6 +57,7 @@ export function Review({ attemptId, questionId }: ReviewProps) {
               results={results}
               questionId={questionId}
               basePath={`/history/${attemptId}`}
+              live={false}
             />
           </div>
         ) : (

--- a/ui/src/strings.ts
+++ b/ui/src/strings.ts
@@ -50,6 +50,15 @@ export const strings = {
     unavailable: "Unavailable",
     liveListLabel: "Exams you can sit",
     soonListLabel: "Exams not built yet",
+    // Hosted only. A seat IS a Pod: the multiple-choice one has no
+    // cluster in it, so a hands-on exam chosen there would boot the exam
+    // into an environment with no instances and grade every task zero.
+    // The card says which seat the exam needs and what to do about it,
+    // because "unavailable" on an exam that is plainly built and live for
+    // everyone else reads as a fault.
+    wrongSeat: "Not in this seat",
+    wrongSeatNote: (needs: string) =>
+      `This is a ${needs} exam and you are in the other kind of seat. End this session and start a ${needs.toLowerCase()} one to sit it.`,
     // The stat strip under each card's title.
     durationLabel: "Duration",
     passingLabel: "To pass",
@@ -1161,6 +1170,14 @@ export const strings = {
     solutionTitle: "Reference solution",
     solutionLoading: "Loading the reference solution…",
     solutionFailed: (detail: string) => `Couldn't load the reference solution (${detail}).`,
+    // Reviewing a past attempt. The reference solution lives in the bank,
+    // which lives in a session Pod, and the attempt being read back may
+    // well be from a different exam than whatever is loaded now — so this
+    // is not a thing to fetch and fail at, it is a thing this screen
+    // genuinely does not have. The grader's own checks, the captured
+    // state and the score are all here, because those were recorded.
+    solutionHistorical:
+      "Reference solutions live in the exam environment, so they are not part of a saved attempt. Start a session on this exam to read them alongside the tasks.",
 
     // The upstream reading a bank author attached to this task
     // (`SolutionDetail.docs`). Most questions carry none, and the footer
@@ -1333,10 +1350,16 @@ export const strings = {
     signInLead:
       "A hosted session gives you a real cluster for a few hours. Signing in is how your attempts stay yours — every graded exam is kept against your account, and it outlives the environment it was taken in.",
     signInGitHub: "Continue with GitHub",
+    // Both kinds, because both are offered the moment you sign in and a
+    // page that counts only the scarce one tells a visitor there may be
+    // nowhere to sit when thirty multiple-choice seats are free. The
+    // hands-on figure still leads: it is the one that runs out.
     signInSeats: (used: number, total: number) =>
       used >= total
         ? `All ${total} hands-on seats are in use right now — you can still join the queue.`
         : `${total - used} of ${total} hands-on seats free.`,
+    signInSeatsMcq: (free: number) =>
+      free > 0 ? `Multiple choice needs no cluster: ${free} seats free.` : "",
     // No login to offer. AUTH_MODE=header sits behind someone else's
     // proxy, and if it did not identify you, this app cannot.
     signInUnavailable:
@@ -1382,8 +1405,17 @@ export const strings = {
     bootPendingBody:
       "Your seat is held. Environments are built one at a time — building two at once makes both slow rather than making either fast.",
     bootStartingTitle: "Building your environment",
+    // Per seat, because the two are not the same wait and saying so
+    // wrongly is worse than saying nothing. A hands-on seat really does
+    // build a cluster and really does take minutes. A multiple-choice
+    // seat is a facilitator and 128Mi with no cluster in it at all, and
+    // it is ready in about twenty seconds — telling that candidate to
+    // expect six minutes of cluster building describes someone else's
+    // session.
     bootStartingBody:
       "A two-node Kubernetes cluster, the exam images and 22 tasks' worth of setup. It usually takes three to six minutes; nothing is lost if you close this tab.",
+    bootStartingBodyMcq:
+      "No cluster to build for a multiple-choice exam — just the question bank and the marker. This takes a few seconds.",
     bootElapsed: (elapsed: string) => `${elapsed} so far`,
     bootFailedTitle: "Your environment did not start",
     bootRetry: "Try again",

--- a/ui/src/strings.ts
+++ b/ui/src/strings.ts
@@ -1170,14 +1170,15 @@ export const strings = {
     solutionTitle: "Reference solution",
     solutionLoading: "Loading the reference solution…",
     solutionFailed: (detail: string) => `Couldn't load the reference solution (${detail}).`,
-    // Reviewing a past attempt. The reference solution lives in the bank,
-    // which lives in a session Pod, and the attempt being read back may
-    // well be from a different exam than whatever is loaded now — so this
-    // is not a thing to fetch and fail at, it is a thing this screen
-    // genuinely does not have. The grader's own checks, the captured
-    // state and the score are all here, because those were recorded.
+    // Reviewing an OLD past attempt. Attempts are stored with their
+    // reference solutions now, so this is the narrow case: a record
+    // written before that, whose solution stayed behind in a Pod that no
+    // longer exists. Never a fetch and never an error — the attempt being
+    // read back may be from a different exam than whatever is loaded now,
+    // so asking a running session would answer with the wrong document
+    // rather than fail honestly.
     solutionHistorical:
-      "Reference solutions live in the exam environment, so they are not part of a saved attempt. Start a session on this exam to read them alongside the tasks.",
+      "This attempt was saved before reference solutions were kept alongside them, and the environment it was taken in is long gone. Newer attempts carry theirs; the checks, the captured state and the score above are all recorded here.",
 
     // The upstream reading a bank author attached to this task
     // (`SolutionDetail.docs`). Most questions carry none, and the footer
@@ -1350,6 +1351,13 @@ export const strings = {
     signInLead:
       "A hosted session gives you a real cluster for a few hours. Signing in is how your attempts stay yours — every graded exam is kept against your account, and it outlives the environment it was taken in.",
     signInGitHub: "Continue with GitHub",
+    // Said before the button is pressed, because it is true and because
+    // "Continue with GitHub" is a phrase people have learned to read as
+    // "grant an app access to my repositories". The hub requests no OAuth
+    // scopes at all (hub/internal/auth/github.go) — keep this sentence and
+    // that decision in step.
+    signInScope:
+      "No permissions are requested. GitHub tells this app your username and nothing else; it cannot see your repositories.",
     // Both kinds, because both are offered the moment you sign in and a
     // page that counts only the scarce one tells a visitor there may be
     // nowhere to sit when thirty multiple-choice seats are free. The
@@ -1382,6 +1390,10 @@ export const strings = {
     seatsFree: (used: number, total: number) => `${total - used} of ${total} free`,
     seatsFull: (total: number) => `all ${total} in use`,
     start: "Start",
+    // The same button, when every seat of that flavour is taken. It is
+    // enabled either way — the queue is the answer to a full pool — but
+    // "Start" would promise a session the click does not produce.
+    startQueue: "Join the queue",
     starting: "Starting…",
     startFailed: (detail: string) => `Could not start a session: ${detail}`,
 

--- a/ui/src/theme.css
+++ b/ui/src/theme.css
@@ -3959,13 +3959,20 @@
 .desktop-required {
   min-height: 100%;
   display: flex;
-  align-items: center;
-  justify-content: center;
   padding: var(--space-5) var(--space-4);
 }
 
+/* Centred by AUTO MARGINS, not by align-items/justify-content. A flex
+   centre whose item is taller than the line pushes the item's top edge
+   past the container's, and that overflow is unreachable — no scrollbar
+   goes there. This card grows: three paragraphs, a requirements list, a
+   live exam's clock and two controls, at 320px, at 200% text zoom. Auto
+   margins centre while there is room and collapse to zero when there is
+   not, which is the whole difference between a centred card and a
+   heading nobody can scroll back up to. */
 .desktop-required-card {
   width: min(34rem, 100%);
+  margin: auto;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-l);
@@ -4040,6 +4047,29 @@
 
   .score-actions .btn {
     width: 100%;
+  }
+
+  /* A single-purpose screen's single control is a full-width tap. Both
+     of these are the last thing on a card the reader has just scrolled
+     through, and a 90px button hugging the left edge below three
+     paragraphs is easy to miss entirely. */
+  .desktop-required-anyway,
+  .gate-session .btn,
+  .hosted-queue .btn,
+  .hosted-booting > .btn {
+    width: 100%;
+  }
+
+  /* The hosted screens close their gutters with everything else. The
+     sign-in card keeps a smaller inset than the lobby cards do: it is
+     the only content on its viewport, so its edge is the page's. */
+  .signin-card,
+  .hosted-flavour {
+    padding: var(--space-4);
+  }
+
+  .signin {
+    padding: var(--space-3);
   }
 }
 
@@ -5977,42 +6007,156 @@
   max-width: 56rem;
 }
 
-.hosted-card {
+/* ---- the sign-in screen ----
+
+   The only screen in the product with no header, which is why it is the
+   only one that draws its own mark, wordmark and theme control. It is
+   also the first thing anyone sees, so it is a centred door rather than
+   a page with its heading in the top-left corner of an empty viewport.
+
+   Centred with `margin: auto` on the child rather than `place-items:
+   center` on the parent: a flex/grid centre whose content outgrows the
+   viewport pushes the top edge out of reach, and this screen grows —
+   the unavailable copy is four lines, and 320px at 200% text zoom is a
+   size it must survive. auto margins collapse instead of overflowing. */
+.signin {
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: var(--space-3);
+  padding: var(--space-4);
+}
+
+.signin-chrome {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.signin-main {
+  width: min(27rem, 100%);
+  margin: auto;
+  padding: var(--space-5) 0 var(--space-6);
+}
+
+.signin-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
   padding: var(--space-6);
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: var(--radius-l);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-2);
 }
 
-/* An anchor styled as the primary button. Anchors do not inherit the
-   button's line box, so the two would otherwise sit at different
-   heights on the same row. */
-.hosted-signin {
-  display: inline-flex;
+/* The header's lockup, at the one scale in the product where it is the
+   subject rather than the chrome. */
+.signin-brand {
+  display: flex;
   align-items: center;
+  gap: var(--space-3);
+}
+
+.signin-mark {
+  width: 34px;
+  height: 34px;
+  flex-shrink: 0;
+}
+
+.signin-wordmark {
+  font-size: var(--text-xl);
+  font-weight: 600;
+  letter-spacing: var(--tracking-tight);
+}
+
+.signin-wordmark-tail {
+  color: var(--text-secondary);
+}
+
+.signin-title {
+  margin: 0;
+  font-size: var(--text-3xl);
+  font-weight: 600;
+  letter-spacing: var(--tracking-tight);
+}
+
+.signin-lead {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+/* Full width, because it is the only thing on this screen to do and a
+   button that fills its card cannot be missed or mis-tapped. The anchor
+   needs the flex line box explicitly: anchors do not inherit the
+   button's, so the mark and the label would otherwise sit off each
+   other's baseline. */
+.signin-github {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--text-l);
   text-decoration: none;
 }
 
-.hosted-seats,
-.hosted-flavour-seats {
+.signin-github-mark {
+  flex-shrink: 0;
+}
+
+.signin-scope {
   margin: 0;
   color: var(--text-muted);
   font-size: var(--text-s);
+  line-height: 1.55;
 }
 
-.hosted-unavailable {
+/* Live capacity, so it reads as a reading off a meter rather than as
+   copy: a dot, then the figure. */
+.signin-seats {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  margin: 0;
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: var(--text-s);
+  line-height: 1.55;
+}
+
+.signin-seats-dot {
+  width: 7px;
+  height: 7px;
+  margin-top: 0.42em;
+  border-radius: var(--radius-pill);
+  background: var(--success);
+  flex-shrink: 0;
+}
+
+/* A full pool is not an error — the queue is the answer to it — so this
+   is the waiting colour and never the failure one. */
+.signin-seats-dot[data-full] {
+  background: var(--warn);
+}
+
+.signin-seats-mcq {
+  display: block;
+}
+
+.signin-unavailable {
   margin: 0;
   color: var(--text-body);
+  line-height: 1.6;
 }
 
-.hosted-local {
-  margin-top: var(--space-5);
+.signin-local {
+  margin: var(--space-5) 0 0;
+  padding: 0 var(--space-2);
   color: var(--text-muted);
   font-size: var(--text-s);
+  line-height: 1.55;
 }
 
 /* Two cards, side by side where there is room and stacked where there
@@ -6028,34 +6172,77 @@
   list-style: none;
 }
 
+/* Deliberately .exam-card's shape, token for token: this lobby is the
+   exam selector one step earlier — same choice, same furniture — and a
+   card that agreed with it in words while disagreeing in radius, shadow
+   and tile size is what made the hosted screens read as a different
+   application bolted on the front. */
 .hosted-flavour {
   height: 100%;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: var(--space-3);
+  gap: var(--space-4);
   padding: var(--space-5);
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: var(--radius-l);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-1);
 }
 
 /* A full pool is not an error and not a disabled card: the button still
-   works, and what it gets you is a place in the queue. Dashed, the same
-   language a not-yet-available exam speaks. */
+   works, it says "Join the queue", and that is what it does. Dashed and
+   flat, the same language a not-yet-available exam speaks. */
 .hosted-flavour[data-full] {
   background: var(--bg);
   border-style: dashed;
+  box-shadow: none;
 }
 
-.hosted-flavour h2 {
+.hosted-flavour-head {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+}
+
+/* The exam avatar's tile, carrying a glyph instead of a certification
+   mark — there is no certification to name yet at this step. */
+.hosted-flavour-tile {
+  font-size: var(--text-xl);
+}
+
+.hosted-flavour-name {
+  flex: 1;
+  min-width: 0;
+}
+
+.hosted-flavour-name h2 {
   margin: 0;
-  font-size: var(--text-l);
+  font-size: var(--text-xl);
+  font-weight: 600;
 }
 
-.hosted-flavour p {
+.hosted-flavour-body {
   margin: 0;
   color: var(--text-body);
+  line-height: 1.55;
+}
+
+.hosted-flavour-seats {
+  margin: var(--space-1) 0 0;
+  color: var(--text-muted);
+  font-size: var(--text-s);
+  line-height: 1.4;
+}
+
+/* Pinned, so both cards' buttons sit on one line whatever the pitch
+   above them runs to — .exam-card-actions, for the same reason. */
+.hosted-flavour-actions {
+  margin-top: auto;
+  display: flex;
+}
+
+.hosted-flavour-actions .btn {
+  flex: 1;
 }
 
 /* Standing state rather than an interruption, so it reads as part of


### PR DESCRIPTION
## The bug

Picking the **multiple-choice** seat and then choosing **CKAD** booted the
hands-on bank into an MCQ Pod: two containers, no cluster, no instances,
no desktop. What the candidate got:

```
Failed: runs as uid 10001 / gid 20001 …   0/2
  Warning: Identity file /shared/ssh/id_ed25519 not accessible: No such file or directory.
  ssh: Could not resolve hostname instance-1: Name does not resolve
```

…twenty-two times, a desktop viewport retrying a WebSocket with nothing
behind it until it gave up at code 1006, and a **0/180 recorded as a real
attempt** against their history.

## Why

Four links, each measured on the live deployment rather than reasoned about:

1. The hub admitted an **mcq** seat and created exactly the right Pod —
   `2/2 Running`, two containers, `BANK=kcna-mock`,
   `kubestronaut-sim/bank=kcna-mock`. Creation was never the problem.
2. The facilitator inside it served a catalog advertising
   `{"id":"ckad-mock-01","examType":"hands-on","available":true}`. The
   banks image stages **every** bank into **every** session, and a Pod has
   no idea which seat it is.
3. The UI offered it as **LIVE** with a "Choose a mode" button.
4. Choosing it POSTed `/api/control/switch`. `handleSwitch` took the bank
   straight from the request body and handed it to `Recycle`, which
   re-creates **the same flavour's template** with the new bank.

A seat is a Pod template. Switching its bank never switched its template.

The candidate's stored attempt on the PVC reads `"bank": "ckad-mock-01",
"examType": "hands-on", 22 questions, 0/180` — written from an mcq
session — and the hub log shows `admitted … to a mcq seat` followed by
`sim-session-mcq-… is ready` **three times**: one boot and two recycles.

## The fix

**The hub refuses the switch, before anything is destroyed** — the rule
`canRestart()` already enforces for an operation that cannot finish. What
an exam needs is a property of the bank, and the bank lives in the session
Pod, so the gate asks the candidate's own facilitator for the catalog it
was rendered from and compares the exam's `examType` against the seat's
kind. Two decisions worth stating:

- **Every uncertain answer refuses.** Not knowing whether a hands-on bank
  is about to be booted into a Pod with no cluster is not a reason to try
  it and find out.
- **Same-kind switching stays allowed.** A practical seat may move between
  hands-on exams, because the Pod it needs is the one it already has. The
  gate is on the flavour, not on the bank the seat started with — an
  existing test switches `ckad-mock-01` → `ckad-mock-02` and still passes.

**The picker no longer offers it either.** An exam the seat cannot run
renders in the existing cannot-be-sat card with the badge **"Not in this
seat"** and a note naming the seat it needs — deliberately not
"Unavailable", which on an exam that is finished and live for everyone
else reads as a fault. The server refusal is the one that matters; this is
so nobody is offered it first.

## Three more, found while reproducing that one

- **The boot screen told a multiple-choice candidate** to expect *"a
  two-node Kubernetes cluster, the exam images and 22 tasks' worth of
  setup"* and *"three to six minutes"*. That seat has no cluster in it and
  was ready in twenty seconds. It was describing someone else's session.
- **The sign-in page counted only hands-on seats.** A visitor arriving
  when all three were taken was told there was nowhere to sit while thirty
  multiple-choice seats were free.
- **Reviewing a saved attempt fetched reference solutions from a session**
  and reported *"Couldn't load the reference solution (Error: you have no
  session running — start one first)"*. It is not an error and it should
  not be a fetch: reference solutions live in the bank, and a stored
  attempt does not contain one. Worse, with a session running it would
  have answered from whichever exam was loaded *then*, which need not be
  the exam being reviewed. Review now says where they live and does not
  ask.

## And one regression of mine

A WebSocket handshake is a GET, and `/desktop/websockify` is not under
`/api/`, so `wantsShell` caught it: during boot the hub answered the
desktop stream with an HTML page and the browser reported an abnormal
close instead of the 503 with `Retry-After` that the SPA's reconnect loop
is written against.

## Verification

- **Six mutations across both halves, all six caught**: the gate uncalled,
  the kind uncompared, an unreadable catalog waved through, the gate
  refusing *everything* (so it is not a blanket ban), the picker ignoring
  the seat, and a saved attempt still asking a session for a solution.
- Seven new hub tests covering both directions of the gate, the unknown
  exam, the unreadable catalog, the untouched reset path, and that a
  refused switch leaves the session **Ready** rather than half-destroyed.
- Six new UI tests, including that none of this changes the local product,
  where there is no seat and every exam is yours.
- `go vet ./... && go test ./...` clean across the hub; `tsc --noEmit`,
  `eslint`, and 666 UI tests green.

Not verified here: this has not run in the cluster, because `v0.1.2` does
not exist until a tag is pushed.

---

# Second commit: the hosted tier's own surfaces

## The sign-in screen

It is the only screen in the product with **no header**, and it was the
only one that did not carry the header's furniture itself: a left-aligned
page heading at the top of an empty viewport, with the mark, the
wordmark, the theme control and — on the GitHub button — the GitHub mark
all simply missing.

It is now a centred card with the product's lockup, the mark on the
button, and one line saying what pressing it costs. The hub requests **no
OAuth scopes at all** (`hub/internal/auth/github.go`), and "Continue with
GitHub" is a phrase people have learned to read as *grant this app my
repositories*; a visitor cannot read that Go comment. Seat capacity keeps
its place above the fold, now as a meter reading — a dot, then the figure
— with the multiple-choice count that a hands-on-only line was hiding.

Centred with **auto margins**, not `place-items: center`, for the reason
below.

## The lobby

The flavour cards are now `.exam-card`, token for token: same radius,
same shadow, same avatar tile, same pinned action row. They agreed with
the exam selector in words while disagreeing in every measurement, and
that is most of what made the hosted screens read as a different
application bolted on the front.

The button on a full pool now says **"Join the queue"**. It was always
enabled — the queue is the answer to a full pool, and a greyed-out button
offers no way to ask for one — but labelled "Start" it promised a session
the click does not produce.

## The desktop gate

Two faults, on the one device this screen exists for.

**The submit control was below the fold.** The clock and "End exam" sat
under three paragraphs and a requirements list. Someone who reaches this
screen mid-attempt has one question — how do I get out of this — and the
answer was off the bottom. It now comes first, under the heading;
"Continue anyway" stays last, because it is the "I have read why this
will not work" action and not an escape from a running exam.

**The card was centred with `align-items`,** so the moment it outgrew the
viewport its top edge went *above* the container and no scrollbar went
there. Measured in Chrome against a 300px container:

| | top of card at scrollTop 0 | scrollable |
|---|---|---|
| `align-items: center` | **−66px** (unreachable) | 90px of 180 |
| `margin: auto` | +24px (the padding) | 180px of 180 |

Auto margins centre while there is room and collapse to zero when there
is not, which is the whole difference between a centred card and a
heading nobody can scroll back up to.

## Reviewing a saved attempt

The previous commit stopped this screen asking a session for a reference
solution it could not answer for. That removed the error; it did not make
the attempt whole. Reference solutions live in the bank, the bank lives
in the session Pod, and **the Pod is exactly what a stored attempt
outlives** — so a hosted candidate could read every check they failed and
nothing at all about what passing looked like.

The facilitator now attaches the solutions on the way to the hub, and on
a **copy**: the live document is also what a mid-session practice grade
produces, and `GET /api/questions/{id}/solution` answers 403 in precisely
that state. Writing a solution into the live results would hand one out
through the door that is meant to be shut. 88 KB for a full CKAD bank,
against a 4 MiB ingest cap.

Attempts stored before this carry no solution, so the screen says that —
as a note, not an error.

## Verification

- **Seven mutations, seven caught.** The enrichment writing into the live
  document; the mirror not enriching at all; review ignoring the stored
  solution; a live screen rendering one out of its own results; the gate
  putting its submit control back below the prose; the lobby promising
  "Start" on a full pool; the GitHub mark dropped. One of them **survived
  the first attempt** — the live-leak test passed a solution fetch that
  succeeded, so the fetch always won; it now refuses the fetch with the
  403 that is the real case, and fails without the guard.
- Browser pass at 1280px and at an emulated 320px viewport: no sideways
  overflow on any hosted screen, the submit control above the fold, and
  the gate's unreachable top measured before and after.
- `go vet ./... && go test ./...` clean across the facilitator;
  `tsc --noEmit`, `eslint`, and **672 UI tests** green.
