### PR TITLE
Exam-scoped environments, the copyable value, and a bank that pools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,52 @@ jobs:
             --set hub.baseURL=https://sim.invalid --set hub.existingSecret=hub \
             --show-only templates/configmap-session-pods.yaml > /tmp/cm.yaml
 
+      # The per-exam manifest, which the default values render none of.
+      #
+      # `sessions.practical.banks.<id>.resources` is how an exam whose
+      # cluster is a different size gets a Pod sized for it, and the
+      # FILENAME is a contract: hub/cmd/hub/main.go's bankTemplates
+      # discovers these by looking for session-bank-<id>.json beside the
+      # flavour's own manifest. A rename on either side would leave every
+      # session silently taking the default Pod, which still boots — so
+      # nothing else would notice.
+      - name: A per-exam Pod spec renders, merged over the flavour's
+        run: |
+          helm template sim deploy/helm/kubestronaut-sim -n kubestronaut-sim \
+            --set hub.baseURL=https://sim.invalid --set hub.existingSecret=hub \
+            --set sessions.practical.resources.k8s-env.requests.cpu=1500m \
+            --set sessions.practical.banks.cka-mock-01.resources.k8s-env.limits.memory=10Gi \
+            --show-only templates/configmap-session-pods.yaml > /tmp/cm-bank.yaml
+          python3 - <<'PY'
+          import json, re, sys
+          docs, key = {}, None
+          for line in open('/tmp/cm-bank.yaml'):
+              line = line.rstrip('\n')
+              m = re.match(r'^  ([A-Za-z0-9._-]+\.json): \|\s*$', line)
+              if m:
+                  key = m.group(1); docs[key] = []; continue
+              if key is None:
+                  continue
+              if line.startswith('    '):
+                  docs[key].append(line[4:])
+              elif line.strip():
+                  key = None
+          name = 'session-bank-cka-mock-01.json'
+          if name not in docs:
+              sys.exit(f'no per-exam manifest was rendered: {sorted(docs)}')
+          pod = json.loads('\n'.join(docs[name]))
+          env = next(c for c in pod['spec']['containers'] if c['name'] == 'k8s-env')
+          # Three layers, most specific last: the manifest's measured
+          # numbers, then the flavour's, then the exam's.
+          if env['resources']['limits']['memory'] != '10Gi':
+              sys.exit(f"the exam's own limit was lost: {env['resources']}")
+          if env['resources']['requests']['cpu'] != '1500m':
+              sys.exit(f"the flavour's request was lost: {env['resources']}")
+          if env['resources']['requests']['memory'] != '2Gi':
+              sys.exit(f"the manifest's own request was lost: {env['resources']}")
+          print(f'{name}: {env["resources"]}')
+          PY
+
       # What the chart is responsible for, as opposed to what the
       # manifests are: that every first-party image was rewritten to the
       # configured registry and tag, that no container was lost on the

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,17 @@ shared/
 # committed here — not even "temporarily".
 killer-sh-*.txt
 *-dump.txt
+dump*.txt
+# The two patterns above name the files someone thought to name that way,
+# which is the weakness: a dump dropped in as `dump1.txt` inside a
+# plausible-looking bank directory matched neither, and sat in the tree
+# one `git add banks/` from being committed.
+#
+# A bank is YAML, Markdown and shell — nothing under banks/ has ever been
+# a .txt and nothing should be. So the rule stops guessing at filenames
+# and states that instead: a .txt under banks/ is foreign material by
+# definition. `git status` will not show it, which is the point.
+banks/**/*.txt
 
 # Local agent/tool state.
 #

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -343,7 +343,7 @@ The rules that govern them:
 | Rare Accent | blue arrives for four things only — focus, currency (the selected question, the active exam, the running phase), the one filled primary button per screen, and links. Progress is cyan, not blue, which is what lets the two coexist. A screen that reads as blue before it is touched has used it as decoration |
 | Two Tiers For One Hue | wherever a hue serves both a bar and a label, the base token is the graphic (3:1) and `-strong` is the text (4.5:1) — `--success`, `--warn`, `--progress`. Using the base for text is the single easiest way to fail AA here, and the contrast test is what catches it |
 | The Machine Is Not The App | `--machine-*` is a dark palette that appears in BOTH themes, reserved for things that are literally a computer. Never reach for it to make an app surface look technical. In dark mode the distinction is carried by hue and chrome rather than by lightness (`tokens.css`, header) |
-| Hover is not an accent channel | hover is one step of tone and nothing more, so the tile under a cursor never draws the outline that means "the question I am on". Two exceptions, both elements with no resting box to tone: the click-to-copy value and the 6px panel resizer |
+| Hover is not an accent channel | hover is one step of tone and nothing more, so the tile under a cursor never draws the outline that means "the question I am on". Two exceptions: the click-to-copy value, which goes accent on hover because its resting state is a hairline rather than a fill, and the 6px panel resizer, which has no resting box at all |
 | Two-Tier Hairline | `--border-strong` if the edge identifies a control's hit area or carries a state, which answers WCAG 1.4.11's 3:1 floor; `--border` for everything structural. This is the one place the design brief was overruled: it draws every border at a value measuring ~1.2:1 (`tokens.css`, borders) |
 | Three Mirrors | these values also live in the Go locked page (`facilitator/internal/desktop/proxy.go`), the favicon (`ui/public/favicon.svg`) and the terminal palette (`images/desktop/assets/terminalrc` plus its xfconf twin), so a colour change is never a one-file change. Enforced by `ui/src/styles/mirrors.test.ts`, which was written after the xfconf twin was found to have silently lost its palette |
 
@@ -416,6 +416,7 @@ the rest owning their whole viewport.
 | About drawer | `min(480px, 92vw)` |
 | Confirm dialog | `min(440px, 90%)` |
 | Wide confirm dialog | `min(560px, 92%)` |
+| Exam tips sheet | `min(760px, 94%)` — a dialog that is READ rather than answered. 560px is the measure for a sentence and two buttons; the tips are pipe tables and long command lines, and at that width every one of them wraps |
 | Control dialog | `min(92vw, 520px)` |
 | Boot panel | `min(94vw, 560px)` |
 | Desktop-required card | `min(34rem, 100%)` |

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ It is built to stay with you across the whole path rather than one
 sitting: every graded attempt is kept, so you can see which domains are
 still weak and how far along the five certifications you are.
 
-Two banks ship today. **CKAD Mock Exam 01** is hands-on: 22 questions
-across all five curriculum domains, 120 minutes, 66% to pass, against a
-two-node Kubernetes 1.35 cluster. **KCNA Mock Exam** is multiple-choice
+Two banks ship today. **CKAD Mock Exam 01** is hands-on: 26 original
+questions across all five curriculum domains, 22 drawn per attempt and
+stratified to the curriculum weights every time, 120 minutes, 66% to
+pass, against a two-node Kubernetes 1.35 cluster. **KCNA Mock Exam** is multiple-choice
 in the real exam's shape: 97 original questions, 65 drawn per attempt
 and weighted to the post-November-2025 curriculum on every draw, 90
 minutes, 75% to pass, every question with a full explanation for
@@ -35,13 +36,14 @@ Requires Docker Desktop (or docker + compose v2), python3, and about
 
 ```bash
 ./sim doctor                 # optional preflight: RAM, disk, cgroups, tools
-./sim up                     # boots everything (first run: several minutes)
+./sim up                     # up in seconds; pick an exam in the browser
 open http://localhost:8080   # then never touch the CLI again
 ```
 
-The UI comes up before the cluster does, so `http://localhost:8080`
-shows the same boot progress the terminal does. `./sim doctor` catches
-the environmental problems that are cheaper to find before a boot than
+Nothing is built until you choose an exam: the app is up in seconds and
+picking a certification in the browser is what creates its cluster,
+narrating each phase as it goes. `./sim doctor` catches the
+environmental problems that are cheaper to find before a build than
 during one.
 
 Everything after `up` happens in the browser. See [docs/cli.md](docs/cli.md)
@@ -112,9 +114,11 @@ layout.
 
 ## The cluster you get
 
-A two-node kind cluster (one control plane, one worker) with **Calico**
-rather than kindnet, so NetworkPolicies are genuinely enforced and a
-policy question can be graded on behaviour. It also carries
+A kind cluster sized by the exam you picked — `spec.environment.nodes`
+in its bank decides how many nodes get built, so a bank that needs
+somewhere to drain to gets one — with **Calico** rather than kindnet, so
+NetworkPolicies are genuinely enforced and a policy question can be
+graded on behaviour. It also carries
 ingress-nginx, a local Helm repository, and a plain-HTTP registry for
 the image-building questions.
 

--- a/banks/ckad-mock-01/exam.yaml
+++ b/banks/ckad-mock-01/exam.yaml
@@ -14,6 +14,25 @@ spec:
   duration: 120m
   passingScore: 66
   kubernetesVersion: "1.35"
+  # One attempt asks 22 of the 26 questions below, drawn fresh and
+  # domain-stratified every time it starts. The number is the sitting, not
+  # the bank: the real CKAD is around twenty tasks in two hours, and
+  # putting four more into the same 120 minutes would have made this a
+  # harder exam rather than a fuller one.
+  #
+  # The variety is a bonus and a modest one — with a pool this close to
+  # the draw, three of the five domains are asked in full every time and
+  # only Design and Build (4 of 7) and Observability (3 of 4) rotate.
+  # Deepening a domain widens its rotation; nothing else has to change.
+  #
+  # The cost is real and worth knowing before copying this line into
+  # another bank: a pooled hands-on bank is NOT seeded at boot. The draw
+  # has not happened yet at boot time, so images/k8s-env/bootstrap.sh
+  # pre-pulls the images and stops, and the drawn questions' setup.sh
+  # scripts run when the attempt starts — POST /api/session/start answers
+  # 202 and the clock waits on the conductor's seed job. See
+  # docs/bank-spec.md.
+  examLength: 22
   # The published CKAD curriculum weights. These are not documentation:
   # a domain's share of this exam's points IS its weight here, and
   # tests/bank-weights.sh fails the build if any domain drifts more than
@@ -58,7 +77,7 @@ spec:
       title: NetworkPolicy lockdown
       instance: instance-2
       domain: Services and Networking
-      weight: 9
+      weight: 11
       docs:
         - label: Network policies
           url: https://kubernetes.io/docs/concepts/services-networking/network-policies/
@@ -104,7 +123,7 @@ spec:
       title: Route two Services with one Ingress
       instance: instance-2
       domain: Services and Networking
-      weight: 9
+      weight: 11
       docs:
         - label: Ingress
           url: https://kubernetes.io/docs/concepts/services-networking/ingress/
@@ -167,7 +186,7 @@ spec:
       title: Health checks
       instance: instance-2
       domain: Application Observability and Maintenance
-      weight: 9
+      weight: 8
       docs:
         - label: Liveness, readiness and startup probes
           url: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
@@ -175,12 +194,12 @@ spec:
       title: Find out why two workloads are broken
       instance: instance-1
       domain: Application Observability and Maintenance
-      weight: 9
+      weight: 8
     - id: q18
       title: Bring a manifest up to date
       instance: instance-2
       domain: Application Observability and Maintenance
-      weight: 9
+      weight: 8
       docs:
         - label: Deprecated API migration guide
           url: https://kubernetes.io/docs/reference/using-api/deprecation-guide/
@@ -188,7 +207,7 @@ spec:
       title: A Service that reaches nothing
       instance: instance-1
       domain: Services and Networking
-      weight: 9
+      weight: 11
       docs:
         - label: Services
           url: https://kubernetes.io/docs/concepts/services-networking/service/
@@ -196,7 +215,7 @@ spec:
       title: Expose a Deployment on a node port
       instance: instance-2
       domain: Services and Networking
-      weight: 9
+      weight: 11
       docs:
         - label: Service types
           url: https://kubernetes.io/docs/concepts/services-networking/service/
@@ -210,3 +229,43 @@ spec:
       instance: instance-2
       domain: Application Design and Build
       weight: 6
+    - id: q23
+      title: Blue/green cutover
+      instance: instance-1
+      domain: Application Deployment
+      weight: 9
+      docs:
+        - label: Services
+          url: https://kubernetes.io/docs/concepts/services-networking/service/
+        - label: Labels and selectors
+          url: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+    - id: q24
+      title: Replace a bare Pod with a hardened Deployment
+      instance: instance-2
+      domain: Application Environment, Configuration and Security
+      weight: 9
+      docs:
+        - label: Security contexts
+          url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+        - label: Deployments
+          url: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+    - id: q25
+      title: Debug a Pod you cannot get into
+      instance: instance-1
+      domain: Application Observability and Maintenance
+      weight: 8
+      docs:
+        - label: Ephemeral containers
+          url: https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/
+        - label: Debug running Pods
+          url: https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/
+    - id: q26
+      title: Pull policy and shutdown budget
+      instance: instance-2
+      domain: Application Design and Build
+      weight: 6
+      docs:
+        - label: Images and pull policy
+          url: https://kubernetes.io/docs/concepts/containers/images/
+        - label: Pod lifecycle
+          url: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/

--- a/banks/ckad-mock-01/q03/validate.d/20_ingress.sh
+++ b/banks/ckad-mock-01/q03/validate.d/20_ingress.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 2
+# points: 3
 # desc: single ingress rule: from role=frontend pods, TCP 80 only
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q03/validate.d/40_enforced.sh
+++ b/banks/ckad-mock-01/q03/validate.d/40_enforced.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 4
+# points: 5
 # desc: the policy is actually enforced — frontend reaches api, metrics does not
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q08/validate.d/10_ingress.sh
+++ b/banks/ckad-mock-01/q08/validate.d/10_ingress.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 4
+# points: 5
 # desc: Ingress helios-routes uses class nginx, host helios.sim.local, two Prefix paths
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q08/validate.d/20_routes.sh
+++ b/banks/ckad-mock-01/q08/validate.d/20_routes.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 5
+# points: 6
 # desc: the controller really routes / to storefront and /checkout to checkout
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q16/validate.d/10_probes.sh
+++ b/banks/ckad-mock-01/q16/validate.d/10_probes.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 5
+# points: 4
 # desc: startup, readiness and liveness probes with the requested settings
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q17/validate.d/30_mailer.sh
+++ b/banks/ckad-mock-01/q17/validate.d/30_mailer.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 4
+# points: 3
 # desc: the unpullable image was recorded and the mailer Deployment repaired
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q18/validate.d/30_ingress.sh
+++ b/banks/ckad-mock-01/q18/validate.d/30_ingress.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 3
+# points: 2
 # desc: the Ingress was migrated to the v1 backend schema, host and rule intact
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q19/validate.d/10_service.sh
+++ b/banks/ckad-mock-01/q19/validate.d/10_service.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 3
+# points: 4
 # desc: the Service selects the Pods and targets the port they listen on
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q19/validate.d/20_reachable.sh
+++ b/banks/ckad-mock-01/q19/validate.d/20_reachable.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 5
+# points: 6
 # desc: the Service has both endpoints and really answers from inside the cluster
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q20/validate.d/10_nodeport.sh
+++ b/banks/ckad-mock-01/q20/validate.d/10_nodeport.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 3
+# points: 4
 # desc: status-page is a NodePort Service on port 80 with node port 30081
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q20/validate.d/20_answers.sh
+++ b/banks/ckad-mock-01/q20/validate.d/20_answers.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 5
+# points: 6
 # desc: the node port really answers, from a node address inside the cluster
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q23/expected/service.yaml
+++ b/banks/ckad-mock-01/q23/expected/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: checkout
+  namespace: lacerta
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: checkout
+    release: green
+  type: ClusterIP

--- a/banks/ckad-mock-01/q23/hints.md
+++ b/banks/ckad-mock-01/q23/hints.md
@@ -1,0 +1,25 @@
+## Hint 1
+
+Nothing about the two Deployments changes. Ask what a Service actually
+uses to decide where a request goes — it is not the Deployment's name,
+and it is not the Pod's name either.
+
+Compare the labels on the two sets of Pods:
+
+```bash
+k -n lacerta get pods --show-labels
+```
+
+## Hint 2
+
+`spec.selector` on the Service is the whole switch. `kubectl edit`,
+`kubectl patch --type=merge` or a re-`apply` all move it.
+
+One trap: a merge patch adds keys to a map rather than replacing it, so
+patching in `release: green` on its own leaves `release: blue` behind
+only if you spell it as a different key — check what you ended up with
+before you trust it:
+
+```bash
+k -n lacerta get svc checkout -o jsonpath='{.spec.selector}'
+```

--- a/banks/ckad-mock-01/q23/question.md
+++ b/banks/ckad-mock-01/q23/question.md
@@ -1,0 +1,20 @@
+Namespace `lacerta` runs two releases of the checkout service side by
+side: Deployment `checkout-blue` and Deployment `checkout-green`. Both
+are healthy. Service `checkout` currently sends every request to the blue
+release.
+
+Green has passed verification. Cut the live traffic over to it:
+
+1. Service `checkout` must send requests to the green release's Pods and
+   to no others.
+2. Leave `checkout-blue` running and at its current replica count. It is
+   the rollback, and it stays warm until green has been watched under
+   real traffic.
+3. Do not delete or replace the Service, and leave it publishing port
+   `80`.
+
+Deployment `checkout-client` is in the Namespace to make requests from:
+
+```bash
+k -n lacerta exec deploy/checkout-client -- wget -q -O - http://checkout
+```

--- a/banks/ckad-mock-01/q23/setup.sh
+++ b/banks/ckad-mock-01/q23/setup.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl create ns lacerta --dry-run=client -o yaml | kubectl apply -f -
+
+# Two releases of one service, both live and both healthy. What makes the
+# cutover observable is that each serves a different body: nothing about
+# a blue/green switch is visible in `kubectl get pods`, and a question
+# that could only be graded on the Service's YAML would be a question
+# about YAML rather than about releases.
+#
+# checkout-client exists so the candidate — and the behavioural check —
+# have somewhere to make a request FROM that is neither release. Curling
+# the Service from inside one of the two Deployments would work, but it
+# reaches the Service that may now point back at the Pod making the call,
+# and a hairpin is not what a client does.
+kubectl -n lacerta apply -f - <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: checkout-blue-page
+  namespace: lacerta
+data:
+  index.html: |
+    checkout release blue
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: checkout-green-page
+  namespace: lacerta
+data:
+  index.html: |
+    checkout release green
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout-blue
+  namespace: lacerta
+spec:
+  replicas: 2
+  selector:
+    matchLabels: {app: checkout, release: blue}
+  template:
+    metadata:
+      labels: {app: checkout, release: blue}
+    spec:
+      containers:
+        - name: web
+          image: nginx:1.27-alpine
+          ports: [{containerPort: 80}]
+          volumeMounts:
+            - name: page
+              mountPath: /usr/share/nginx/html
+      volumes:
+        - name: page
+          configMap: {name: checkout-blue-page}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout-green
+  namespace: lacerta
+spec:
+  replicas: 2
+  selector:
+    matchLabels: {app: checkout, release: green}
+  template:
+    metadata:
+      labels: {app: checkout, release: green}
+    spec:
+      containers:
+        - name: web
+          image: nginx:1.29-alpine
+          ports: [{containerPort: 80}]
+          volumeMounts:
+            - name: page
+              mountPath: /usr/share/nginx/html
+      volumes:
+        - name: page
+          configMap: {name: checkout-green-page}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: checkout
+  namespace: lacerta
+spec:
+  selector: {app: checkout, release: blue}
+  ports: [{port: 80, targetPort: 80, protocol: TCP}]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout-client
+  namespace: lacerta
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: checkout-client}
+  template:
+    metadata:
+      labels: {app: checkout-client}
+    spec:
+      containers:
+        - name: client
+          image: busybox:1.37
+          command: ["sh", "-c", "while true; do sleep 30; done"]
+EOF
+
+kubectl -n lacerta rollout status deploy/checkout-blue --timeout=180s
+kubectl -n lacerta rollout status deploy/checkout-green --timeout=180s
+kubectl -n lacerta rollout status deploy/checkout-client --timeout=180s

--- a/banks/ckad-mock-01/q23/solution.md
+++ b/banks/ckad-mock-01/q23/solution.md
@@ -1,0 +1,86 @@
+# Solution 23
+
+Both releases are already running. The only thing that decides which one
+receives traffic is the Service's label selector, so the whole cutover is
+one field.
+
+```bash
+k -n lacerta get pods --show-labels
+# checkout-blue-...   app=checkout,release=blue
+# checkout-green-...  app=checkout,release=green
+```
+
+Move the selector onto green:
+
+```bash
+k -n lacerta patch svc checkout --type=merge \
+  -p '{"spec":{"selector":{"app":"checkout","release":"green"}}}'
+```
+
+Confirm it from a client, not from the YAML:
+
+```bash
+k -n lacerta exec deploy/checkout-client -- wget -q -O - http://checkout
+# checkout release green
+```
+
+## Why the selector and nothing else
+
+A Service does not know that `checkout-blue` and `checkout-green` exist.
+It holds a set of labels, the EndpointSlice controller keeps a list of
+every Pod in the Namespace carrying them, and kube-proxy programmes the
+node's forwarding rules from that list. Change the labels and the list is
+rebuilt within a second or so — no Pod restarts, no image is pulled, and
+no connection that is already open is disturbed.
+
+That is the entire appeal of blue/green over a rolling update: the new
+version is already built, already scheduled, already warm and already
+answering health checks before a single user reaches it. The switch is
+atomic from the caller's point of view, and so is the rollback.
+
+## The merge-patch trap
+
+`--type=merge` merges maps key by key. This does **not** do what it looks
+like:
+
+```bash
+# WRONG: leaves release=blue in place alongside app=checkout
+k -n lacerta patch svc checkout --type=merge -p '{"spec":{"selector":{"app":"checkout"}}}'
+```
+
+and this quietly selects *both* releases:
+
+```bash
+# WRONG: a selector matching both means traffic is split across versions
+selector:
+  app: checkout
+```
+
+A selector that matches too much does not error. It load-balances across
+two versions of your application, which is the failure you find out about
+from support tickets rather than from `kubectl`. Read the selector back
+after patching.
+
+## Rolling back
+
+Because blue was left running at full strength, the rollback is the same
+command with one word changed:
+
+```bash
+k -n lacerta patch svc checkout --type=merge \
+  -p '{"spec":{"selector":{"app":"checkout","release":"blue"}}}'
+```
+
+This is why the question forbids scaling blue down. `replicas: 0` looks
+tidy and costs nothing until you need it, at which point the rollback has
+to schedule Pods, pull an image and wait for readiness — the minutes you
+adopted blue/green to avoid.
+
+## Where canary differs
+
+A canary shares the same mechanism from the other end: instead of moving
+the selector, you give both Deployments the *same* selectable label and
+let the replica counts decide the split — nine blue Pods and one green
+Pod sends roughly a tenth of the traffic to green. It is the same
+Service, the same EndpointSlice and the same kube-proxy; only the
+proportion is different.

--- a/banks/ckad-mock-01/q23/validate.d/10_selector.sh
+++ b/banks/ckad-mock-01/q23/validate.d/10_selector.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# points: 3
+# desc: the Service selects exactly the green release's Pods and still publishes port 80
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+evidence() {
+  show_actual yaml "$(kubectl -n lacerta get svc checkout -o yaml 2>/dev/null | k8s_clean)"
+  show_expected yaml "/banks/${BANK:-ckad-mock-01}/q23/expected/service.yaml"
+  show_why "$1"
+}
+
+sel=$(kubectl -n lacerta get svc checkout -o json 2>/dev/null \
+  | jq -r '.spec.selector // {} | to_entries | map("\(.key)=\(.value)") | sort | join(",")')
+[ -n "$sel" ] || {
+  echo "Service checkout has no selector"
+  evidence "A Service with no spec.selector matches nothing and is never given endpoints by the controller — the cutover has to move the selector, not remove it. If the Service is gone entirely, recreate it rather than routing around it: the question is about the switch, and the Service IS the switch."
+  exit 1
+}
+
+# Graded on which Pods the selector REACHES, not on how it is spelled.
+# `release=green` alone and `app=checkout,release=green` select exactly
+# the same two Pods here, and both are correct answers; a check that
+# insisted on one of them would fail correct work.
+pods_for() {
+  kubectl -n lacerta get pods -l "$1" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | sort
+}
+matched=$(pods_for "$sel")
+green=$(pods_for "app=checkout,release=green")
+
+[ -n "$green" ] || {
+  echo "the green release has no Pods running, so nothing can be cut over to it"
+  show_why "checkout-green is part of the pre-seeded state rather than part of the answer. If its Pods are gone, restore the Deployment — 'kubectl -n lacerta rollout status deploy/checkout-green' says what happened to them."
+  exit 1
+}
+
+same_set "$matched" "$green" || {
+  echo "selector '$sel' matches $(printf '%s\n' "$matched" | grep -c . || true) Pod(s), want exactly the $(printf '%s\n' "$green" | grep -c .) green one(s)"
+  show_actual text "$(printf 'selector: %s\nmatches:\n%s\n\ngreen release Pods:\n%s\n' "$sel" "$matched" "$green")"
+  show_why "A Service routes to every Pod its labels match and has no other opinion about them, so 'switch the release' means 'change which labels the selector names'. Matching both releases at once is the failure worth knowing: it does not error, it silently load-balances across the two versions."
+  exit 1
+}
+
+port=$(kubectl -n lacerta get svc checkout \
+  -o jsonpath='{.spec.ports[?(@.port==80)].port}' 2>/dev/null)
+[ "$port" = "80" ] || {
+  echo "the Service no longer publishes port 80"
+  evidence "Clients hold the Service's name and port, not its selector, so a cutover that changes the published port has broken every caller in exchange for the release it was meant to deliver invisibly."
+  exit 1
+}
+
+echo "selector cut over to green"

--- a/banks/ckad-mock-01/q23/validate.d/20_serves-green.sh
+++ b/banks/ckad-mock-01/q23/validate.d/20_serves-green.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# points: 5
+# desc: a request through the Service really comes back from the green release
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+# The behavioural half, and the one worth the most points: a selector
+# that looks right in YAML and a Service that actually delivers green are
+# different claims, and only the second one is the release.
+#
+# The request is made from checkout-client, which is neither release, so
+# it crosses DNS, the Service, kube-proxy and the EndpointSlice exactly
+# as a caller would. Retried because a selector edit and a reprogrammed
+# kube-proxy are not the same instant — the EndpointSlice updates first —
+# and a single attempt straight after the answer loses that race often
+# enough to fail correct work.
+body=""
+for _ in 1 2 3 4 5; do
+  body=$(kubectl -n lacerta exec deploy/checkout-client -- \
+    wget -q -T 4 -O - http://checkout.lacerta.svc:80/ 2>/dev/null)
+  case "$body" in *green*) break ;; esac
+  sleep 2
+done
+
+case "$body" in
+  *green*) echo "the Service serves the green release"; exit 0 ;;
+esac
+
+if [ -z "$body" ]; then
+  echo "no answer came back through the Service"
+  show_actual text "$(kubectl -n lacerta get endpointslices -l kubernetes.io/service-name=checkout \
+    -o jsonpath='{range .items[*]}{.metadata.name}{": "}{.endpoints[*].addresses[0]}{"\n"}{end}' 2>/dev/null)"  # lint: allow-index (one Pod IP per endpoint is all this pane needs to show)
+  show_why "A Service with no endpoints refuses the connection rather than routing it. The EndpointSlice above lists what the selector actually found; an empty one means the labels named in the selector are on no Pod in this Namespace."
+  exit 1
+fi
+
+echo "the Service answered '$(printf '%s' "$body" | tr -d '\n')', which is not the green release"
+show_actual text "$body"
+show_why "The bodies are how the two releases are told apart, and this one came from blue. A selector that still matches blue's Pods — or matches both — sends traffic there whatever the intent was; the Service is the only thing that decides, and it decides by label."
+exit 1

--- a/banks/ckad-mock-01/q23/validate.d/30_blue-standby.sh
+++ b/banks/ckad-mock-01/q23/validate.d/30_blue-standby.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# points: 1
+# desc: the cutover left blue standing at full strength as the rollback
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+# Both halves, and the second one is not decoration. "blue is still
+# running" is true before the candidate touches anything, so on its own
+# this would be a point every fresh environment scores — which is exactly
+# what the smoke suite's "a fresh environment scores 0" assertion exists
+# to catch. What is being graded is the CUTOVER having been made without
+# dismantling the rollback, and that is only a state a correct answer
+# reaches.
+want=$(kubectl -n lacerta get deploy checkout-blue -o jsonpath='{.spec.replicas}' 2>/dev/null)
+[ -n "$want" ] || {
+  echo "Deployment checkout-blue is gone"
+  show_why "The point of blue/green over a rolling update is that the previous release is still standing: rollback is one selector edit, with no image to re-pull and no Pods to reschedule. Deleting blue after the cutover throws that away and leaves an ordinary, slower rollback."
+  exit 1
+}
+
+ready=$(kubectl -n lacerta get deploy checkout-blue -o jsonpath='{.status.readyReplicas}' 2>/dev/null)
+[ -n "$ready" ] || ready=0
+[ "$want" -ge 2 ] && [ "$ready" = "$want" ] || {
+  echo "checkout-blue has ${ready}/${want} replicas ready, want 2/2"
+  show_actual text "$(kubectl -n lacerta get deploy checkout-blue -o wide 2>/dev/null)"
+  show_why "Scaling blue to zero costs the same as deleting it: the rollback is no longer instant, because the Pods have to be scheduled and started again before the selector can be moved back."
+  exit 1
+}
+
+# Standby means "not receiving traffic". While the Service still matches
+# blue's Pods, blue is the live release and there is no rollback to be
+# ready for.
+pods_for() {
+  kubectl -n lacerta get pods -l "$1" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | sort
+}
+sel=$(kubectl -n lacerta get svc checkout -o json 2>/dev/null \
+  | jq -r '.spec.selector // {} | to_entries | map("\(.key)=\(.value)") | sort | join(",")')
+blue=$(pods_for "app=checkout,release=blue")
+matched=""
+[ -n "$sel" ] && matched=$(pods_for "$sel")
+
+for pod in $blue; do
+  case "
+$matched
+" in
+    *"
+$pod
+"*)
+      echo "the Service still sends traffic to the blue release, so nothing is on standby"
+      show_actual text "$(printf 'selector: %s\nmatches:\n%s\n\nblue release Pods:\n%s\n' "$sel" "$matched" "$blue")"
+      show_why "Blue is the rollback only once green is the one being served. Until the selector moves, blue IS the release — and a selector that matches both is worse than either, because it silently splits live traffic across two versions."
+      exit 1 ;;
+  esac
+done
+
+echo "blue is warm and on standby, ready to roll back to"

--- a/banks/ckad-mock-01/q24/expected/securitycontext.json
+++ b/banks/ckad-mock-01/q24/expected/securitycontext.json
@@ -1,0 +1,16 @@
+{
+  "pod": {},
+  "container": {
+    "allowPrivilegeEscalation": false,
+    "capabilities": {
+      "drop": [
+        "ALL"
+      ]
+    },
+    "runAsNonRoot": true,
+    "runAsUser": 1000,
+    "seccompProfile": {
+      "type": "RuntimeDefault"
+    }
+  }
+}

--- a/banks/ckad-mock-01/q24/hints.md
+++ b/banks/ckad-mock-01/q24/hints.md
@@ -1,0 +1,24 @@
+## Hint 1
+
+You do not have to write the Pod spec again. The running Pod already has
+one, and a Deployment's `spec.template.spec` is exactly that spec one
+level down — export it and rebuild around it rather than retyping.
+
+For the hardening, note that the five requirements are not all fields of
+the same object. Two of them exist in only one of the two places
+`securityContext` can appear.
+
+## Hint 2
+
+`kubectl create deploy --image` gets you a skeleton fast, but it will not
+give you the container name or the command. `kubectl -n auriga get pod
+report-runner -o json` gives you both, and `--dry-run=client -o yaml`
+turns the skeleton into something you can paste them into.
+
+`runAsUser`, `runAsNonRoot` and `seccompProfile` are legal on either
+securityContext. `allowPrivilegeEscalation` and `capabilities` are
+container-level only.
+
+The seccomp field is a small object with a `type`, not a string.
+`kubectl explain pod.spec.containers.securityContext.seccompProfile`
+spells it out.

--- a/banks/ckad-mock-01/q24/question.md
+++ b/banks/ckad-mock-01/q24/question.md
@@ -1,0 +1,19 @@
+Namespace `auriga` runs `report-runner` as a bare Pod. Nothing owns it,
+so nothing replaces it when its node is drained, and it can be neither
+rolled out nor rolled back. It also runs as root with every default
+privilege the runtime hands out.
+
+Replace it with a Deployment, hardened:
+
+1. Create Deployment `report-runner` in Namespace `auriga` with `3`
+   replicas. Its Pods carry the label `app=report-runner`, and its single
+   container keeps the name `report` and the image `busybox:1.37`.
+2. That container must run as user ID `1000`; the kubelet must refuse to
+   start it if it would run as root; it must not be able to gain more
+   privileges than it starts with; it must drop **all** Linux
+   capabilities; and it must run under the container runtime's default
+   seccomp profile.
+3. Delete the original bare Pod once the Deployment's replicas are
+   running.
+
+All three replicas must reach `Ready`.

--- a/banks/ckad-mock-01/q24/setup.sh
+++ b/banks/ckad-mock-01/q24/setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl create ns auriga --dry-run=client -o yaml | kubectl apply -f -
+
+# A bare Pod, deliberately: no ownerReferences, no ReplicaSet, nothing
+# that would put it back. It is also deliberately unhardened, so the
+# securityContext is something the candidate adds rather than something
+# they copy across.
+#
+# Re-applied on every reset and bank switch, which is what restores it
+# after an attempt in which the candidate did the last step of the
+# question and deleted it.
+kubectl -n auriga apply -f - <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: report-runner
+  namespace: auriga
+  labels:
+    app: report-runner
+spec:
+  containers:
+    - name: report
+      image: busybox:1.37
+      command: ["sh", "-c", "while true; do echo 'report-runner: nothing to do'; sleep 15; done"]
+EOF
+
+kubectl -n auriga wait --for=condition=Ready pod/report-runner --timeout=180s

--- a/banks/ckad-mock-01/q24/solution.md
+++ b/banks/ckad-mock-01/q24/solution.md
@@ -1,0 +1,101 @@
+# Solution 24
+
+Read the Pod you are replacing before writing anything — the container
+name and command are part of the answer and are already on the cluster:
+
+```bash
+k -n auriga get pod report-runner -o json | jq '.spec.containers'
+```
+
+Then write the Deployment. `spec.template.spec` is a Pod spec, so
+everything you just read goes straight into it:
+
+```bash
+k -n auriga apply -f - <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: report-runner
+  namespace: auriga
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: report-runner
+  template:
+    metadata:
+      labels:
+        app: report-runner
+    spec:
+      containers:
+        - name: report
+          image: busybox:1.37
+          command: ["sh", "-c", "while true; do echo 'report-runner: nothing to do'; sleep 15; done"]
+          securityContext:
+            runAsUser: 1000
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+EOF
+
+k -n auriga rollout status deploy/report-runner --timeout=180s
+k -n auriga delete pod report-runner
+```
+
+Delete the bare Pod **last**. It is the only copy of the spec you are
+working from, and until the Deployment's replicas are Ready it is also
+the only thing running the workload.
+
+## Why a Deployment rather than a Pod
+
+A bare Pod has no controller. Nothing recreates it when its node is
+drained, cordoned or lost; `kubectl rollout` has nothing to act on, so
+there is no versioned history, no rollback and no way to change the image
+without deleting and recreating by hand. A Deployment owns a ReplicaSet,
+the ReplicaSet owns the Pods, and every one of those problems belongs to
+the controller instead of to you.
+
+The selector is the one part that is not simply copied down from the Pod.
+`spec.selector.matchLabels` is how the ReplicaSet finds its Pods and
+`spec.template.metadata.labels` is what goes on them; if they disagree
+the API server rejects the Deployment outright, which is a good error to
+have met once.
+
+## The five settings, and where each may live
+
+| Field | Pod securityContext | Container securityContext |
+|---|---|---|
+| `runAsUser`, `runAsNonRoot` | yes | yes |
+| `seccompProfile` | yes | yes |
+| `allowPrivilegeEscalation` | **no** | yes |
+| `capabilities` | **no** | yes |
+
+Putting the last two at Pod level is rejected by the API, so you find out
+straight away. Putting the first three at Pod level is fine and often
+better: they then apply to every container, including ones added later.
+
+`runAsUser: 1000` and `runAsNonRoot: true` are not the same instruction.
+The first says which UID to use. The second refuses to start the
+container at all if it would end up as UID 0 — including the case where
+someone rebuilds the image tomorrow with `USER root` and nobody notices.
+
+## seccomp, and how it differs from capabilities
+
+Capabilities split root's powers into pieces and decide which of them a
+privileged system call may use. seccomp works one level out: it decides
+which system calls the kernel will accept from the process **at all**.
+
+`RuntimeDefault` asks for the container runtime's own curated profile —
+containerd and CRI-O both ship one that blocks a few dozen calls no
+normal application makes. Without the field the Pod runs `Unconfined`,
+with the whole system-call surface available. It is the cheapest of the
+five settings to adopt and the one most often left out, which is why Pod
+Security's `baseline` and `restricted` levels both look for it.
+
+```bash
+k -n auriga get deploy report-runner \
+  -o jsonpath='{.spec.template.spec.containers[0].securityContext}' | jq .
+```

--- a/banks/ckad-mock-01/q24/validate.d/10_deployment.sh
+++ b/banks/ckad-mock-01/q24/validate.d/10_deployment.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# points: 3
+# desc: Deployment report-runner runs 3 ready replicas of the same container, labelled app=report-runner
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+evidence() {
+  show_actual json "$(kubectl -n auriga get deploy report-runner -o json 2>/dev/null \
+    | jq '{replicas: .spec.replicas, readyReplicas: .status.readyReplicas,
+           labels: .spec.template.metadata.labels,
+           containers: [.spec.template.spec.containers[] | {name, image}]}')"
+  show_why "$1"
+}
+
+want=$(kubectl -n auriga get deploy report-runner -o jsonpath='{.spec.replicas}' 2>/dev/null)
+[ -n "$want" ] || {
+  echo "there is no Deployment report-runner in auriga"
+  show_why "A Deployment is the workload resource for a stateless application that should survive its Pods: it owns a ReplicaSet, the ReplicaSet owns the Pods, and every one of them is recreated when it is lost. 'kubectl create deployment' or a manifest built from the Pod's own spec both get there."
+  exit 1
+}
+[ "$want" = "3" ] || {
+  echo "spec.replicas is '$want', want 3"
+  evidence "replicas is the desired count the ReplicaSet controller reconciles towards. It is the only thing that decides how many Pods exist; scaling is changing this number and nothing else."
+  exit 1
+}
+
+names=$(kubectl -n auriga get deploy report-runner \
+  -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"\n"}{end}' 2>/dev/null)
+same_set "$names" "report" || {
+  echo "the Pod template's containers are '$(printf '%s' "$names" | tr '\n' ' ')', want exactly one named report"
+  evidence "The Deployment's spec.template is a Pod spec — the same fields the bare Pod already had, one level down. Copying it across is the conversion; adding or renaming containers is not part of it."
+  exit 1
+}
+
+img=$(kubectl -n auriga get deploy report-runner \
+  -o jsonpath='{.spec.template.spec.containers[?(@.name=="report")].image}' 2>/dev/null)
+[ "$img" = "busybox:1.37" ] || {
+  echo "the report container runs '$img', want busybox:1.37"
+  evidence "The workload is meant to be the same application under new management. A different image is a different application, however well the Deployment around it is written."
+  exit 1
+}
+
+app=$(kubectl -n auriga get deploy report-runner \
+  -o jsonpath='{.spec.template.metadata.labels.app}' 2>/dev/null)
+[ "$app" = "report-runner" ] || {
+  echo "the Pod template's app label is '$app', want report-runner"
+  evidence "spec.template.metadata.labels is what goes ON the Pods, and spec.selector.matchLabels is what the ReplicaSet uses to find them. They have to agree — the API server rejects a Deployment whose selector matches nothing in its own template — and the label is also the handle anything else in the Namespace would use to reach these Pods."
+  exit 1
+}
+
+ready=$(kubectl -n auriga get deploy report-runner -o jsonpath='{.status.readyReplicas}' 2>/dev/null)
+[ -n "$ready" ] || ready=0
+[ "$ready" = "3" ] || {
+  echo "${ready}/3 replicas are ready"
+  show_actual text "$(kubectl -n auriga get pods -l app=report-runner 2>/dev/null)"
+  show_why "A Deployment that is declared but not running has not replaced anything. When the count is short, the Pods themselves say why — 'kubectl -n auriga describe pod' on one of them names the constraint it violated, and a securityContext the image cannot satisfy is the usual reason here."
+  exit 1
+}
+
+echo "deployment ok"

--- a/banks/ckad-mock-01/q24/validate.d/20_hardened.sh
+++ b/banks/ckad-mock-01/q24/validate.d/20_hardened.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# points: 4
+# desc: the report container runs as uid 1000, non-root, no privilege escalation, no capabilities, RuntimeDefault seccomp
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+tmpl='.spec.template.spec'
+evidence() {
+  show_actual json "$(kubectl -n auriga get deploy report-runner -o json 2>/dev/null \
+    | jq "{pod: ${tmpl}.securityContext,
+           container: (${tmpl}.containers[] | select(.name == \"report\") | .securityContext)}")"
+  show_expected json "/banks/${BANK:-ckad-mock-01}/q24/expected/securitycontext.json"
+  show_why "$1"
+}
+
+# Three of the five settings are legal on the Pod securityContext as well
+# as on the container's, where they apply to every container unless one
+# overrides them. Both placements are correct answers, so both panes are
+# read — an empty result means the field was set in neither.
+get() {
+  local field=$1 v
+  v=$(kubectl -n auriga get deploy report-runner \
+    -o jsonpath="{${tmpl}.containers[?(@.name==\"report\")].securityContext.${field}}" 2>/dev/null)
+  [ -n "$v" ] || v=$(kubectl -n auriga get deploy report-runner \
+    -o jsonpath="{${tmpl}.securityContext.${field}}" 2>/dev/null)
+  printf '%s' "$v"
+}
+# The other two exist only on the container, so there is one place to look.
+container_only() {
+  kubectl -n auriga get deploy report-runner \
+    -o jsonpath="{${tmpl}.containers[?(@.name==\"report\")].securityContext.$1}" 2>/dev/null
+}
+
+[ "$(get runAsUser)" = "1000" ] || {
+  echo "runAsUser='$(get runAsUser)', want 1000"
+  evidence "runAsUser is the UID the container's process runs as, overriding whatever USER the image was built with. busybox declares none, so without this the process is root — which is the state the question is asking to leave. Either placement is a correct answer and this check reads both, so an EXPECTED pane showing an empty pod block records where the reference solution happened to put it — not where it has to go."
+  exit 1
+}
+[ "$(get runAsNonRoot)" = "true" ] || {
+  echo "runAsNonRoot='$(get runAsNonRoot)', want true"
+  evidence "runAsUser TELLS the kubelet which UID to use; runAsNonRoot: true makes it REFUSE to start a container that would end up as UID 0 anyway. Intent and enforcement — an image rebuilt tomorrow with USER root is caught by the second and not by the first. Either placement is a correct answer and this check reads both, so an EXPECTED pane showing an empty pod block records where the reference solution happened to put it — not where it has to go."
+  exit 1
+}
+[ "$(container_only allowPrivilegeEscalation)" = "false" ] || {
+  echo "allowPrivilegeEscalation='$(container_only allowPrivilegeEscalation)', want false"
+  evidence "allowPrivilegeEscalation controls the no_new_privs bit: with it false, no setuid binary inside the container can hand the process more privilege than it started with. It is a container-level field only — the API rejects it on the Pod securityContext, which is how you find out immediately."
+  exit 1
+}
+drop=$(kubectl -n auriga get deploy report-runner -o json 2>/dev/null \
+  | jq -r "${tmpl}.containers[] | select(.name == \"report\") | .securityContext.capabilities.drop // [] | join(\",\")")
+case ",${drop}," in
+  *,ALL,*) ;;
+  *)
+    echo "capabilities dropped are '${drop}', want ALL"
+    evidence "A container starts with a default set of Linux capabilities it almost never uses. Dropping ALL removes the lot, and anything genuinely needed is added back one name at a time under capabilities.add — which is the point: an explicit short list rather than an implicit long one."
+    exit 1 ;;
+esac
+[ "$(get seccompProfile.type)" = "RuntimeDefault" ] || {
+  echo "seccompProfile.type='$(get seccompProfile.type)', want RuntimeDefault"
+  evidence "seccomp filters which SYSTEM CALLS the kernel will accept from the container, which is a different boundary from capabilities: capabilities decide what a privileged call may do, seccomp decides whether the call is allowed at all. RuntimeDefault asks for the container runtime's own profile rather than an Unconfined one, and is the setting Pod Security's baseline and restricted levels both expect. Either placement is a correct answer and this check reads both, so an EXPECTED pane showing an empty pod block records where the reference solution happened to put it — not where it has to go."
+  exit 1
+}
+
+echo "hardening ok"

--- a/banks/ckad-mock-01/q24/validate.d/30_pod-gone.sh
+++ b/banks/ckad-mock-01/q24/validate.d/30_pod-gone.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: the bare Pod was replaced by the Deployment and then deleted
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+# The replacement is checked FIRST, and not as a courtesy to 10_deployment
+# — which grades the Deployment on its own merits and is unaffected by
+# this. It is what stops the check being vacuous.
+#
+# "There is no Pod called report-runner" is true of a cluster where this
+# question was never set up at all, so on its own this scored 2 points on
+# an untouched environment. That made it the one check in the bank a
+# freshly reset cluster could earn anything from, which is exactly what
+# the smoke suite's "a reset environment scores 0" assertion exists to
+# catch, and it caught it.
+#
+# Reading it as grading rather than as a bug fix: deleting the only
+# running copy of a workload with nothing standing in for it is not a
+# partially correct answer to "replace this Pod with a Deployment". It is
+# the one outcome worse than leaving the Pod alone.
+[ -n "$(kubectl -n auriga get deploy report-runner -o jsonpath='{.metadata.name}' 2>/dev/null)" ] || {
+  echo "there is no Deployment report-runner, so nothing has replaced the bare Pod"
+  show_actual text "$(kubectl -n auriga get all 2>/dev/null)"
+  show_why "This step is the last one for a reason: the bare Pod is the only copy of the workload until the Deployment's replicas are Running. Delete it first and there is an outage between the two; delete it INSTEAD and there is no workload at all."
+  exit 1
+}
+
+# The Deployment's Pods are named report-runner-<replicaset>-<suffix>, so
+# a Pod called exactly report-runner is the bare one and nothing else.
+owner=$(kubectl -n auriga get pod report-runner \
+  -o jsonpath='{.metadata.ownerReferences[*].kind}' 2>/dev/null)
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  echo "the bare Pod is gone"
+  exit 0
+fi
+
+echo "Pod report-runner is still there${owner:+ (owned by ${owner})}"
+show_actual text "$(kubectl -n auriga get pods -o wide 2>/dev/null)"
+show_why "Leaving it running means the old, unhardened, unowned copy is still serving alongside the three new ones — four Pods where the question asked for three, and the one that cannot be rolled back is the one still holding root. Nothing deletes it for you: a Deployment adopts existing Pods only when they carry its selector AND have no controller of their own, and even then it would not have hardened this one."
+exit 1

--- a/banks/ckad-mock-01/q25/hints.md
+++ b/banks/ckad-mock-01/q25/hints.md
@@ -1,0 +1,23 @@
+## Hint 1
+
+`kubectl exec` runs a command in a container that already exists, and
+this Pod's only container has no tools worth running. There is a
+different verb for adding one to a live Pod — `kubectl -h` lists it, and
+`kubectl debug -h` is worth reading in full because almost every flag it
+takes matters to this question.
+
+The two files can then be produced with an ordinary `exec` into the
+container you added.
+
+## Hint 2
+
+`--image` chooses what the new container runs, `-c` names it, and a third
+flag decides whether it can see another container's processes at all.
+Without that flag `ps` shows one line: itself.
+
+An ephemeral container whose command exits is finished, and you cannot
+`exec` into a container that is not running — so give it something that
+keeps running, and do the fetching from a second command.
+
+Redirect on the instance rather than inside the container: the
+debugging container has no `/opt/course`.

--- a/banks/ckad-mock-01/q25/question.md
+++ b/banks/ckad-mock-01/q25/question.md
@@ -1,0 +1,17 @@
+Namespace `perseus` runs Pod `ledger-api`. Its `api` container serves a
+health endpoint at `http://127.0.0.1:8080/healthz`, bound to loopback —
+there is no Service, and there is nothing a Service could reach.
+
+Diagnose it from inside the Pod, without restarting it and without
+changing the container it already runs:
+
+1. Attach an ephemeral debugging container to Pod `ledger-api`, named
+   `debugger`, running `busybox:1.37`, sharing the `api` container's
+   process namespace.
+2. From inside that container, fetch the health endpoint and save the
+   response body to `/opt/course/25/healthz`.
+3. Save the command line of the `api` container's main process — as the
+   debugging container sees it — to `/opt/course/25/api-process`.
+
+Pod `ledger-api` must still be the same Pod when you are done: one
+container named `api`, never deleted and never recreated.

--- a/banks/ckad-mock-01/q25/setup.sh
+++ b/banks/ckad-mock-01/q25/setup.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl create ns perseus --dry-run=client -o yaml | kubectl apply -f -
+
+# The endpoint is bound to loopback on purpose. It is what makes the
+# question about getting INSIDE the Pod rather than about reaching a
+# Service: there is no Service, and there is nothing for one to select,
+# because nginx is not listening on the Pod's address at all.
+#
+# The body lives in its own ConfigMap, served as a static file, so the
+# check can read what the endpoint is meant to answer from the cluster
+# instead of carrying a second copy of the string that would drift.
+kubectl -n perseus apply -f - <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ledger-api-conf
+  namespace: perseus
+data:
+  default.conf: |
+    server {
+        listen 127.0.0.1:8080;
+        server_name localhost;
+        root /usr/share/nginx/html;
+        location / {
+        }
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ledger-api-page
+  namespace: perseus
+data:
+  healthz: |
+    ledger-api ok build 4471
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ledger-api
+  namespace: perseus
+  labels:
+    app: ledger-api
+spec:
+  containers:
+    - name: api
+      image: nginx:1.29-alpine
+      volumeMounts:
+        - name: conf
+          mountPath: /etc/nginx/conf.d
+        - name: page
+          mountPath: /usr/share/nginx/html
+  volumes:
+    - name: conf
+      configMap: {name: ledger-api-conf}
+    - name: page
+      configMap: {name: ledger-api-page}
+EOF
+
+kubectl -n perseus wait --for=condition=Ready pod/ledger-api --timeout=180s

--- a/banks/ckad-mock-01/q25/solution.md
+++ b/banks/ckad-mock-01/q25/solution.md
@@ -1,0 +1,97 @@
+# Solution 25
+
+`kubectl debug` adds a container to a Pod that is already running. It
+does not restart anything, it does not go through the Deployment or the
+ReplicaSet, and it does not need the application image to contain a
+single diagnostic tool.
+
+```bash
+k -n perseus debug ledger-api --image=busybox:1.37 -c debugger --target=api --profile=general -- sleep 3600
+```
+
+That returns immediately, having added the container. Now work from it:
+
+```bash
+k -n perseus exec ledger-api -c debugger -- \
+  wget -q -O - http://127.0.0.1:8080/healthz > /opt/course/25/healthz
+
+k -n perseus exec ledger-api -c debugger -- ps > /opt/course/25/api-process
+```
+
+```bash
+cat /opt/course/25/healthz
+# ledger-api ok build 4471
+cat /opt/course/25/api-process
+# PID   USER     TIME  COMMAND
+#     1 root      0:00 nginx: master process nginx -g daemon off;
+#    ...
+```
+
+Interactively you would normally write it as one command and look around
+by hand:
+
+```bash
+k -n perseus debug ledger-api -it --image=busybox:1.37 -c debugger --target=api --profile=general -- sh
+```
+
+The `-- sleep 3600` form above exists so the container is still running
+when the next `exec` arrives — an ephemeral container whose command has
+exited cannot be `exec`'d into, exactly like any other container.
+
+## What each flag buys
+
+| Flag | Effect |
+|---|---|
+| `--image` | The image the new container runs. This is the whole point: bring the tools rather than baking them into production images |
+| `-c` / `--container` | Names it. Left out, kubectl invents something like `debugger-8kx2t` |
+| `--target` | Joins that container's **process namespace** |
+| `-it` | Attach a terminal, for interactive use |
+
+Without `--target`, the ephemeral container still shares the Pod's
+**network** namespace — which is why the `wget` above reaches a listener
+bound to `127.0.0.1` — but it gets a process namespace of its own, so
+`ps` shows one process: itself. With `--target`, `/proc` is the target
+container's `/proc`, and you can read its command line, its environment
+and its open file descriptors.
+
+## Why loopback matters here
+
+`127.0.0.1` is not one address. Inside `ledger-api` it is that Pod's own
+loopback interface; on the instance it is the instance. A Service cannot
+help, because the listener is not bound to the Pod's address at all — an
+EndpointSlice would point at an address nginx is not accepting
+connections on, and every request would be refused.
+
+Binding an admin or health endpoint to loopback is a common and
+deliberate production choice, and this is how you reach it: from inside
+the same network namespace.
+
+## Ephemeral containers are permanent
+
+Once added, the entry stays in `spec.ephemeralContainers` forever. There
+is no `kubectl debug --remove`, and deleting one is not a supported
+update — the container stops when its command exits, but the record of it
+does not go away.
+
+```bash
+k -n perseus get pod ledger-api -o jsonpath='{.spec.ephemeralContainers}' | jq .
+```
+
+They also have deliberate limitations: no ports, no readiness or liveness
+probes, no resource requests, and no way to add a volume mount after the
+fact. They exist to look, not to run anything the Pod depends on.
+
+## When the container will not start at all
+
+If the Pod's own container is crash-looping, `kubectl exec` refuses it —
+you cannot exec into a container that is not running — and an ephemeral
+container targeting it has nothing to share. The tool for that case is a
+copy rather than an attachment:
+
+```bash
+k -n perseus debug ledger-api -it --copy-to=ledger-api-debug --container=api -- sh
+```
+
+which builds a new Pod from the same spec with the command replaced, and
+leaves the original untouched for whatever else you still want to read
+off it.

--- a/banks/ckad-mock-01/q25/validate.d/10_ephemeral.sh
+++ b/banks/ckad-mock-01/q25/validate.d/10_ephemeral.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# points: 4
+# desc: an ephemeral container named debugger runs busybox:1.37 targeting api, in the original Pod
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+evidence() {
+  show_actual json "$(kubectl -n perseus get pod ledger-api -o json 2>/dev/null \
+    | jq '{containers: [.spec.containers[].name],
+           ephemeralContainers: [.spec.ephemeralContainers // [] | .[]
+             | {name, image, targetContainerName}]}')"
+  show_why "$1"
+}
+
+# The Pod has to be the one that was already there. `kubectl debug` never
+# restarts anything — an ephemeral container is added through a
+# subresource on the live Pod — so a Pod that was deleted and recreated
+# is a different answer to a different question, and it also threw away
+# whatever state was being diagnosed.
+containers=$(kubectl -n perseus get pod ledger-api \
+  -o jsonpath='{range .spec.containers[*]}{.name}{"\n"}{end}' 2>/dev/null)
+[ -n "$containers" ] || {
+  echo "there is no Pod ledger-api in perseus"
+  show_why "Ephemeral containers are added to a Pod that exists. If it is gone, there is nothing to debug and nothing to attach to — and deleting it is the one thing the question rules out, because on a real incident the Pod IS the evidence."
+  exit 1
+}
+same_set "$containers" "api" || {
+  echo "the Pod's containers are '$(printf '%s' "$containers" | tr '\n' ' ')', want exactly one named api"
+  evidence "spec.containers is immutable on a running Pod, so a changed container list means the Pod was deleted and replaced. An ephemeral container is not added there — it lives in spec.ephemeralContainers, which is why it can be added to a Pod that is already running."
+  exit 1
+}
+
+eph=$(kubectl -n perseus get pod ledger-api -o json 2>/dev/null \
+  | jq -r '.spec.ephemeralContainers // [] | map(select(.name == "debugger")) | first // empty')
+[ -n "$eph" ] || {
+  echo "the Pod has no ephemeral container named debugger"
+  evidence "kubectl debug names the container it adds with -c/--container; left to itself it invents a name like debugger-8kx2t, which is fine in a terminal and not what the question asks for. The name is recorded in the Pod spec permanently — an ephemeral container can never be removed, only stopped."
+  exit 1
+}
+
+img=$(printf '%s' "$eph" | jq -r '.image // ""')
+[ "$img" = "busybox:1.37" ] || {
+  echo "the debugger container runs '$img', want busybox:1.37"
+  evidence "The whole point of a debugging image is that it carries tools the application image does not have to ship. Which image you pick is the --image flag, and it is the only reason the ephemeral container is worth adding."
+  exit 1
+}
+
+target=$(printf '%s' "$eph" | jq -r '.targetContainerName // ""')
+[ "$target" = "api" ] || {
+  echo "targetContainerName is '$target', want api"
+  evidence "Without --target, an ephemeral container shares the Pod's network and IPC but gets a process namespace of its own, so 'ps' shows only itself. Naming the target joins that container's process namespace, which is what makes another container's processes and its /proc visible at all."
+  exit 1
+}
+
+echo "ephemeral debugger attached"

--- a/banks/ckad-mock-01/q25/validate.d/20_healthz.sh
+++ b/banks/ckad-mock-01/q25/validate.d/20_healthz.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: the loopback health endpoint's response body was saved on the instance
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+# Read back from the cluster rather than carried here as a second copy of
+# the string, which would drift the first time setup.sh is edited.
+# Compared with the whitespace out: a trailing newline from `wget -O` and
+# one from an editor are not a wrong answer.
+want=$(kubectl -n perseus get cm ledger-api-page -o jsonpath='{.data.healthz}' 2>/dev/null)
+got=$(cat /opt/course/25/healthz 2>/dev/null)
+squash() { printf '%s' "$1" | tr -d '[:space:]'; }
+
+[ -n "$(squash "$want")" ] && [ "$(squash "$got")" = "$(squash "$want")" ] \
+  && { echo "health response recorded"; exit 0; }
+
+echo "/opt/course/25/healthz contains '$(printf '%s' "$got" | tr '\n' ' ')', want '$(printf '%s' "$want" | tr '\n' ' ')'"
+show_actual text "$(cat /opt/course/25/healthz 2>/dev/null)"
+show_why "The endpoint listens on 127.0.0.1, so 'localhost' means something different depending on where the request is made from: from the instance it is the instance, and from another Pod it is that Pod. Only a container inside ledger-api's own network namespace — which every ephemeral container is, targeted or not — resolves it to the listener this question is about."
+exit 1

--- a/banks/ckad-mock-01/q25/validate.d/30_process.sh
+++ b/banks/ckad-mock-01/q25/validate.d/30_process.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: the api container's main process was recorded from the shared process namespace
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+got=$(cat /opt/course/25/api-process 2>/dev/null)
+case "$got" in
+  *"master process"*) echo "process recorded"; exit 0 ;;
+esac
+
+echo "/opt/course/25/api-process does not name the api container's main process"
+show_actual text "$got"
+show_why "nginx rewrites its own argv, so its main process reports itself as 'nginx: master process ...'. That string is visible from the debugging container only when the two share a process namespace: with no --target, 'ps' inside an ephemeral container lists that container's own processes and nothing else, and /proc holds only its own PIDs."
+exit 1

--- a/banks/ckad-mock-01/q26/expected/podspec.json
+++ b/banks/ckad-mock-01/q26/expected/podspec.json
@@ -1,0 +1,15 @@
+{
+  "terminationGracePeriodSeconds": 45,
+  "containers": [
+    {
+      "name": "cache",
+      "image": "nginx:1.29-alpine",
+      "imagePullPolicy": "Never"
+    },
+    {
+      "name": "refresher",
+      "image": "busybox:1.37",
+      "imagePullPolicy": "Never"
+    }
+  ]
+}

--- a/banks/ckad-mock-01/q26/hints.md
+++ b/banks/ckad-mock-01/q26/hints.md
@@ -1,0 +1,26 @@
+## Hint 1
+
+Two settings, and they do not live at the same level. One of them is a
+property of each container; the other is a property of the Pod as a
+whole. Getting that backwards is the mistake this question is built
+around, and `kubectl explain` will tell you which is which before the API
+server does.
+
+Read what the Deployment says now before changing it — one of the two
+fields already has a value you did not write.
+
+## Hint 2
+
+The pull-policy field takes one of three words, and the one you want is
+the one that forbids a pull outright rather than the one that avoids an
+unnecessary one. It has to be written twice, once per container.
+
+The grace period is `terminationGracePeriodSeconds`, directly under
+`spec.template.spec`, beside `containers` rather than inside it.
+
+Editing the template starts a rollout. Wait for it before believing the
+Pods have changed:
+
+```bash
+k -n volans rollout status deploy/edge-cache
+```

--- a/banks/ckad-mock-01/q26/question.md
+++ b/banks/ckad-mock-01/q26/question.md
@@ -1,0 +1,13 @@
+Namespace `volans` runs Deployment `edge-cache`. Its Pod has two
+containers, `cache` and `refresher`, and both images are already present
+on every node.
+
+These nodes are treated as air-gapped. Change the Deployment so that:
+
+1. Neither container can make the kubelet contact a registry. Each must
+   use only the image already on the node, and fail to start rather than
+   fetch one.
+2. The Pod is given `45` seconds to shut down cleanly instead of the
+   default.
+
+The rollout must complete, and both containers must be `Ready`.

--- a/banks/ckad-mock-01/q26/setup.sh
+++ b/banks/ckad-mock-01/q26/setup.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl create ns volans --dry-run=client -o yaml | kubectl apply -f -
+
+# Neither imagePullPolicy nor terminationGracePeriodSeconds is set here,
+# so the API server defaults both: IfNotPresent for these pinned tags,
+# and 30 seconds. That matters for the question — the answer has to be a
+# value the server would not have written on its own, or a candidate who
+# changed nothing would score for it.
+kubectl -n volans apply -f - <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: edge-cache
+  namespace: volans
+spec:
+  replicas: 2
+  selector:
+    matchLabels: {app: edge-cache}
+  template:
+    metadata:
+      labels: {app: edge-cache}
+    spec:
+      containers:
+        - name: cache
+          image: nginx:1.29-alpine
+          ports: [{containerPort: 80}]
+        - name: refresher
+          image: busybox:1.37
+          command: ["sh", "-c", "while true; do echo 'refresher: cache warm'; sleep 20; done"]
+EOF
+
+kubectl -n volans rollout status deploy/edge-cache --timeout=180s

--- a/banks/ckad-mock-01/q26/solution.md
+++ b/banks/ckad-mock-01/q26/solution.md
@@ -1,0 +1,99 @@
+# Solution 26
+
+Two fields, at two different levels. `imagePullPolicy` belongs to each
+container; `terminationGracePeriodSeconds` belongs to the Pod.
+
+```bash
+k -n volans edit deploy edge-cache
+```
+
+```yaml
+spec:
+  template:
+    spec:
+      terminationGracePeriodSeconds: 45
+      containers:
+        - name: cache
+          image: nginx:1.29-alpine
+          imagePullPolicy: Never
+        - name: refresher
+          image: busybox:1.37
+          imagePullPolicy: Never
+```
+
+Or without an editor:
+
+```bash
+k -n volans patch deploy edge-cache -p '{
+  "spec": {"template": {"spec": {
+    "terminationGracePeriodSeconds": 45,
+    "containers": [
+      {"name": "cache", "imagePullPolicy": "Never"},
+      {"name": "refresher", "imagePullPolicy": "Never"}
+    ]
+  }}}
+}'
+
+k -n volans rollout status deploy/edge-cache --timeout=180s
+```
+
+**Leave `--type` off**, which is the trap worth meeting once. With no
+`--type`, `kubectl patch` sends a *strategic* merge patch, and Kubernetes
+declares `name` as the merge key for `containers`: the entries above are
+matched by name and merged into the existing ones, so naming a container
+and giving only the field you are changing is enough.
+
+Add `--type=merge` and it is an RFC 7386 JSON merge patch instead, where
+a list is a single value and is **replaced wholesale**. The same body
+then means "the Pod has two containers, each with a name and a pull
+policy and no image", and the API server rejects it:
+
+```
+The Deployment "edge-cache" is invalid:
+* spec.template.spec.containers[0].image: Required value
+```
+
+which is at least a loud failure. The quiet version of the same mistake
+is a list where every container you did not mention is simply gone.
+
+## The three pull policies
+
+| Value | The kubelet |
+|---|---|
+| `Always` | Contacts the registry every time a container starts, to check the digest behind the tag |
+| `IfNotPresent` | Uses the local copy if there is one, pulls if there is not |
+| `Never` | Uses the local copy or fails the container with `ErrImageNeverPull` |
+
+`Never` is the only one of the three that guarantees no registry traffic,
+which is what an air-gapped node needs. `IfNotPresent` looks close enough
+and is not: the first time an image is missing — a new node, a garbage
+collected image store — it goes to the network.
+
+The default is not "none". Leave the field out and the API server writes
+one for you, chosen by the tag: `Always` for `:latest` or no tag at all,
+`IfNotPresent` for anything else. So the value already stored on an
+untouched container here is `IfNotPresent`, written by the server, and
+indistinguishable from having typed it yourself.
+
+```bash
+k -n volans get deploy edge-cache \
+  -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"\t"}{.imagePullPolicy}{"\n"}{end}'
+```
+
+## Why the policy is per container and the grace period is not
+
+A Pod's containers each have their own image, so each needs its own
+answer about fetching it — there is no Pod-level `imagePullPolicy` to
+set once, and looking for one is the usual way to lose time here.
+
+Shutdown is the opposite. When a Pod is deleted, the kubelet sends
+`SIGTERM` to **every** container at once and starts one clock. When it
+expires, whatever is still alive gets `SIGKILL`. There is one clock
+because there is one Pod, and `terminationGracePeriodSeconds` is it.
+
+Worth knowing about that clock: it starts at the same moment the Pod is
+removed from its Service's endpoints, and those two things race — the
+endpoint removal has to propagate to every node's kube-proxy while the
+application is already shutting down. A `preStop` hook that sleeps a few
+seconds before the process begins to exit is the usual fix, and its sleep
+comes out of this same budget rather than being added to it.

--- a/banks/ckad-mock-01/q26/validate.d/10_pull-policy.sh
+++ b/banks/ckad-mock-01/q26/validate.d/10_pull-policy.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# points: 3
+# desc: both containers declare imagePullPolicy Never in the Deployment's Pod template
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+evidence() {
+  show_actual json "$(kubectl -n volans get deploy edge-cache -o json 2>/dev/null \
+    | jq '{terminationGracePeriodSeconds: .spec.template.spec.terminationGracePeriodSeconds,
+           containers: [.spec.template.spec.containers[] | {name, image, imagePullPolicy}]}')"
+  show_expected json "/banks/${BANK:-ckad-mock-01}/q26/expected/podspec.json"
+  show_why "$1"
+}
+
+for c in cache refresher; do
+  got=$(kubectl -n volans get deploy edge-cache \
+    -o jsonpath="{.spec.template.spec.containers[?(@.name==\"${c}\")].imagePullPolicy}" 2>/dev/null)
+  [ -n "$got" ] || {
+    echo "the Deployment has no container named ${c}"
+    evidence "The two containers are the workload as it stands. Renaming or removing one answers a different question, and the pull policy still has to be set on whatever is left."
+    exit 1
+  }
+  [ "$got" = "Never" ] || {
+    echo "container ${c} has imagePullPolicy '${got}', want Never"
+    evidence "imagePullPolicy is a field of the CONTAINER, not of the Pod: there is no single place to set it once for both. Never means the kubelet uses only what is already in the node's image store and fails the container with ErrImageNeverPull rather than reaching for a registry. Left unset, the API server writes a default that depends on the tag — IfNotPresent for a pinned one like these, Always for :latest — which is why an untouched container already reads IfNotPresent and why that cannot be the answer."
+    exit 1
+  }
+done
+
+echo "pull policy ok"

--- a/banks/ckad-mock-01/q26/validate.d/20_grace.sh
+++ b/banks/ckad-mock-01/q26/validate.d/20_grace.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: the Pod template asks for a 45 second termination grace period
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+got=$(kubectl -n volans get deploy edge-cache \
+  -o jsonpath='{.spec.template.spec.terminationGracePeriodSeconds}' 2>/dev/null)
+[ "$got" = "45" ] && { echo "grace period ok"; exit 0; }
+
+echo "terminationGracePeriodSeconds is '$got', want 45"
+# The same projection 10_pull-policy shows, and the same expected file.
+# Two checks that quote the same document must filter it identically, or
+# the side-by-side marks fields as differing that are simply absent from
+# one pane.
+show_actual json "$(kubectl -n volans get deploy edge-cache -o json 2>/dev/null \
+  | jq '{terminationGracePeriodSeconds: .spec.template.spec.terminationGracePeriodSeconds,
+         containers: [.spec.template.spec.containers[] | {name, image, imagePullPolicy}]}')"
+show_expected json "/banks/${BANK:-ckad-mock-01}/q26/expected/podspec.json"
+show_why "terminationGracePeriodSeconds belongs to the POD, not to a container — the opposite of imagePullPolicy, which is why the two together are worth knowing. It is the whole budget from SIGTERM to SIGKILL, shared by every container in the Pod, and it starts at the same moment the endpoint is removed from the Service. Unset it defaults to 30, which is what an untouched Deployment reads."
+exit 1

--- a/banks/ckad-mock-01/q26/validate.d/30_running.sh
+++ b/banks/ckad-mock-01/q26/validate.d/30_running.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# points: 1
+# desc: the rollout completed and the live Pods carry the new settings
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+want=$(kubectl -n volans get deploy edge-cache -o jsonpath='{.spec.replicas}' 2>/dev/null)
+ready=$(kubectl -n volans get deploy edge-cache -o jsonpath='{.status.readyReplicas}' 2>/dev/null)
+[ -n "$want" ] || want=0
+[ -n "$ready" ] || ready=0
+[ "$want" -gt 0 ] && [ "$ready" = "$want" ] || {
+  echo "${ready}/${want} replicas are ready"
+  show_actual text "$(kubectl -n volans get pods -l app=edge-cache 2>/dev/null)"
+  show_why "A template edited but not rolled out has changed nothing that is running. ErrImageNeverPull is the failure to expect here: it means the kubelet was told never to pull and could not find the image already on the node, which is exactly what Never is for — a loud failure instead of a silent trip to a registry."
+  exit 1
+}
+
+live=$(kubectl -n volans get pods -l app=edge-cache -o json 2>/dev/null \
+  | jq -r '[.items[] | select(.spec.terminationGracePeriodSeconds == 45)
+            | select([.spec.containers[].imagePullPolicy] | unique == ["Never"])] | length')
+[ "$live" = "$ready" ] || {
+  echo "only ${live} of ${ready} running Pods carry both settings"
+  show_actual json "$(kubectl -n volans get pods -l app=edge-cache -o json 2>/dev/null \
+    | jq '[.items[] | {name: .metadata.name, grace: .spec.terminationGracePeriodSeconds,
+                       policies: [.spec.containers[].imagePullPolicy]}]')"
+  show_why "Changing a Deployment's Pod template starts a rollout; it does not edit the Pods that are already there. Until the new ReplicaSet has fully replaced the old one, some of what is running is still the previous spec — 'kubectl -n volans rollout status deploy/edge-cache' is what waits for that."
+  exit 1
+}
+
+echo "rollout complete with both settings live"

--- a/banks/ckad-mock-01/tips.md
+++ b/banks/ckad-mock-01/tips.md
@@ -1,0 +1,194 @@
+Two hours is not long. Most people who fail this exam knew the answers —
+they ran out of time getting to them. What follows is technique, not
+Kubernetes: the habits that decide how many of the twenty-two you reach.
+
+## Set the terminal up before you start
+
+The exam desktop already has these, and it is worth spending ninety
+seconds confirming them rather than discovering halfway through that you
+have been typing `kubectl` in full.
+
+```bash
+alias k=kubectl
+source <(kubectl completion bash)
+complete -o default -F __start_kubectl k
+```
+
+Tab completion is the part that matters. It completes resource types,
+resource *names*, and namespaces — so `k -n ` then Tab is faster and more
+reliable than remembering which namespace a question named.
+
+Two more that pay for themselves:
+
+```bash
+export do="--dry-run=client -o yaml"
+export now="--grace-period 0 --force"
+```
+
+`$do` turns any generator into a manifest you can edit. `$now` deletes a
+Pod immediately instead of waiting out its termination grace period,
+which is thirty seconds you do not have.
+
+## Never write a manifest from memory
+
+Generate the skeleton, then edit it. This is the single biggest time
+saving available, and it also removes a whole class of typos.
+
+```bash
+k create deploy web --image=nginx:1.29-alpine $do > web.yaml
+k run tmp --image=busybox:1.37 $do --command -- sleep 3600 > pod.yaml
+k create job report --image=busybox:1.37 $do -- sh -c 'echo done' > job.yaml
+k create cj nightly --image=busybox:1.37 --schedule='0 2 * * *' $do -- sh -c 'echo done' > cj.yaml
+k expose deploy web --port=80 --target-port=8080 $do > svc.yaml
+k create cm app-config --from-literal=LOG_LEVEL=debug $do > cm.yaml
+k create secret generic db --from-literal=password=hunter2 $do > secret.yaml
+k create ingress web --rule='site.local/*=web:80' $do > ing.yaml
+```
+
+There is no generator for a few things you will be asked for —
+NetworkPolicy, PersistentVolumeClaim, a multi-container Pod. For those,
+generate the nearest thing that does exist and add to it, or start from
+a document you already have on the cluster.
+
+## The docs are the last resort, not the first
+
+Reaching for a browser costs a minute even when you find the page
+immediately. Three faster sources, in order:
+
+```bash
+k explain pod.spec.containers.securityContext
+k explain deploy.spec.strategy --recursive
+k create deploy -h
+```
+
+`explain` is authoritative for **field names and structure** — it is
+generated from the same schema the API server validates against, so it
+cannot be out of date with the cluster you are on. `--recursive` prints
+the whole subtree at once, which is usually what you actually wanted.
+
+`-h` on a command shows its examples, and the examples are the fastest
+path to a flag you half-remember. `k create secret generic -h` answers
+"was it `--from-literal` or `--from-file`" in a second.
+
+When you do open the documentation, go straight to a page you can search
+inside rather than using the site search: the concept pages carry the
+YAML examples, and copying one and editing it beats typing one.
+
+## Read what is there before you change it
+
+Almost every question in a hands-on exam operates on something the
+cluster already has. Look at it first.
+
+```bash
+k -n <ns> get all
+k -n <ns> get pod <name> -o yaml
+k -n <ns> describe pod <name>
+k -n <ns> get pod <name> -o jsonpath='{.spec.containers[*].image}'
+```
+
+`describe` is for **events** — scheduling failures, image pull errors,
+probe failures, the reason a Pod is Pending. `-o yaml` is for the spec.
+`-o jsonpath` is for pulling one field out without reading a hundred
+lines, and it is the fastest way to check your own answer:
+
+```bash
+k -n volans get deploy edge-cache \
+  -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"\t"}{.imagePullPolicy}{"\n"}{end}'
+```
+
+Editing something that exists is usually faster than replacing it:
+
+```bash
+k -n <ns> edit deploy <name>
+k -n <ns> patch deploy <name> --type=merge -p '{"spec":{"replicas":3}}'
+k -n <ns> set image deploy/<name> web=nginx:1.29-alpine
+k -n <ns> scale deploy <name> --replicas=3
+```
+
+## YAML in a terminal editor
+
+Most lost points in a written exam are indentation. Configure the editor
+once, at the start:
+
+```vim
+:set expandtab shiftwidth=2 tabstop=2
+:set number
+```
+
+`expandtab` is the important one — a literal tab character is not valid
+YAML indentation, and the error it produces points at a line that looks
+correct. If the editor inserts one anyway, `:set list` shows it.
+
+Two editing moves worth having:
+
+- **Indent a block**: select it in visual mode (`V`, then `j` to extend),
+  then `>` to shift right or `<` to shift left. Repeat with `.`.
+- **Yank a block**: `yy` copies a line, `3yy` copies three, `p` pastes
+  below. A container block is usually a copy of the one above it with two
+  fields changed.
+
+And validate before you believe it:
+
+```bash
+k apply -f pod.yaml --dry-run=server
+```
+
+Server-side dry run catches what client-side does not: an invalid field
+name, a value the API rejects, a securityContext setting that is not
+legal where you put it.
+
+## Pacing
+
+The clock is the exam. Two rules:
+
+**Do not finish a question you are stuck on.** If you have not made
+progress in a few minutes, note the id, leave what you have and move on.
+A question you have not started is worth the same as one you have half
+done, and the one after it may take two minutes. Come back with whatever
+time is left.
+
+**Do exactly what is asked, and nothing else.** Extra labels, tidier
+names and a Service the question did not mention cost time and can only
+lose points. If a question names a Namespace, work in it; if it names a
+file path, write to it exactly.
+
+Verify each answer as you finish it, in one command, then leave it alone:
+
+```bash
+k -n <ns> get pod <name>
+k -n <ns> rollout status deploy/<name> --timeout=60s
+```
+
+## When something will not start
+
+The order to look, and it is almost always answered in the first two:
+
+```bash
+k -n <ns> get pod                       # Pending? CrashLoopBackOff? ImagePullBackOff?
+k -n <ns> describe pod <name>           # events at the bottom
+k -n <ns> logs <name>                   # the container's own output
+k -n <ns> logs <name> --previous        # the output of the one that already died
+```
+
+`--previous` is the one people forget. A container in
+`CrashLoopBackOff` has no current output worth reading; what killed it is
+in the previous container's log.
+
+| Symptom | Usually |
+|---|---|
+| `Pending` | Nothing can schedule it: resource requests too large, a node selector that matches nothing, an unbound PVC |
+| `ImagePullBackOff` | Wrong tag, wrong registry, or a pull policy that will not use the local copy |
+| `CrashLoopBackOff` | The process exits. Read `--previous`; a readOnlyRootFilesystem or a dropped capability is a common cause |
+| `Running` but not `Ready` | The readiness probe is failing. `describe` says which |
+| `CreateContainerConfigError` | A ConfigMap or Secret the container reads as **env** does not exist. Mounted as a **volume** instead, the same missing object leaves the Pod in `ContainerCreating` with a `FailedMount` event |
+
+## Shell habits
+
+- `Ctrl+R` searches your command history. You will run variations of the
+  same `kubectl get` fifty times; retyping them is minutes.
+- `Ctrl+Z` suspends the editor, `fg` brings it back. Faster than closing
+  and reopening a file to run one command.
+- `!!` repeats the last command; `sudo !!` repeats it with sudo.
+- Set the namespace once instead of typing `-n` every time:
+  `k config set-context --current --namespace=<ns>`. Just remember you
+  did it before the next question.

--- a/conductor/internal/control/control.go
+++ b/conductor/internal/control/control.go
@@ -251,7 +251,29 @@ func (c *Controller) runReset(jobID string, mcq bool) {
 // never touches either, and the rebuild is the whole 2-4 minute wait.
 // The cluster keeps the outgoing bank's state until the next hands-on
 // switch rebuilds it — nothing reads it in between.
-func switchPhases(mcq bool) []job.PhaseSpec {
+//
+// provision drops the two phases that only make sense when there is an
+// outgoing exam. Nothing is switching: there is no session to end, no
+// desktop to lock, and no candidate work to wipe, because no exam has
+// ever been chosen in this environment. Running them anyway would work
+// — both are no-ops against nothing — but the checklist is the only
+// account of what is happening the candidate gets, and "End session and
+// lock desktop" as the first thing they see after picking their first
+// exam describes a product they have not used yet.
+func switchPhases(mcq, provision bool) []job.PhaseSpec {
+	if provision {
+		phases := []job.PhaseSpec{{ID: "write-bank", Label: "Select the exam"}}
+		if !mcq {
+			phases = append(phases,
+				job.PhaseSpec{ID: "recreate-cluster", Label: "Build the Kubernetes cluster"},
+				job.PhaseSpec{ID: "restart-instances", Label: "Start the exam instances"},
+			)
+		}
+		return append(phases,
+			job.PhaseSpec{ID: "restart-facilitator", Label: "Start the exam services"},
+			job.PhaseSpec{ID: "verify", Label: "Verify the exam is live"},
+		)
+	}
 	if mcq {
 		return []job.PhaseSpec{
 			{ID: "end-session", Label: "End session and lock desktop"},
@@ -287,6 +309,18 @@ func (c *Controller) StartSwitch(bank string) (job.Job, error) {
 		return job.Job{}, fmt.Errorf("%w: %v", ErrInvalidBank, err)
 	}
 	mcq := c.bankIsMCQ(bank)
+	// An environment that has never been told which exam to be is not
+	// switching away from anything — it is being built for the first
+	// time. The distinction is the bank file's absence and nothing else:
+	// k8s-env rests without writing it, and the conductor is its only
+	// other writer, so an empty read here means no exam was ever chosen.
+	//
+	// It changes the phase list and the job's op label; the sequence
+	// below is otherwise the same one a switch has always run, which is
+	// the point. Building an environment on demand was never a missing
+	// capability — bootstrapCmd tears the cluster down and rebuilds it
+	// from whatever /shared/bank says — only a missing name for it.
+	provision := c.activeBank() == ""
 	// Every switch restarts the bank-reading services (RestartExtra), and
 	// a hands-on target restarts the instances too. Unlike reset there is
 	// no variant that needs none, so on an engine that cannot restart, a
@@ -308,11 +342,15 @@ func (c *Controller) StartSwitch(bank string) (job.Job, error) {
 		return job.Job{}, ErrSessionRunning
 	}
 
-	j, err := c.Store.Begin("switch", bank, switchPhases(mcq))
+	op := "switch"
+	if provision {
+		op = "provision"
+	}
+	j, err := c.Store.Begin(op, bank, switchPhases(mcq, provision))
 	if err != nil {
 		return job.Job{}, err
 	}
-	go c.runSwitch(j.ID, bank, mcq)
+	go c.runSwitch(j.ID, bank, mcq, provision)
 	return j, nil
 }
 
@@ -321,19 +359,26 @@ func (c *Controller) StartSwitch(bank string) (job.Job, error) {
 // and the bank-reading services restart after the instances, the
 // facilitator last (its entrypoint re-derives EXAM_JSON; its restart
 // also triggers the session manager's cross-bank discard).
-func (c *Controller) runSwitch(jobID, bank string, mcq bool) {
+// When provision is set the first two steps are skipped rather than run
+// against nothing — see switchPhases, whose checklist must agree with
+// this sequence phase for phase. StartPhase silently ignores an id the
+// job never declared, so a phase run without a spec would settle nothing
+// and leave the UI counting a step that is not on screen.
+func (c *Controller) runSwitch(jobID, bank string, mcq, provision bool) {
 	ctx := context.Background()
 
-	c.Store.StartPhase(jobID, "end-session")
-	if err := c.endSession(ctx); err != nil {
-		c.Store.Fail(jobID, err.Error())
-		return
-	}
+	if !provision {
+		c.Store.StartPhase(jobID, "end-session")
+		if err := c.endSession(ctx); err != nil {
+			c.Store.Fail(jobID, err.Error())
+			return
+		}
 
-	c.Store.StartPhase(jobID, "wipe-instances")
-	if err := c.wipeCandidateState(ctx, jobID); err != nil {
-		c.Store.Fail(jobID, err.Error())
-		return
+		c.Store.StartPhase(jobID, "wipe-instances")
+		if err := c.wipeCandidateState(ctx, jobID); err != nil {
+			c.Store.Fail(jobID, err.Error())
+			return
+		}
 	}
 
 	c.Store.StartPhase(jobID, "write-bank")

--- a/conductor/internal/control/control_test.go
+++ b/conductor/internal/control/control_test.go
@@ -90,6 +90,24 @@ func newTestController(t *testing.T, eng Engine, facilitator string) *Controller
 	}
 }
 
+// bankFileHolding returns a bank-file path that already names an active
+// exam — i.e. an environment somebody is already sitting in.
+//
+// This is what makes a switch a switch. StartSwitch reads the same file
+// to tell "replace the exam that is loaded" from "there has never been
+// one", and a test that only pointed BankFile at an empty temp dir was
+// silently exercising the second: no session to end and no candidate
+// work to wipe, so both of those phases were correctly skipped and the
+// assertions about them failed.
+func bankFileHolding(t *testing.T, bank string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "bank")
+	if err := os.WriteFile(path, []byte(bank), 0o644); err != nil {
+		t.Fatalf("seed bank file: %v", err)
+	}
+	return path
+}
+
 // waitIdle blocks until the store has no in-flight job.
 func waitIdle(t *testing.T, s *job.Store) job.Snapshot {
 	t.Helper()
@@ -306,7 +324,7 @@ func TestSwitchRunsFullSequenceAndWritesBankFile(t *testing.T) {
 	eng := &fakeEngine{}
 	c := newTestController(t, eng, facilitator.URL)
 	c.Catalog = testCatalogForSwitch(t)
-	c.BankFile = filepath.Join(t.TempDir(), "bank")
+	c.BankFile = bankFileHolding(t, "ckad-mock-01")
 	c.RestartExtra = []string{"docs-proxy", "facilitator"}
 
 	if _, err := c.StartSwitch("cka-mock-01"); err != nil {
@@ -369,7 +387,7 @@ func TestSwitchToMCQBankSkipsClusterRebuild(t *testing.T) {
 	eng := &fakeEngine{}
 	c := newTestController(t, eng, facilitator.URL)
 	c.Catalog = testCatalogWithMCQ(t)
-	c.BankFile = filepath.Join(t.TempDir(), "bank")
+	c.BankFile = bankFileHolding(t, "ckad-mock-01")
 	c.RestartExtra = []string{"docs-proxy", "facilitator"}
 
 	j, err := c.StartSwitch("kcna-mock")
@@ -400,6 +418,99 @@ func TestSwitchToMCQBankSkipsClusterRebuild(t *testing.T) {
 		t.Errorf("mcq switch restarted instances:\n%s", calls)
 	}
 	for _, needle := range []string{wipeShell, "restart:docs-proxy", "restart:facilitator"} {
+		if !strings.Contains(calls, needle) {
+			t.Errorf("engine calls missing %q:\n%s", needle, calls)
+		}
+	}
+}
+
+// The first exam an environment is ever given.
+//
+// `./sim up` with no bank builds nothing: k8s-env rests after the two
+// phases that are not about any particular exam, and the bank file is
+// never written. Choosing an exam then runs this — the same sequence a
+// switch runs, minus the two phases that only mean something when there
+// is an outgoing exam to end and candidate work to wipe.
+//
+// The op label is load-bearing, not cosmetic: it is what the overlay and
+// the background chip title themselves from, and "Switching to CKA Mock
+// Exam 01" is a lie told to somebody who has chosen exactly one exam in
+// their life. The empty bank file is the whole trigger, so this test
+// deliberately does not create one.
+func TestFirstExamProvisionsRatherThanSwitches(t *testing.T) {
+	var deletes int
+	var mu sync.Mutex
+	facilitator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/session":
+			fmt.Fprint(w, `{"state":"idle"}`)
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/session":
+			mu.Lock()
+			deletes++
+			mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		case r.URL.Path == "/healthz":
+			fmt.Fprint(w, "ok")
+		case r.URL.Path == "/api/exam":
+			fmt.Fprint(w, `{"name":"cka-mock-01"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer facilitator.Close()
+
+	eng := &fakeEngine{}
+	c := newTestController(t, eng, facilitator.URL)
+	c.Catalog = testCatalogForSwitch(t)
+	// Points at a path inside an empty dir: no exam has ever been chosen.
+	c.BankFile = filepath.Join(t.TempDir(), "bank")
+	c.RestartExtra = []string{"docs-proxy", "facilitator"}
+
+	j, err := c.StartSwitch("cka-mock-01")
+	if err != nil {
+		t.Fatalf("StartSwitch: %v", err)
+	}
+	if j.Op != "provision" {
+		t.Errorf("op = %q, want provision", j.Op)
+	}
+	for _, p := range j.Phases {
+		if p.ID == "end-session" || p.ID == "wipe-instances" {
+			t.Errorf("provision job advertises phase %q, want it absent", p.ID)
+		}
+	}
+
+	snap := waitIdle(t, c.Store)
+	if snap.LastJob == nil || snap.LastJob.Error != "" {
+		t.Fatalf("provision job = %+v, want clean completion", snap.LastJob)
+	}
+	// Every declared phase must have run. A phase left pending in a
+	// COMPLETED job is what happens when the checklist and the sequence
+	// disagree — StartPhase ignores an id the job never declared, and the
+	// reverse leaves a row on screen that never ticks.
+	for _, p := range snap.LastJob.Phases {
+		if p.State != job.PhaseDone {
+			t.Errorf("phase %q ended in state %q, want done", p.ID, p.State)
+		}
+	}
+
+	mu.Lock()
+	if deletes != 0 {
+		t.Errorf("DELETE /api/session calls = %d, want 0: there is no session to end", deletes)
+	}
+	mu.Unlock()
+
+	wrote, err := os.ReadFile(c.BankFile)
+	if err != nil || string(wrote) != "cka-mock-01" {
+		t.Fatalf("bank file = %q, %v; want cka-mock-01", wrote, err)
+	}
+
+	calls := strings.Join(eng.recorded(), "\n")
+	if strings.Contains(calls, wipeShell) || strings.Contains(calls, registryShell) {
+		t.Errorf("provision wiped state that cannot exist yet:\n%s", calls)
+	}
+	// It is still a full build: the cluster and everything that reads the
+	// bank. Only the teardown half is gone.
+	for _, needle := range []string{"exec:k8s-env:", "restart:instance-1", "restart:facilitator"} {
 		if !strings.Contains(calls, needle) {
 			t.Errorf("engine calls missing %q:\n%s", needle, calls)
 		}
@@ -493,7 +604,7 @@ func TestSwitchSeparatesTheFacilitatorRestartIntoItsOwnPhase(t *testing.T) {
 	eng := &fakeEngine{}
 	c := newTestController(t, eng, facilitator.URL)
 	c.Catalog = testCatalogForSwitch(t)
-	c.BankFile = filepath.Join(t.TempDir(), "bank")
+	c.BankFile = bankFileHolding(t, "ckad-mock-01")
 	c.RestartExtra = []string{"docs-proxy", "facilitator"}
 
 	if _, err := c.StartSwitch("cka-mock-01"); err != nil {
@@ -577,7 +688,7 @@ func TestSwitchRefusedWhileSessionRunning(t *testing.T) {
 
 	c := newTestController(t, &fakeEngine{}, facilitator.URL)
 	c.Catalog = testCatalogForSwitch(t)
-	c.BankFile = filepath.Join(t.TempDir(), "bank")
+	c.BankFile = bankFileHolding(t, "ckad-mock-01")
 
 	_, err := c.StartSwitch("cka-mock-01")
 	if !errors.Is(err, ErrSessionRunning) {
@@ -612,7 +723,7 @@ func TestSwitchVerifyFailsOnExamNameMismatch(t *testing.T) {
 
 	c := newTestController(t, &fakeEngine{}, facilitator.URL)
 	c.Catalog = testCatalogForSwitch(t)
-	c.BankFile = filepath.Join(t.TempDir(), "bank")
+	c.BankFile = bankFileHolding(t, "ckad-mock-01")
 
 	if _, err := c.StartSwitch("cka-mock-01"); err != nil {
 		t.Fatalf("StartSwitch: %v", err)

--- a/conductor/internal/job/job.go
+++ b/conductor/internal/job/job.go
@@ -62,10 +62,16 @@ type Phase struct {
 
 // Job is one control operation's progress record. Snapshots returned by
 // Status are deep copies — callers can never mutate store state.
+//
+// Op's fourth value, "provision", is a switch run in an environment that
+// has never had an exam: the same sequence minus the two phases that
+// only mean something when there is an outgoing one. It gets a label of
+// its own because the UI titles the job from it, and "Switching to CKAD"
+// is the wrong thing to tell somebody choosing their first exam.
 type Job struct {
 	ID         string  `json:"id"`
-	Op         string  `json:"op"`   // "reset" | "switch" | "seed"
-	Bank       string  `json:"bank"` // target bank for switch and seed, "" for reset
+	Op         string  `json:"op"`   // "reset" | "switch" | "provision" | "seed"
+	Bank       string  `json:"bank"` // target bank for switch, provision and seed, "" for reset
 	StartedAt  string  `json:"startedAt"`
 	FinishedAt string  `json:"finishedAt,omitempty"`
 	Phase      string  `json:"phase"` // id of the phase currently running ("" before the first)

--- a/deploy/helm/kubestronaut-sim/templates/configmap-session-pods.yaml
+++ b/deploy/helm/kubestronaut-sim/templates/configmap-session-pods.yaml
@@ -1,5 +1,5 @@
 {{- if or (gt (int .Values.sessions.practical.seats) 0) (gt (int .Values.sessions.mcq.seats) 0) }}
-# The two Pod manifests, as JSON, for the hub to stamp out.
+# The Pod manifests, as JSON, for the hub to stamp out.
 #
 # JSON because the hub is stdlib-only and the standard library has no
 # YAML parser — a rule this repo keeps everywhere, and the conversion is
@@ -9,6 +9,13 @@
 # Rendered from files/ at install time, so `helm template` shows exactly
 # what a session will be. See the sessionPod helper for the four fields
 # this chart rewrites and why.
+#
+# `session-pod.json` is a flavour's default. `session-bank-<id>.json` is
+# one exam's, rendered only for the banks given overrides under
+# sessions.<kind>.banks, and picked by the hub when a session for that
+# exam is created. The naming is the contract between this file and
+# hub/cmd/hub/main.go's bankTemplates: a bank with no file here simply
+# gets the flavour's default, which is every bank the product ships.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -21,4 +28,17 @@ data:
     {{- include "kubestronaut-sim.sessionPod" (dict "ctx" . "file" "files/session-pod.yaml" "flavour" .Values.sessions.practical) | nindent 4 }}
   session-pod-mcq.json: |
     {{- include "kubestronaut-sim.sessionPod" (dict "ctx" . "file" "files/session-pod-mcq.yaml" "flavour" .Values.sessions.mcq) | nindent 4 }}
+{{- range $flavour, $file := dict "practical" "files/session-pod.yaml" "mcq" "files/session-pod-mcq.yaml" }}
+{{- $spec := index $.Values.sessions $flavour }}
+{{- range $bank, $override := ($spec.banks | default dict) }}
+{{/* The per-exam resources are merged OVER the flavour's, which the
+     helper then merges over the manifest's own measured numbers. Three
+     layers, most specific last, and deepCopy on each so a merge cannot
+     write back into .Values and leak into the next iteration. */}}
+{{- $merged := mergeOverwrite (deepCopy ($spec.resources | default dict)) (deepCopy ($override.resources | default dict)) }}
+{{- $perBank := merge (dict "resources" $merged) (omit (deepCopy $spec) "resources" "banks") }}
+  session-bank-{{ $bank }}.json: |
+    {{- include "kubestronaut-sim.sessionPod" (dict "ctx" $ "file" $file "flavour" $perBank) | nindent 4 }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/deploy/helm/kubestronaut-sim/templates/deployment.yaml
+++ b/deploy/helm/kubestronaut-sim/templates/deployment.yaml
@@ -67,6 +67,42 @@ spec:
         fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
+      {{- if $sessions }}
+      initContainers:
+        # The exam list, staged out of the banks image.
+        #
+        # The hub needs it because of WHEN the question is asked: a
+        # candidate in the lobby is choosing which certification to sit,
+        # and until they have chosen there is no session Pod, so there is
+        # nothing running that could be asked what exams exist.
+        #
+        # It copies /index — JSON generated at image build time from each
+        # bank's exam.yaml — and not /src. The hub is a FROM scratch
+        # image with no shell, and no Go binary in this repo parses YAML,
+        # so the conversion happens where the content lives. Same reason
+        # the session Pod stages banks from this image rather than baking
+        # them into six others.
+        - name: banks
+          image: {{ include "kubestronaut-sim.image" (dict "ctx" . "name" "banks") | quote }}
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          # -r and not -a, unlike the session Pod's identical-looking
+          # init container. That one runs as root; this Pod runs as
+          # 65532, and -a asks to preserve root ownership, which a
+          # non-root process cannot do and busybox reports as a failure.
+          # Nothing here needs the original ownership: the hub reads
+          # these files and no one else ever opens them.
+          command: ["sh", "-c", "cp -r /index/. /banks/"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - {name: banks, mountPath: /banks}
+          resources:
+            requests: {memory: "16Mi", cpu: "10m"}
+            limits: {memory: "64Mi", cpu: "200m"}
+      {{- end }}
       containers:
         - name: hub
           image: {{ include "kubestronaut-sim.image" (dict "ctx" . "name" "hub") | quote }}
@@ -109,6 +145,7 @@ spec:
                 secretKeyRef: {name: {{ $secret | quote }}, key: GITHUB_CLIENT_SECRET, optional: true}
 
             {{- if $sessions }}
+            - {name: BANKS_INDEX_DIR, value: "/banks"}
             - {name: SESSION_NAMESPACE, value: {{ include "kubestronaut-sim.sessionNamespace" . | quote }}}
             - {name: DEFAULT_KIND, value: {{ .Values.sessions.defaultKind | quote }}}
             - {name: POD_PREFIX, value: {{ .Values.sessions.podPrefix | quote }}}
@@ -135,6 +172,7 @@ spec:
             - {name: state, mountPath: /state}
             {{- if $sessions }}
             - {name: session-pods, mountPath: /etc/hub, readOnly: true}
+            - {name: banks, mountPath: /banks, readOnly: true}
             {{- end }}
           # /healthz answers before any of the interesting wiring, which
           # is what makes it a liveness probe and not a readiness one: a
@@ -158,6 +196,11 @@ spec:
         - name: session-pods
           configMap:
             name: {{ include "kubestronaut-sim.fullname" . }}-session-pods
+        # Read once at startup and never again: banks are an image layer,
+        # so a new bank is a new image and therefore a new hub Pod.
+        - name: banks
+          emptyDir:
+            sizeLimit: 16Mi
         {{- end }}
       {{- with .Values.hub.nodeSelector }}
       nodeSelector:

--- a/deploy/helm/kubestronaut-sim/values.yaml
+++ b/deploy/helm/kubestronaut-sim/values.yaml
@@ -134,7 +134,17 @@ sessions:
   practical:
     # 0 seats disables the flavour: no template is loaded and
     # /api/session/start refuses it.
+    #
+    # Seats are counted per ENGINE, not per exam. Every hands-on
+    # certification draws from this one pool, because what a seat costs
+    # the cluster is a session Pod and every hands-on session is one.
     seats: 3
+    # The exam a session sits when the candidate names none.
+    #
+    # It used to be THE exam: the lobby offered a flavour and this
+    # decided which bank was behind it, so nobody sitting the exam ever
+    # chose it. The lobby offers certifications now and sends the one
+    # that was picked; this is the fallback for a request without one.
     bank: ckad-mock-01
     # A practical session is a privileged Pod that hands a stranger a
     # root shell with a container runtime in it. Confine it to nodes you
@@ -155,6 +165,24 @@ sessions:
     #       limits: {memory: 8Gi}
     resources: {}
 
+    # Per-EXAM overrides, merged over `resources` above, which is itself
+    # merged over the manifest. One seat pool, one queue; the Pod is
+    # sized for the exam that will run in it.
+    #
+    # This exists because the cluster is per-exam now:
+    # spec.environment.nodes in the bank decides how many kind nodes get
+    # built, and a CKA bank asking for three cannot be sized by what
+    # CKAD's two measured. A bank with no entry here gets the numbers
+    # above, which is every bank the product ships today.
+    #
+    #   banks:
+    #     cka-mock-01:
+    #       resources:
+    #         k8s-env:
+    #           requests: {memory: 6Gi}
+    #           limits: {memory: 10Gi}
+    banks: {}
+
   mcq:
     # An MCQ session is a facilitator and 128Mi. It needs no cluster, no
     # shells and no privilege, so it schedules anywhere and the cap is
@@ -164,6 +192,10 @@ sessions:
     nodeSelector: {}
     tolerations: []
     resources: {}
+    # As above. A multiple-choice session is a facilitator and 128Mi
+    # whichever bank it serves, so nothing here is likely ever to need
+    # one — it exists so the two flavours are configured the same way.
+    banks: {}
 
   # What a session Pod may talk to. Not optional in any deployment that
   # sells seats to strangers: without it a session reaches the cluster's

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,14 @@ services:
     hostname: k8s-env
     privileged: true
     environment:
-      BANK: ${BANK:-ckad-mock-01}
+      # No default, deliberately. This used to read ${BANK:-ckad-mock-01},
+      # which meant a bare `./sim up` built one specific exam's cluster and
+      # seeded one specific exam's questions before anyone had chosen
+      # anything — and every other exam then cost a destructive rebuild of
+      # work nobody asked for. Empty means "no exam yet": k8s-env rests
+      # after its two exam-independent phases and the environment is built
+      # when a candidate picks one. `./sim up <bank>` still sets it.
+      BANK: ${BANK:-}
     ports:
       # The host end of the host -> cluster chain (see kind-config.yaml).
       # 80/443 inside this container are the kind control-plane node's
@@ -82,9 +89,14 @@ services:
     build: images/instance
     hostname: instance-1
     environment:
-      BANK: ${BANK:-ckad-mock-01}
-    depends_on:
-      k8s-env: {condition: service_healthy}
+      BANK: ${BANK:-}
+    # No depends_on, for the same reason the facilitator has none (see
+    # its comment below), now extended one step further. `service_healthy`
+    # makes `docker compose up` BLOCK until /shared/ready exists — and
+    # with no exam chosen it never does, so a bare `./sim up` would hang
+    # forever waiting for a cluster nobody asked for. The entrypoint's own
+    # wait is the real gate and always was: it waits for the kubeconfig
+    # and the ssh key, which is what this container actually needs.
     volumes:
       - shared:/shared:ro
       - ./banks:/banks:ro
@@ -113,9 +125,8 @@ services:
     build: images/instance
     hostname: instance-2
     environment:
-      BANK: ${BANK:-ckad-mock-01}
-    depends_on:
-      k8s-env: {condition: service_healthy}
+      BANK: ${BANK:-}
+    # See instance-1.
     volumes:
       - shared:/shared:ro
       - ./banks:/banks:ro
@@ -158,7 +169,7 @@ services:
     build: proxy
     hostname: docs-proxy
     environment:
-      BANK: ${BANK:-ckad-mock-01}
+      BANK: ${BANK:-}
     volumes:
       - ./banks:/banks:ro
       - shared:/shared:ro
@@ -168,7 +179,11 @@ services:
     build: images/desktop
     hostname: desktop
     depends_on:
-      k8s-env: {condition: service_healthy}
+      # docs-proxy only. The k8s-env health gate came off for the same
+      # reason as the instances': it would block `up` on a cluster that
+      # does not exist until an exam is chosen. This container's own wait
+      # for the shared ssh key is unbounded and it carries
+      # `restart: unless-stopped`, so it simply sits until there is one.
       docs-proxy: {condition: service_started}
     volumes:
       - shared:/shared:ro
@@ -207,7 +222,7 @@ services:
     ports:
       - "${SIM_BIND:-0.0.0.0}:8080:8080"
     environment:
-      BANK: ${BANK:-ckad-mock-01}
+      BANK: ${BANK:-}
       SESSION_DURATION_OVERRIDE: ${SESSION_DURATION_OVERRIDE:-}
     volumes:
       - ./banks:/banks:ro

--- a/docs/api.md
+++ b/docs/api.md
@@ -125,11 +125,13 @@ and the three selectable modes. Always 200.
   "durationSeconds": 7200,
   "passingScore": 66,
   "kubernetesVersion": "1.35",
+  "questionCount": 22,
+  "hasTips": true,
   "questions": [
     {"id": "q01", "instance": "instance-1", "domain": "Application Environment, Configuration and Security", "weight": 9, "totalPoints": 9, "hintCount": 2, "targetSeconds": 360, "targetDerived": true}
   ],
   "domains": [
-    {"name": "Application Environment, Configuration and Security", "weightPct": 25, "questionCount": 5}
+    {"name": "Application Environment, Configuration and Security", "weightPct": 25, "questionCount": 6}
   ],
   "modes": [
     {"id": "training", "durationSeconds": 0, "untimed": true, "helpAllowed": true, "gradesPerTask": true, "recorded": false, "recommended": false},
@@ -204,7 +206,39 @@ worth 44% and hold three questions.
 above is narrowed to the drawn subset once an attempt starts
 (`facilitator/internal/api/api.go:313-320`). Counting `questions` by
 domain instead would show a candidate the questions they already drew as
-if they were the whole curriculum.
+if they were the whole curriculum. `questionCount` is the exam's declared
+length — `spec.examLength` for a pooled bank, otherwise the pool size —
+and is what any display of "how many questions" must read, since
+`questions` still lists the whole pool before an attempt has drawn.
+
+`hasTips` says the bank ships a `tips.md`, i.e. that
+[`GET /api/exam/tips`](#get-apiexamtips) has something to serve. Omitted
+when it does not; the client draws no entry point at all in that case,
+because a control that opens an empty sheet is worse than none.
+
+### GET /api/exam/tips
+
+The active bank's `tips.md` — how to sit *this* exam quickly, read from
+disk per request so editing it needs no restart.
+
+```json
+{"markdown": "# Exam tips\n\n..."}
+```
+
+**Ungated, deliberately**, where
+[`/solution`](#get-apiquestionsidsolution) and
+[`/hints/{n}`](#get-apiquestionsidhintsn) are not. Those two carry
+answers, which is what an exam exists to withhold; this carries technique
+— aliases, generators, `kubectl explain`, where to look when a Pod will
+not start — which is the same advice before, during and after an attempt
+and is most useful before one. No mode is consulted and no attempt need
+exist.
+
+| Code | When |
+|---|---|
+| 200 | The bank ships a `tips.md`. |
+| 404 | It does not. Ask `hasTips` on `GET /api/exam` first; this is the honest answer for anything that asks anyway. |
+| 503 | No exam is loaded — the shell is up and nothing has been chosen (`facilitator/internal/api/history.go`, `requireExam`). |
 
 ### GET /api/questions/{id}
 
@@ -960,7 +994,7 @@ history still has a bank list).
       "durationSeconds": 7200,
       "passingScore": 66,
       "questionCount": 22,
-      "poolCount": 22,
+      "poolCount": 26,
       "available": true,
       "progress": {
         "attempts": 3,
@@ -1165,7 +1199,7 @@ The exam catalog the exam selector renders. Always 200.
 {
   "active": "ckad-mock-01",
   "banks": [
-    {"id": "ckad-mock-01", "title": "CKAD Mock Exam 01", "certification": "CKAD", "description": "Developer-track exercises...", "examType": "hands-on", "durationSeconds": 7200, "passingScore": 66, "kubernetesVersion": "1.35", "questionCount": 22, "poolCount": 22, "available": true},
+    {"id": "ckad-mock-01", "title": "CKAD Mock Exam 01", "certification": "CKAD", "description": "Developer-track exercises...", "examType": "hands-on", "durationSeconds": 7200, "passingScore": 66, "kubernetesVersion": "1.35", "questionCount": 22, "poolCount": 26, "available": true},
     {"id": "kcna-mock", "title": "KCNA Mock Exam", "certification": "KCNA", "description": "65 questions drawn each attempt...", "examType": "mcq", "durationSeconds": 5400, "passingScore": 75, "questionCount": 65, "poolCount": 97, "available": true},
     {"id": "cks-mock", "title": "CKS Mock Exam", "certification": "CKS", "examType": "hands-on", "available": false, "comingSoon": true, "note": "Requires security add-ons not in the kind environment yet"}
   ]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,7 +63,7 @@ diagram can reach the internet.
 
 | Service | Build | What it does | Privilege |
 |---|---|---|---|
-| `k8s-env` | `images/k8s-env` | Runs Docker-in-Docker, hosts the two-node kind cluster, serves the local Helm repository on :8879, and runs the boot sequence. | `privileged: true` |
+| `k8s-env` | `images/k8s-env` | Runs Docker-in-Docker, hosts the kind cluster (sized by the active bank's `spec.environment.nodes`), serves the local Helm repository on :8879, and runs the boot sequence. | `privileged: true` |
 | `instance-1`, `instance-2` | `images/instance` | The two shells the candidate works in. sshd, kubectl, helm, podman, and per-question working directories under `/opt/course`. | Five capabilities, `cgroup: host`, writable `/sys/fs/cgroup`, `/dev/fuse`, seccomp and apparmor unconfined |
 | `registry` | `registry:2` image | Plain-HTTP push target at `registry:5000` for the image-building questions. | none |
 | `docs-proxy` | `proxy` | HTTP proxy on :3128 enforcing the documentation allowlist for the desktop's Firefox. | none |
@@ -144,9 +144,9 @@ Pod cannot restart a container under `restartPolicy: Never`, so reset
 and switch return 501 before touching anything
 (`conductor/internal/control/control.go:192,299`); re-seeding is Training
 mode only and the conductor asks the facilitator, not the caller
-(`reseed.go`); and `seed` fires only for a pooled bank, of which the tree
-has none. The socket is what keeps that list from having to stay
-complete — an endpoint added later without its own gate is not
+(`reseed.go`); and `seed` fires only for a pooled bank, which
+`ckad-mock-01` now is. The socket is what keeps that list from having to
+stay complete — an endpoint added later without its own gate is not
 reachable in the first place.
 
 The conductor speaks the Docker Engine API directly over the socket
@@ -395,14 +395,19 @@ re-seeding would overwrite candidate work
 
 ### Where seeding happens, and why it can move
 
-For every bank in this repo, seeding happens at boot, in phase 7, inside
-the progress screen a cold start already shows. A **pooled** hands-on bank
+For an unpooled hands-on bank, seeding happens at boot, in phase 7,
+inside the progress screen a cold start already shows. A **pooled** one
 (`spec.examLength`, see [bank-spec.md](bank-spec.md)) cannot work that way:
 which questions an attempt asks is decided by the draw, and the draw
 happens when the candidate presses Start. So its boot skips the seed loop
 and the drawn questions are seeded then instead — `POST /api/session/start`
 answers 202, the facilitator asks the conductor for a `seed` job, and the
 clock does not start until that job succeeds.
+
+`ckad-mock-01` takes that path — it draws 22 of 26 — so a CKAD boot is
+now materially shorter than it was and the wait moves to the moment Start
+is pressed. The images are still pulled at boot, which is the slow and
+network-fragile half and is identical whichever questions get drawn.
 
 That is the facilitator's **second** server-side call to the conductor,
 after the bank-list fetch behind `GET /api/catalog`, and the first one that

--- a/docs/bank-spec.md
+++ b/docs/bank-spec.md
@@ -1,7 +1,8 @@
 # Question bank specification (v1alpha2)
 
-A bank lives at `banks/<bank-id>/` and holds `exam.yaml` plus one directory
-per question. The conductor scans every `banks/*/exam.yaml` into the catalog
+A bank lives at `banks/<bank-id>/` and holds `exam.yaml`, one directory
+per question, and optionally a [`tips.md`](#exam-tips-banksbank-idtipsmd).
+The conductor scans every `banks/*/exam.yaml` into the catalog
 the exam selector renders; [banks/catalog.yaml](../banks/catalog.yaml) adds
 coming-soon entries whose exam engine does not exist yet.
 
@@ -99,7 +100,8 @@ stopped looking.
 | `spec.kubernetesVersion` | Informational; shown on the catalog card |
 | `spec.domainWeights` | The certification's published weights, and a runtime value in three places: `exam.Load` builds `Exam.Domains` from it, `exam.Draw` stratifies a pooled or filtered draw by it, and both graders weight the final score by it. [bank-weights.sh](../tests/bank-weights.sh) still gates it too. Getting it wrong now moves real scores, not just a build check |
 | `spec.examLength` | Optional, **both engines**. Pools the bank: author more questions than one attempt should ask, set this to the smaller per-attempt count, and `exam.Draw` takes a fresh domain-stratified subset every start. Must be positive and no larger than the pool — `exam.Load` rejects both, because an `examLength` typo that silently turns pooling *off* is worse than one that fails the boot. A pooled bank must declare `spec.domainWeights`; the draw stratifies against them and errors without. Absent or `>=` the pool means no pooling, which is every bank in this repo. **A pooled hands-on bank also changes when its cluster is seeded** — see below |
-| `spec.environment.provider`, `.nodes` | Informational; read by nothing |
+| `spec.environment.nodes` | **The size of this exam's cluster.** [bootstrap.sh](../images/k8s-env/bootstrap.sh) copies `kind-config.yaml` — which holds the control-plane node and nothing else — and appends one `- role: worker` per extra node before `kind create cluster`. Absent means 2; anything that is not a positive integer fails the boot rather than falling back, because a cluster silently the wrong size is discovered by a drain question grading zero. Also served on `GET /api/exam` so the screens that describe the environment while it builds describe the one being built |
+| `spec.environment.provider` | Informational; `kind` is the only one that exists. Served on `GET /api/exam` beside `nodes` |
 | `spec.environment.allowedDomains` | Domain suffixes the desktop browser may reach through the docs proxy, subdomains included ([proxy/entrypoint.sh](../proxy/entrypoint.sh)). Omit it to inherit `allow.DefaultDomains` ([allow.go](../proxy/internal/allow/allow.go)), the smallest set that leaves the documentation sites usable |
 | `spec.instances` | 1 or 2 entries. Convention: names outside `instance-1`/`instance-2` only mark the bank unavailable in the exam selector ([catalog.go:218-230](../conductor/internal/catalog/catalog.go)), and the facilitator's exam loader never parses the block at all |
 | `spec.questions[].id`, `.instance` | Question directory name, and the ssh host the grader runs its checks on |
@@ -173,12 +175,44 @@ the drawn questions are seeded when the attempt starts instead:
 and the candidate's clock does not begin until that job succeeds. See
 [api.md](api.md) for the contract.
 
-The consequence for an author: pooling is a good trade when the pool is
-much larger than an attempt, and a bad one when it is not. A bank that
-pools 22 down to 20 has moved four minutes of seeding out of the boot
-screen and into the moment the candidate presses Start, and gained almost
-no variety for it. Neither shipped bank pools its hands-on questions;
-CKAD draws all 22.
+The consequence for an author: pooling for VARIETY is a good trade when
+the pool is much larger than an attempt, and a bad one when it is not. A
+bank that pools 22 down to 20 has moved four minutes of seeding out of
+the boot screen and into the moment the candidate presses Start, and
+gained almost no variety for it.
+
+`ckad-mock-01` pools 26 down to 22, and its reason is the other one:
+**holding the sitting to the right length.** The real CKAD is around
+twenty tasks in two hours, so the four questions added in this bank's
+last expansion went into the pool rather than into the exam — putting
+them in the sitting would have made it a harder exam rather than a fuller
+one. The variety that comes with it is modest and worth stating honestly:
+with a pool that close to the draw, three of its five domains are asked
+in full every time, and only Application Design and Build (4 of 7) and
+Application Observability and Maintenance (3 of 4) rotate. Deepening a
+domain widens its rotation.
+
+### Points in a pooled bank
+
+Derive them against the **pool**, exactly as an unpooled bank does:
+`domain budget / questions in that domain`, counting every authored
+question. `ckad-mock-01`'s 26 questions total 217 points that way, and
+every domain's share of them lands within one percentage point of its
+curriculum weight.
+
+What that does *not* give you is a drawn attempt whose raw points divide
+in the curriculum's ratios, and it cannot: a domain that contributes 4 of
+its 7 questions to the draw contributes 4/7 of its pool points with it.
+Two other things keep the promise instead, which is why
+[bank-weights.sh](../tests/bank-weights.sh) checks pool DEPTH here rather
+than point share:
+
+- **the draw is stratified by count**, so every attempt holds each
+  domain's published share of the *questions* — which is the candidate's
+  effort;
+- **the graders weight the final score by `spec.domainWeights`**
+  (`evaluate.Results.Finalize`) whether or not the points agree, because
+  a subset of a bank cannot inherit a promise the whole bank makes.
 
 ## Points and domain weights
 
@@ -619,6 +653,36 @@ The rest of what the gate enforces:
 
 Hints are served one tier at a time by `GET /api/questions/{id}/hints/{n}`,
 gated on the attempt being in Training mode.
+
+## Exam tips: `banks/<bank-id>/tips.md`
+
+One optional file beside `exam.yaml`, for the whole bank rather than per
+question: how to sit THIS exam quickly. Aliases and completion, the
+generators that write a manifest so nobody types one, `explain` and `-h`
+before the documentation, editor settings for YAML, what to look at when
+a Pod will not start, and when to give up on a question and move on.
+
+It is bank data, not UI copy, on the same reasoning that governs
+`spec.environment.nodes`: what makes a CKAD sitting fast is not what
+makes a KCNA one fast, and a panel of strings in the client would have to
+claim one of them was the other. CKA and CKS will each ship their own.
+
+- **Served ungated** by `GET /api/exam/tips` as `{"markdown": "…"}` —
+  unlike solutions and hints, which check the attempt's mode first.
+  Technique is not answers: the same advice is true before, during and
+  after an attempt, and it is most useful before one.
+- **Read per request**, like `question.md` and `solution.md`, so editing
+  it needs no facilitator restart. Only its existence is loaded at boot,
+  and it reaches the client as `hasTips` on `GET /api/exam`.
+- **A bank with no `tips.md` draws no control at all.** An empty file
+  counts as none, for the same reason — a control that opens an empty
+  sheet is worse than no control.
+- Rendered through the same Markdown component the questions use, so
+  fenced blocks get their copy buttons and inline backticks become
+  copyable values. Write commands as commands: the point of the page is
+  that nobody retypes them under a clock.
+- No gate script. There is nothing to cross-check — no ids, no points and
+  no answer key — and a length floor would only encourage padding.
 
 ## Attempt modes
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,7 +27,7 @@ it as `MISSING (./sim up needs it)` (`sim:119`).
 
 | Command | What it does | What it destroys |
 |---|---|---|
-| `./sim up [bank]` | `docker compose up -d --build`, then polls `/api/boot` every 3s, printing each phase as it changes, until the environment reports ready. | Nothing. |
+| `./sim up [bank]` | `docker compose up -d --build`, then polls `/api/boot`. With no bank it waits only for the shell to settle — `idle`, meaning up with nothing chosen — and returns in seconds, having built no exam environment. With a bank it waits for that exam's environment to report ready, printing each phase as it changes. | Nothing. |
 | `./sim down` | `docker compose down --remove-orphans`. Volumes survive, so the next `up` resumes the same exam — including a running attempt. | Nothing. |
 | `./sim purge` | `down`, then removes the project's volumes one at a time, skipping the one holding attempt history. | Eight volumes: the kind cluster and its image cache, `/shared` (ready marker, active bank, ssh keys), the session file, both `/opt/course` directories, both podman stores, and the exam registry. **Not** `state`. |
 | `./sim purge --all` | `down -v`. Prints what it is about to destroy first. | All nine volumes, `state` included — every attempt ever graded on this machine, with no backup and no undo. |
@@ -35,13 +35,49 @@ it as `MISSING (./sim up needs it)` (`sim:119`).
 | `./sim reset` | POSTs `/api/control/reset` and polls `/api/control/status` until the job settles. Same code path as the UI's New attempt button. | The session, both instances' work directories and podman stores, the exam registry's contents, and the kind cluster. |
 | `./sim ssh [instance]` | `docker compose exec <instance> su - candidate`, defaulting to `instance-1`. | Nothing. |
 | `./sim status` | `docker compose ps`. | Nothing. |
-| `./sim grade` | Runs the facilitator's session-free scoreboard against the environment as it stands (`docker compose exec facilitator /entrypoint.sh grade`). Hands-on banks only: an mcq bank's answers live in the session, not the cluster, so `grade` refuses with a pointer to the UI/API rather than printing a misleading 0%. | Nothing. It records no result and touches no session state. |
+| `./sim grade` | Runs the facilitator's read-only scoreboard against the environment as it stands (`docker compose exec facilitator /entrypoint.sh grade`). Scores the whole bank, or — on a [pooled](bank-spec.md#pooling-a-bank-specexamlength) one — the open attempt's drawn subset, since the questions it did not draw were never seeded. Hands-on banks only: an mcq bank's answers live in the session, not the cluster, so `grade` refuses with a pointer to the UI/API rather than printing a misleading 0%. | Nothing. It records no result and writes no session state. |
 | `./sim help` | Prints the usage string. It is also the default with no argument (`sim:4`), and what an unknown subcommand prints before exiting 1 (`sim:176`). | Nothing. |
+
+### grade
+
+The scoreboard reads the session file to find out which questions the
+open attempt asks, and scores those. On every unpooled bank that changes
+nothing — the whole bank is seeded at boot, so the attempt and the bank
+are the same set — and with no attempt open it falls back to the whole
+bank, which is what it has always done.
+
+It matters on a pooled bank. `ckad-mock-01` draws 22 of 26 and only the
+drawn questions are ever seeded, so scoring the pool would score four
+questions whose Namespaces do not exist and cannot: a perfect attempt
+printed **191/217 (87%)** before this scoping existed. With no attempt
+open on such a bank it says so on stderr and grades the pool anyway,
+against an environment that holds none of it.
+
+It remains a reader. It never resumes the attempt, never arms a timer and
+never writes the session file, which is what lets it run as a second
+process beside the live server.
 
 ### up
 
-The optional bank argument sets `BANK` for that compose invocation and
-nothing more — see [BANK](#bank) below.
+**Nothing is built until an exam is chosen.** A bare `./sim up` brings
+the stack up, waits for it to settle, and prints where to pick an exam.
+It waits for the boot state to reach `idle` rather than merely for the
+UI to answer: the facilitator answers within a second or two, while
+`k8s-env` still has the two exam-independent phases ahead of it (the
+inner Docker daemon, then the chart repository) and reports `booting`
+throughout. Returning there printed "Choose an exam" over a browser
+still showing a boot screen. It is seconds either way, and it never
+waits for an exam. There is no cluster, no seeded questions and no default bank:
+guessing one costs several minutes and is thrown away the moment the
+candidate picks something else. `k8s-env` rests in a new `idle` boot
+state, the facilitator serves the exam selector with no bank loaded, and
+choosing one runs the conductor's own build.
+
+Naming a bank — `./sim up ckad-mock-01` — additionally builds that
+exam's environment and blocks with the phase printout, which is what the
+smoke suite and anyone who already knows what they want are doing. The
+argument sets `BANK` for that compose invocation and nothing more — see
+[BANK](#bank) below.
 
 `up` exits 1 in two cases: `/api/boot` reported `failed`, in which case
 the error is printed verbatim (`sim:53-59`); or the boot budget elapsed
@@ -82,8 +118,9 @@ a clean machine pulls that image.
 | Variable | Default | Read at |
 |---|---|---|
 | `SIM_BIND` | `0.0.0.0` | `docker-compose.yaml:21-23`, `docker-compose.yaml:208` |
-| `SIM_BOOT_BUDGET` | `3600` | `sim:26` |
-| `BANK` | `ckad-mock-01` | `sim:24`, and every service's compose environment |
+| `SIM_BOOT_BUDGET` | `3600` | `sim` — how long `./sim up <bank>` waits for that exam's environment |
+| `SIM_SHELL_BUDGET` | `300` | `sim` — how long a bare `./sim up` waits for the shell to settle. Far smaller because it waits for a container runtime and a chart repository, never for a cluster |
+| `BANK` | unset | `sim`, and every service's compose environment. No default: nothing is built until an exam is chosen |
 | `PRELOAD` | `full` | `images/k8s-env/Dockerfile:94` (build arg, not runtime) |
 | `SESSION_DURATION_OVERRIDE` | unset | `facilitator/cmd/facilitator/main.go:91` |
 
@@ -103,12 +140,24 @@ SIM_BIND=127.0.0.1 ./sim up     # loopback only
 
 ### SIM_BOOT_BUDGET
 
-Seconds `./sim up` waits for a ready state before giving up. It bounds
-the wait, not the boot: the environment carries on building after the
-command exits 1.
+Seconds `./sim up <bank>` waits for a ready state before giving up. It
+bounds the wait, not the boot: the environment carries on building after
+the command exits 1.
 
 ```bash
-SIM_BOOT_BUDGET=7200 ./sim up
+SIM_BOOT_BUDGET=7200 ./sim up ckad-mock-01
+```
+
+### SIM_SHELL_BUDGET
+
+The same idea for a bare `./sim up`, which waits for the boot state to
+reach `idle` rather than `ready`. Much smaller by default because the
+two phases it covers are a container runtime and a chart repository —
+measured at about eight seconds — and the inner daemon has its own 180s
+deadline underneath it. It never waits for a cluster.
+
+```bash
+SIM_SHELL_BUDGET=600 ./sim up
 ```
 
 ### BANK
@@ -119,6 +168,10 @@ if it does (`images/k8s-env/bootstrap.sh:15-21`); the facilitator, the
 instances and the docs proxy all prefer that file over their `BANK`
 environment. So once the shared volume exists, the conductor owns the
 active bank and `BANK` is ignored.
+
+Unset is the normal case and not a fallback: with neither the file nor
+the variable, `start.sh` stops before the bootstrap and the environment
+waits to be told which exam to be.
 
 ```bash
 ./sim up ckad-mock-01           # same as BANK=ckad-mock-01 ./sim up

--- a/docs/follow-ups.md
+++ b/docs/follow-ups.md
@@ -13,7 +13,7 @@ change the product.
 | Divergence | Why |
 |---|---|
 | Harder than the real exam | The whole point. A candidate who passes here should be comfortable there. |
-| 22 questions against a real CKAD's 15-20 | More coverage per sitting. Point budgets still track the published curriculum weights within 2 points. |
+| 22 questions against a real CKAD's 15-20 | More coverage per sitting. Point budgets still track the published curriculum weights within 2 points. The bank authors 26 and draws 22, so the sitting stays this length as the pool grows. |
 | Two-node cluster | The real exam has more. Two is enough for scheduling, affinity and DaemonSet questions, and it is what fits in 9GB. |
 | Ingress and NodePorts published to the host | The real exam does not do this. Opening your own Ingress in a browser is a fast way to learn why it is not matching. No `validate.d` check may depend on it. |
 | The documentation allowlist has no deny-override | Permitting `kubernetes.io` necessarily permits `discuss.kubernetes.io`, which the real exam disallows. Subdomain matching is what the proxy does. |
@@ -23,6 +23,19 @@ change the product.
 
 Known, chosen, and not currently worth the cost of changing.
 
+- **The instances' `/opt/course` seeding is pooling-unaware.**
+  `images/instance/entrypoint.sh` creates a working directory per
+  question and copies each question's `files/` **for the whole pool**, at
+  container start — before any draw exists, and never again. On a pooled
+  bank that means a candidate can see `/opt/course/23` for a question
+  they were not asked, and a question that ships starting material would
+  hand it over whether or not it was drawn. Harmless today: no question
+  in `ckad-mock-01` ships a `files/` directory, so the only artefact is
+  an empty directory. It is recorded here because the fix is not small —
+  the conductor's seed job runs on `k8s-env`, which has no access to the
+  per-instance `/opt/course` volumes, which is the same reason `files/`
+  cannot come from `setup.sh` — and because the day a pooled bank ships
+  starting material, this stops being cosmetic.
 - **Podman on the instances runs with the `vfs` storage driver.** Slower
   and more disk-hungry than overlay, but it works without granting the
   instances more than the five capabilities they already hold.
@@ -81,15 +94,18 @@ Known, chosen, and not currently worth the cost of changing.
   so the UI needs no hosted branch. Two consequences, both accepted: the
   phases differ from a local reset's (there is no cluster to rebuild in
   place), and a hosted reset costs a full boot rather than a partial one.
-- **In a hosted session, seeding a pooled bank would report no
-  progress.** The hub answers `/api/control/status` and `/api/control/log`
-  from its own job store, because reset and switch are its operations and
-  the Pod they describe may not exist while they run. The conductor's one
-  remaining job type, `seed`, is triggered by the facilitator
-  server-to-server and would therefore be invisible to the browser. No
-  hands-on bank in the tree is pooled — `exam.Pooled()` is false for
-  every one — so nothing is currently affected. Recorded rather than
-  guessed at, because the first pooled hands-on bank will need this.
+- ~~**In a hosted session, seeding a pooled bank would report no
+  progress.**~~ **Closed with the per-exam seat work.** The hub still
+  answers `/api/control/status` and `/api/control/log` from its own job
+  store while one of ITS jobs is in flight — reset and switch are Pod
+  replacement, and the Pod they describe does not exist for most of the
+  time they run — but when it has none running it now asks the session
+  Pod and forwards the conductor's answer untouched. That is what makes
+  the conductor's one remaining job type, `seed`, visible: it is
+  triggered by the facilitator server-to-server, between the candidate
+  pressing Start and their clock beginning. In-flight beats settled, and
+  the hub's own settled job still wins over an idle Pod, so a failed
+  reset the candidate has not dismissed does not vanish from under them.
 - **Hosted history cannot be imported into, and reports no summary.**
   Both are refused with 501 and an explanation rather than proxied. The
   Pod's own `/state` is ephemeral by design, so a history route answered
@@ -184,5 +200,14 @@ Recorded because each has been proposed at least once and is settled.
   Struck through rather than deleted, because this entry was cited as
   settled and a reader who remembers it needs to find out it was reversed
   rather than simply not find it.
-- **`spec.environment.kubernetesVersion` and `nodes` are
-  informational.** They are surfaced to the UI and drive nothing.
+- ~~**`spec.environment.kubernetesVersion` and `nodes` are
+  informational.**~~ **`nodes` is load-bearing as of the per-exam
+  environment work.** `bootstrap.sh` generates the kind config from it —
+  `kind-config.yaml` now ships the control-plane node only, and the
+  workers are appended per the active bank — so the cluster is the size
+  the certification needs rather than the size CKAD needs. Changing it in
+  a bank changes the cluster the next build produces. `provider` and
+  `kubernetesVersion` are still informational; both are served on
+  `GET /api/exam`. Struck through rather than deleted because "read by
+  nothing" was cited as settled, and a reader who remembers it needs to
+  find out it stopped being true rather than simply not find it.

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -25,7 +25,20 @@ Two things, and the second is created and destroyed on demand:
   own Pod.
 - **A session Pod, per candidate** — the whole `./sim up` stack as a
   single Pod. Two flavours: `practical` (eight containers, a real
-  two-node cluster) and `mcq` (a facilitator and 128Mi, no cluster).
+  cluster) and `mcq` (a facilitator and 128Mi, no cluster).
+
+The candidate chooses the **certification**, not the flavour. The hub
+reads a bank index staged beside it from the banks image, so the lobby
+lists the exams themselves rather than a copy of their names in
+`values.yaml`, and the flavour is derived from the bank's own engine. A
+seat is then that one exam: the Pod is stamped and sized for it and the
+exam selector inside the session offers no other, because changing exam
+means a different environment, not a rebuild of this one.
+
+Seats stay per flavour. What a seat costs the cluster is a session Pod,
+and every hands-on exam is one, so CKAD and CKA draw from the same
+pool — see `sessions.practical.banks` below for sizing one exam's Pod
+differently from another's.
 
 The facilitator inside a session has no authentication of any kind and
 gains none. It is simply never reachable except through the hub, which
@@ -123,8 +136,11 @@ still booting and hand both of them a half-built cluster.
 
 | Value | Default | What it governs |
 |---|---|---|
-| `sessions.practical.seats` | 3 | Concurrent hands-on environments |
+| `sessions.practical.seats` | 3 | Concurrent hands-on environments, across every hands-on exam |
+| `sessions.practical.bank` | `ckad-mock-01` | The exam a hands-on session sits when the request names none. A **default**, not the exam: the lobby offers certifications and sends the chosen one |
+| `sessions.practical.banks.<id>.resources` | `{}` | Per-exam container resources, merged over `sessions.practical.resources`, which is itself merged over the manifest. For an exam whose cluster is a different size |
 | `sessions.mcq.seats` | 30 | Concurrent multiple-choice sessions |
+| `sessions.mcq.bank` | `kcna-mock` | As above, for the multiple-choice pool |
 | `sessions.maxAge` | `10h` | The hard cap. A seat is taken back at it |
 | `sessions.idleTimeout` | `30m` | No request from the browser for this long and the seat goes back |
 | `sessions.queueHold` | `2m` | How long the head of the queue has to claim a seat |
@@ -146,6 +162,13 @@ manifest declares them: **3.9Gi / 540m requested, 11.8Gi / 4400m
 limit**. The per-container numbers are measured and live in
 `deploy/helm/kubestronaut-sim/files/session-pod.yaml`; override them
 through `sessions.practical.resources` rather than editing that file.
+
+Those numbers were measured on a two-node cluster. An exam whose bank
+asks for more nodes needs more, and
+`sessions.practical.banks.<id>.resources` is where it goes: the chart
+renders that exam its own Pod manifest and the hub stamps it out for
+sessions on that bank only. Seats are unaffected — one pool, one queue,
+a differently sized Pod in it.
 
 The limits are deliberately far above the requests, which means seats
 are overcommitted: three sessions request 11.8Gi and could in principle

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -159,13 +159,16 @@ testing what it claims to the day one does.
 | The docs-proxy allowlist: `kubernetes.io` and `code.jquery.com` allowed, `example.com`, analytics and open web search blocked, no direct egress from the desktop | tests/smoke.sh:210-231 |
 | The conductor unreachable from the host and the desktop, reachable only through `/api/control/*` | tests/smoke.sh:240-248 |
 | Session lifecycle: start, a countdown that decreases, desktop unlock, submit, results polling, and the solution and desktop gates re-locking | tests/smoke.sh:347-508 |
-| Solving all 22 questions of ckad-mock-01, each on the instance its `exam.yaml` entry names | tests/smoke.sh:428-453 |
+| Solving every question the attempt DREW (22 of ckad-mock-01's 26), each on the instance its `exam.yaml` entry names, plus a check that no pool question lacks a solution script | tests/smoke.sh, `solve_bank` |
 | Warm restart keeping the score, and `./sim reset` returning it to 0 with `/opt/course` re-created empty | tests/smoke.sh:510-531 |
 | A bank round trip, CKAD to the hidden `smoke-01` fixture and back, including its one question and the fixture staying out of the exam selector's list | tests/smoke.sh:539-635 |
 | Switching to a coming-soon certification refused with 400 | tests/smoke.sh:563-571 |
 | A bank id or question id that is not a slug refused with 400, so neither reaches a filesystem path | tests/smoke.sh:572-576, tests/smoke.sh:926-928 |
 | The mcq engine on kcna-mock: a blank attempt grading 0, a partial one, full marks against the attempt's own drawn subset, and the answer gates | tests/smoke.sh:637-883 |
 | Training mode: hint tiers served one at a time, solutions readable mid-attempt, a practice grade that never becomes a result — and every one of those endpoints 403 in an exam attempt | tests/smoke.sh:885-956 |
+| The pooled hands-on path, which no unit test can reach: a boot that seeds nothing, `POST /api/session/start` answering 202, the conductor's seed job, a clock that starts only once it succeeds, and `/api/exam` narrowing from the 26-question pool to the drawn 22 | tests/smoke.sh, `start_session` |
+| Re-seeding an IDENTICAL draw is allowed without a rebuild — the exam-gate attempt replays the training attempt's seed, which is the documented retry path and the only way a second attempt is permitted on a pooled bank | tests/smoke.sh, exam-gate block |
+| `GET /api/exam/tips` answering with no attempt running AND mid-exam, beside the hint and solution routes refusing — the one place the ungated/gated distinction is exercised against a real facilitator | tests/smoke.sh |
 | A session expiring unattended and re-locking the desktop | tests/smoke.sh:958-986 |
 
 CKA is covered only as an assertion that switching to it is refused.

--- a/facilitator/cmd/facilitator/grader.go
+++ b/facilitator/cmd/facilitator/grader.go
@@ -46,7 +46,15 @@ type grader struct {
 // newGrader returns a grader for ex, scoring against bank ex.Name (the
 // bank id evaluate.Grade needs to build each check's remote command).
 func newGrader(ex *exam.Exam, mgr *session.Manager, runner evaluate.Runner, timeout time.Duration) *grader {
-	return &grader{ex: ex, bank: ex.Name, mgr: mgr, runner: runner, timeout: timeout}
+	// ex is nil when no exam has been chosen. Nothing can be graded then —
+	// there is no attempt to grade and no way to start one — so this is
+	// constructed inert rather than not constructed at all, which keeps
+	// the wiring below it identical in both cases.
+	bank := ""
+	if ex != nil {
+		bank = ex.Name
+	}
+	return &grader{ex: ex, bank: bank, mgr: mgr, runner: runner, timeout: timeout}
 }
 
 // Grade kicks an asynchronous grading run unless one is already in

--- a/facilitator/cmd/facilitator/main.go
+++ b/facilitator/cmd/facilitator/main.go
@@ -1,5 +1,5 @@
 // Command facilitator serves the exam session HTTP API (and, in its
-// `grade` argv form, a session-free scoring run). docs/api.md is the
+// `grade` argv form, a read-only scoring run). docs/api.md is the
 // current reference; the original design is frozen at
 // docs/history/specs/2026-07-24-milestone-c-facilitator-design.md.
 package main
@@ -61,15 +61,15 @@ func loadExamConfig() examConfig {
 	}
 }
 
-// runGrade implements the session-free `facilitator grade` subcommand:
-// load the exam, grade it synchronously over the real ssh Runner, print
-// the grade.sh-parity scoreboard to stdout, done. No session file, no
-// HTTP server.
+// runGrade implements the `facilitator grade` subcommand: load the exam,
+// grade it synchronously over the real ssh Runner, print the
+// grade.sh-parity scoreboard to stdout, done. No HTTP server, and no
+// session state is written — this only ever reads.
 //
 // An mcq exam has no cluster to inspect — the only answer sheet is the
-// live session's stored selections, which this session-free path
-// deliberately does not read. Refusing beats grading an empty answer map
-// and printing a misleading 0%.
+// live session's stored selections, and scoring those is the running
+// server's job. Refusing beats grading an empty answer map and printing
+// a misleading 0%.
 func runGrade() error {
 	cfg := loadExamConfig()
 
@@ -82,11 +82,50 @@ func runGrade() error {
 	}
 
 	runner := evaluate.NewSSHRunner(cfg.sshKey)
-	// No session, so no drawn subset: this path grades the whole bank,
-	// which is the only thing it can mean without one.
-	res := evaluate.Grade(ex, ex.Name, runner, checkTimeout, nil)
+	res := evaluate.Grade(ex, ex.Name, runner, checkTimeout, gradeScope(ex))
 	fmt.Print(res.Scoreboard())
 	return nil
+}
+
+// gradeScope returns the question ids `facilitator grade` should score,
+// or nil for "the whole bank" — which is what evaluate.Grade reads an
+// empty list as, and what every unpooled bank gets.
+//
+// This subcommand used to be session-free on principle, and for an
+// unpooled bank the principle and the answer agree: every question in
+// the bank is seeded at boot, so scoring all of them IS scoring the
+// exam. A POOLED bank breaks that. Only the drawn subset is ever seeded,
+// so the questions left out cannot pass and cannot be made to — and
+// grading the pool anyway prints a confident, wrong number: a perfect
+// CKAD attempt scored 191/217 (88%) rather than 100%, on a cluster where
+// every task the candidate was actually set had been done correctly.
+//
+// So the scope comes from the attempt when there is one. Best-effort in
+// every direction, because this is a scoreboard and not the grader of
+// record: an unreadable session file, an idle session, or a bank that
+// does not pool all fall back to the whole bank, which is the behaviour
+// this command has always had.
+func gradeScope(ex *exam.Exam) []string {
+	if !exam.Pooled(ex) {
+		return nil
+	}
+	ids, err := session.DrawnIDs(envOr("SESSION_FILE", "/session/session.json"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr,
+			"grade: %s draws %d of its %d questions per attempt, and this attempt could not be read (%v);\n"+
+				"       scoring the whole bank instead, so questions no attempt drew will score 0\n",
+			ex.Name, ex.ExamLength, len(ex.Questions), err)
+		return nil
+	}
+	if len(ids) == 0 {
+		fmt.Fprintf(os.Stderr,
+			"grade: %s draws %d of its %d questions per attempt and no attempt is open,\n"+
+				"       so no question has been seeded; scoring the whole bank against an\n"+
+				"       environment that holds none of it\n",
+			ex.Name, ex.ExamLength, len(ex.Questions))
+		return nil
+	}
+	return ids
 }
 
 // runServer wires every package into the long-running facilitator HTTP
@@ -121,22 +160,42 @@ func runServer() error {
 		log.Printf("ssh key not usable yet (%v); grading will fail until the environment finishes starting", err)
 	}
 
-	ex, err := exam.Load(cfg.examJSON, cfg.bankDir)
-	if err != nil {
-		return fmt.Errorf("load exam: %w", err)
-	}
+	// No exam is a legitimate state, not a failure.
+	//
+	// An environment that has not been told which exam to be has no bank
+	// to load, and the screen where the candidate chooses one is served by
+	// this process — so refusing to start without one would mean the only
+	// route to picking a bank required a bank to already be picked. The
+	// entrypoint leaves EXAM_JSON empty in that case; `ex` stays nil, and
+	// every handler that needs an exam answers 503 rather than assuming
+	// one (see internal/api).
+	//
+	// A NAMED bank that will not load is still fatal. That is a broken
+	// bank or a bad mount, and serving a catalog while silently ignoring
+	// the exam someone explicitly asked for would hide it.
+	var ex *exam.Exam
+	var dur time.Duration
+	if cfg.examJSON != "" {
+		loaded, err := exam.Load(cfg.examJSON, cfg.bankDir)
+		if err != nil {
+			return fmt.Errorf("load exam: %w", err)
+		}
+		ex = loaded
 
-	dur, err := resolveDuration(ex.Duration, durOverride)
-	if err != nil {
-		return fmt.Errorf("parse SESSION_DURATION_OVERRIDE: %w", err)
-	}
-	ex.Duration = dur
-	// The override is a test knob ("end this attempt in 20s"), so it has
-	// to reach every timed mode — a speed attempt still running for an
-	// hour under SESSION_DURATION_OVERRIDE=20s would be a trap. Training
-	// is deliberately untouched: it has no clock to override.
-	if durOverride != "" {
-		ex.SpeedDuration = dur
+		dur, err = resolveDuration(ex.Duration, durOverride)
+		if err != nil {
+			return fmt.Errorf("parse SESSION_DURATION_OVERRIDE: %w", err)
+		}
+		ex.Duration = dur
+		// The override is a test knob ("end this attempt in 20s"), so it
+		// has to reach every timed mode — a speed attempt still running
+		// for an hour under SESSION_DURATION_OVERRIDE=20s would be a trap.
+		// Training is deliberately untouched: it has no clock to override.
+		if durOverride != "" {
+			ex.SpeedDuration = dur
+		}
+	} else {
+		log.Printf("no exam selected; serving the exam selector until one is chosen")
 	}
 
 	// onExpire must be wired into session.New before the grader that
@@ -149,8 +208,14 @@ func runServer() error {
 	// see session.New's doc comment on the load-time-expiry case).
 	// The active bank id comes from the entrypoint (ACTIVE_BANK, derived
 	// from /shared/bank); ex.Name matches it by bank convention and is
-	// the natural fallback for direct/dev runs.
-	activeBank := envOr("ACTIVE_BANK", ex.Name)
+	// the natural fallback for direct/dev runs. With no exam loaded it is
+	// empty, which is the right identity for a session manager that will
+	// refuse to start anything: a persisted session belonging to a real
+	// bank is then correctly not resumed into a bank-less process.
+	activeBank := os.Getenv("ACTIVE_BANK")
+	if activeBank == "" && ex != nil {
+		activeBank = ex.Name
+	}
 
 	var onExpire atomic.Pointer[func()]
 	mgr, err := session.New(sessionFile, activeBank, dur, time.Now, func() {

--- a/facilitator/entrypoint.sh
+++ b/facilitator/entrypoint.sh
@@ -10,8 +10,27 @@ set -eu
 if [ -f /shared/bank ]; then
   BANK=$(cat /shared/bank)
 fi
-yq -o=json '.' "/banks/${BANK}/exam.yaml" > /tmp/exam.json
-export EXAM_JSON=/tmp/exam.json
-export BANK_DIR="/banks/${BANK}"
-export ACTIVE_BANK="${BANK}"
+
+# No exam chosen yet is a normal state, not a failure.
+#
+# This used to interpolate $BANK unconditionally under `set -eu`, so an
+# unset one killed the wrapper before the binary ever ran — and with
+# `restart: unless-stopped` on the service, that is an invisible restart
+# loop with nothing on :8080. It has to survive it now: the exam selector
+# this facilitator serves is exactly where the candidate goes to choose
+# the bank, so refusing to start until one exists cannot work.
+#
+# The three variables are left empty and the binary decides what to do
+# with that (facilitator/cmd/facilitator/main.go).
+if [ -n "${BANK:-}" ] && [ -f "/banks/${BANK}/exam.yaml" ]; then
+  yq -o=json '.' "/banks/${BANK}/exam.yaml" > /tmp/exam.json
+  export EXAM_JSON=/tmp/exam.json
+  export BANK_DIR="/banks/${BANK}"
+  export ACTIVE_BANK="${BANK}"
+elif [ -n "${BANK:-}" ]; then
+  # Named a bank that is not there. Distinct from choosing none, and
+  # worth saying out loud: it is a typo or a bad mount, not a state the
+  # product has.
+  echo "facilitator: bank '${BANK}' has no /banks/${BANK}/exam.yaml; starting with no exam loaded" >&2
+fi
 exec /facilitator "$@"

--- a/facilitator/internal/api/api.go
+++ b/facilitator/internal/api/api.go
@@ -120,6 +120,12 @@ func New(ex *exam.Exam, bankDir string, mgr *session.Manager, grade Grader, desk
 	mux.HandleFunc("GET /healthz", handleHealthz)
 	mux.HandleFunc("GET /api/boot", s.handleBoot)
 	mux.HandleFunc("GET /api/exam", s.handleExam)
+	// Ungated, unlike solutions and hints. Technique is not answers: what
+	// this serves is how to drive kubectl and an editor quickly, which is
+	// the same advice before, during and after an attempt, and is most
+	// useful before one. Registering it beside the gated routes rather
+	// than under them is the whole distinction.
+	mux.HandleFunc("GET /api/exam/tips", s.handleExamTips)
 	mux.HandleFunc("GET /api/questions/{id}", s.handleQuestion)
 	mux.HandleFunc("GET /api/questions/{id}/solution", s.handleSolution)
 	mux.HandleFunc("GET /api/questions/{id}/hints/{n}", s.handleHint)
@@ -205,6 +211,12 @@ type examResponse struct {
 	// pooled bank is larger than the exam a candidate will actually get.
 	QuestionCount int                `json:"questionCount"`
 	Questions     []examQuestionInfo `json:"questions"`
+	// Environment is the cluster this bank is sat in, so a screen that
+	// describes the environment can describe the one being built rather
+	// than the one CKAD happens to use. Omitted entirely for a bank that
+	// declares none — an mcq exam has no cluster, and "0 nodes" is a
+	// worse answer than no answer.
+	Environment *environmentInfo `json:"environment,omitempty"`
 	// Modes the lobby renders its picker from, so the three cards are
 	// described by the server rather than hardcoded in the UI.
 	Modes []examMode `json:"modes"`
@@ -214,6 +226,18 @@ type examResponse struct {
 	// Questions is that attempt's drawn subset, and counting it by domain
 	// would present the drawn questions as if they were the curriculum.
 	Domains []domainInfo `json:"domains"`
+	// HasTips says whether GET /api/exam/tips has anything to serve, so a
+	// bank that ships no tips.md draws no control rather than one that
+	// opens empty. Omitted when false: absent and false are the same
+	// answer, and every client already treats a missing field as no.
+	HasTips bool `json:"hasTips,omitempty"`
+}
+
+// environmentInfo is spec.environment as the UI sees it: what builds the
+// cluster and how many nodes it has.
+type environmentInfo struct {
+	Provider string `json:"provider,omitempty"`
+	Nodes    int    `json:"nodes,omitempty"`
 }
 
 // domainInfo is one curriculum domain of the loaded exam.
@@ -282,6 +306,9 @@ type examQuestionInfo struct {
 }
 
 func (s *server) handleExam(w http.ResponseWriter, r *http.Request) {
+	if !s.requireExam(w) {
+		return
+	}
 	pool := s.questionsForExamResponse()
 	resp := examResponse{
 		Name:              s.ex.Name,
@@ -292,9 +319,13 @@ func (s *server) handleExam(w http.ResponseWriter, r *http.Request) {
 		PassingScore:      s.ex.PassingScore,
 		KubernetesVersion: s.ex.KubernetesVersion,
 		QuestionCount:     s.declaredQuestionCount(),
+		HasTips:           s.ex.HasTips,
 		// Pre-sized (not nil) so an exam with zero questions still
 		// marshals Questions as JSON "[]" rather than "null".
 		Questions: make([]examQuestionInfo, 0, len(pool)),
+	}
+	if env := s.ex.Environment; env.Provider != "" || env.Nodes > 0 {
+		resp.Environment = &environmentInfo{Provider: env.Provider, Nodes: env.Nodes}
 	}
 	for _, q := range pool {
 		info := examQuestionInfo{
@@ -333,6 +364,39 @@ func (s *server) handleExam(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// tipsResponse is the GET /api/exam/tips JSON shape. One markdown body,
+// with no id beside it: tips belong to the bank, not to a question.
+type tipsResponse struct {
+	Markdown string `json:"markdown"`
+}
+
+// handleExamTips serves the loaded bank's tips.md.
+//
+// Deliberately ungated. The solution and hint handlers check the
+// attempt's mode before they will answer, because reading an answer
+// during an exam is the thing an exam is for stopping; this is the
+// opposite errand. It is technique — aliases, generators, `explain`,
+// where to look when a Pod will not start — none of which is specific to
+// a question, and all of which is most useful in the minutes BEFORE the
+// clock starts.
+//
+// Read from disk per request rather than cached at load, exactly as
+// question.md and solution.md are, so editing the file needs no restart.
+// A bank with no tips.md answers 404: the client already knows from
+// GET /api/exam's hasTips whether to ask, and this is the honest answer
+// for anything that asks anyway.
+func (s *server) handleExamTips(w http.ResponseWriter, r *http.Request) {
+	if !s.requireExam(w) {
+		return
+	}
+	md, err := os.ReadFile(exam.TipsPath(s.bankDir))
+	if err != nil {
+		writeJSONError(w, http.StatusNotFound, "this exam ships no tips")
+		return
+	}
+	writeJSON(w, http.StatusOK, tipsResponse{Markdown: string(md)})
 }
 
 // totalPoints sums the Points of every check in q that Load did not
@@ -426,6 +490,14 @@ func (s *server) questionsForExamResponse() []exam.Question {
 // The second return value is false when id names no question at all, or
 // names one outside the current subset.
 func (s *server) findQuestion(id string) (exam.Question, bool) {
+	// With no exam chosen there are no questions to find. Answering here
+	// rather than at each caller keeps the solution and hint endpoints'
+	// deliberate ordering intact — both gate on session state BEFORE any
+	// id lookup so they cannot be used to enumerate ids, and a
+	// requireExam ahead of that gate would have inverted it.
+	if s.ex == nil {
+		return exam.Question{}, false
+	}
 	if ids := s.mgr.QuestionIDs(); len(ids) > 0 {
 		inSubset := false
 		for _, want := range ids {
@@ -461,6 +533,9 @@ type questionResponse struct {
 }
 
 func (s *server) handleQuestion(w http.ResponseWriter, r *http.Request) {
+	if !s.requireExam(w) {
+		return
+	}
 	id := r.PathValue("id")
 	q, ok := s.findQuestion(id)
 	if !ok {
@@ -624,6 +699,9 @@ type answerResponse struct {
 // ordering matches the solution handler: the endpoint must not double as
 // a question-id oracle for whatever state the session is in.
 func (s *server) handleAnswerPut(w http.ResponseWriter, r *http.Request) {
+	if !s.requireExam(w) {
+		return
+	}
 	if s.ex.Type != exam.TypeMCQ {
 		writeJSONError(w, http.StatusBadRequest, "not a multiple-choice exam")
 		return
@@ -785,6 +863,9 @@ type startResponse struct {
 }
 
 func (s *server) handleSessionStart(w http.ResponseWriter, r *http.Request) {
+	if !s.requireExam(w) {
+		return
+	}
 	// The facilitator answers long before the cluster is usable now, so
 	// this is the gate that stops a candidate starting a 120-minute
 	// clock against a half-built environment. Without it, "the UI came
@@ -952,6 +1033,9 @@ type startRequest struct {
 // state check comes first so the endpoint cannot double as a way to
 // enumerate question ids.
 func (s *server) handleSessionFocus(w http.ResponseWriter, r *http.Request) {
+	if !s.requireExam(w) {
+		return
+	}
 	if s.mgr.Snapshot().State != "running" {
 		writeJSONError(w, http.StatusConflict, "no attempt is running")
 		return

--- a/facilitator/internal/api/api_mcq_test.go
+++ b/facilitator/internal/api/api_mcq_test.go
@@ -102,6 +102,12 @@ func TestMCQExamResponse(t *testing.T) {
 	if strings.Contains(rec.Body.String(), `"instance"`) {
 		t.Errorf("exam response contains an instance key: %s", rec.Body.String())
 	}
+	// Nor a cluster. Absent entirely rather than zeroed: a client reading
+	// `nodes: 0` has to know to ignore it, and any copy built from it
+	// would describe a cluster that does not exist.
+	if strings.Contains(rec.Body.String(), `"environment"`) {
+		t.Errorf("exam response describes an environment an mcq exam has none of: %s", rec.Body.String())
+	}
 }
 
 func TestMCQQuestionServesOptionsNeverTheKey(t *testing.T) {

--- a/facilitator/internal/api/api_noexam_test.go
+++ b/facilitator/internal/api/api_noexam_test.go
@@ -1,0 +1,131 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"kubestronaut-sim/facilitator/internal/api"
+	"kubestronaut-sim/facilitator/internal/session"
+)
+
+// An environment that has not been told which exam to be.
+//
+// This is the state a fresh `./sim up` lands in: k8s-env rests after its
+// two exam-independent phases, no cluster exists, and the facilitator is
+// running with no bank loaded so it can serve the screen where one gets
+// chosen. Before this existed, every route below dereferenced a nil
+// *exam.Exam and the process either refused to start at all or took the
+// connection down mid-response.
+//
+// The split being pinned: routes that need a bank say 503 and say why;
+// routes that do not are unaffected; and GET /api/catalog — the one
+// route that is how a bank gets chosen — answers without one.
+func newNoExamServer(t *testing.T) http.Handler {
+	t.Helper()
+
+	// Empty bank id, exactly as main derives it when ACTIVE_BANK is unset.
+	mgr, err := session.New(t.TempDir()+"/session.json", "", 0, time.Now, func() {})
+	if err != nil {
+		t.Fatalf("session.New: %v", err)
+	}
+	grader := &fakeGrader{}
+	return api.New(nil, "", mgr, grader.Grade, fakeDesktop, fakeControl, fstest.MapFS{}, nil, nil)
+}
+
+func doNoExam(t *testing.T, h http.Handler, method, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(method, path, nil))
+	return rec
+}
+
+func TestNoExamLoadedRefusesBankRoutes(t *testing.T) {
+	h := newNoExamServer(t)
+
+	for _, tc := range []struct{ method, path string }{
+		{http.MethodGet, "/api/exam"},
+		{http.MethodPost, "/api/session/start"},
+		{http.MethodPut, "/api/session/focus"},
+		{http.MethodPut, "/api/questions/q01/answer"},
+	} {
+		rec := doNoExam(t, h, tc.method, tc.path)
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Errorf("%s %s: status = %d, want %d", tc.method, tc.path, rec.Code, http.StatusServiceUnavailable)
+		}
+		var body struct {
+			Error string `json:"error"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Errorf("%s %s: body is not JSON: %v", tc.method, tc.path, err)
+			continue
+		}
+		// A candidate reading this should learn what to do about it, so
+		// it names the action rather than reporting a missing field.
+		if body.Error == "" {
+			t.Errorf("%s %s: refused with no explanation", tc.method, tc.path)
+		}
+	}
+}
+
+// A question route must not claim a question exists, and must not
+// dereference the bank to find that out.
+func TestNoExamLoadedHasNoQuestions(t *testing.T) {
+	h := newNoExamServer(t)
+	if rec := doNoExam(t, h, http.MethodGet, "/api/questions/q01"); rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("GET /api/questions/q01: status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+	// The solution and hint gates deliberately check session state BEFORE
+	// any id lookup, so they refuse for that reason first. What matters
+	// here is only that they refuse rather than panic.
+	for _, path := range []string{"/api/questions/q01/solution", "/api/questions/q01/hints/1"} {
+		rec := doNoExam(t, h, http.MethodGet, path)
+		if rec.Code == http.StatusOK {
+			t.Errorf("GET %s: served content with no exam loaded", path)
+		}
+	}
+}
+
+// The routes that never needed a bank keep working, because the boot
+// screen and the session poller run in exactly this state.
+func TestNoExamLoadedStillServesBankIndependentRoutes(t *testing.T) {
+	h := newNoExamServer(t)
+
+	for _, path := range []string{"/api/boot", "/api/session", "/api/answers", "/healthz"} {
+		if rec := doNoExam(t, h, http.MethodGet, path); rec.Code != http.StatusOK {
+			t.Errorf("GET %s: status = %d, want 200", path, rec.Code)
+		}
+	}
+}
+
+// The catalog is how an exam gets chosen, so it is the one bank-reading
+// route that has to answer without a bank. With no conductor wired it
+// takes the degraded path — which used to build its first row entirely
+// out of the loaded exam.
+func TestNoExamLoadedStillServesTheCatalog(t *testing.T) {
+	h := newNoExamServer(t)
+
+	rec := doNoExam(t, h, http.MethodGet, "/api/catalog")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/catalog: status = %d, want 200", rec.Code)
+	}
+
+	var body struct {
+		Active string            `json:"active"`
+		Exams  []json.RawMessage `json:"exams"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("catalog body is not JSON: %v", err)
+	}
+	if body.Active != "" {
+		t.Errorf("active = %q, want empty: nothing has been chosen yet", body.Active)
+	}
+	// Never nil: an empty catalog has to marshal as [] so the selector
+	// renders an empty list rather than crashing on null.
+	if body.Exams == nil {
+		t.Error("exams marshalled as null, want []")
+	}
+}

--- a/facilitator/internal/api/api_test.go
+++ b/facilitator/internal/api/api_test.go
@@ -168,6 +168,10 @@ type examResponse struct {
 		WeightPct     int    `json:"weightPct"`
 		QuestionCount int    `json:"questionCount"`
 	} `json:"domains"`
+	Environment *struct {
+		Provider string `json:"provider"`
+		Nodes    int    `json:"nodes"`
+	} `json:"environment"`
 }
 
 func TestExam(t *testing.T) {
@@ -198,6 +202,17 @@ func TestExam(t *testing.T) {
 	}
 	if got.KubernetesVersion != "1.30" {
 		t.Errorf("KubernetesVersion = %q, want %q", got.KubernetesVersion, "1.30")
+	}
+	// The shape of the cluster this bank is sat in — the same
+	// spec.environment.nodes bootstrap.sh generates the kind config from.
+	// It is here so the screens that describe an environment while it is
+	// being built can describe THIS one instead of asserting CKAD's two
+	// nodes at a candidate sitting something else. The fixture says three
+	// precisely so a hardcoded default cannot pass.
+	if got.Environment == nil {
+		t.Errorf("Environment absent; the bank declares one")
+	} else if got.Environment.Provider != "kind" || got.Environment.Nodes != 3 {
+		t.Errorf("Environment = %+v, want provider=kind nodes=3", *got.Environment)
 	}
 	if len(got.Questions) != 2 {
 		t.Fatalf("len(Questions) = %d, want 2", len(got.Questions))

--- a/facilitator/internal/api/api_tips_test.go
+++ b/facilitator/internal/api/api_tips_test.go
@@ -1,0 +1,155 @@
+package api_test
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"kubestronaut-sim/facilitator/internal/api"
+	"kubestronaut-sim/facilitator/internal/exam"
+	"kubestronaut-sim/facilitator/internal/session"
+)
+
+const tipsBody = "# Exam tips\n\nGenerate the manifest, do not type it.\n"
+
+// bankWithTips copies the standard test bank into a temp directory and
+// drops a tips.md beside its exam definition, so the tips tests exercise
+// the same exam every other test here does.
+func bankWithTips(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.CopyFS(dir, os.DirFS(bankDir)); err != nil {
+		t.Fatalf("copy bank: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tips.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write tips.md: %v", err)
+	}
+	return dir
+}
+
+func newTipsServer(t *testing.T, bank string) *testServer {
+	t.Helper()
+	ex, err := exam.Load(examJSON, bank)
+	if err != nil {
+		t.Fatalf("exam.Load: %v", err)
+	}
+	clock, setNow := fakeClock(epoch)
+	mgr, err := session.New(t.TempDir()+"/session.json", ex.Name, ex.Duration, clock, func() {})
+	if err != nil {
+		t.Fatalf("session.New: %v", err)
+	}
+	grader := &fakeGrader{}
+	h := api.New(ex, bank, mgr, grader.Grade, fakeDesktop, fakeControl, fstest.MapFS{}, nil, nil)
+	return &testServer{handler: h, mgr: mgr, grader: grader, setNow: setNow}
+}
+
+func TestTipsAreServedVerbatimFromTheBank(t *testing.T) {
+	ts := newTipsServer(t, bankWithTips(t, tipsBody))
+
+	rec := ts.do(t, http.MethodGet, "/api/exam/tips")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/exam/tips = %d, want 200", rec.Code)
+	}
+	got := decodeJSON[struct {
+		Markdown string `json:"markdown"`
+	}](t, rec)
+	if got.Markdown != tipsBody {
+		t.Fatalf("markdown = %q, want the bank's file verbatim %q", got.Markdown, tipsBody)
+	}
+}
+
+// The whole reason this endpoint is registered beside /api/exam rather
+// than beside the solution and hint routes. Technique is not answers: it
+// is how to alias kubectl and where to look when a Pod will not start,
+// which is the same advice whatever mode the attempt is in — and it is
+// most useful before the clock starts, when there is no attempt at all.
+func TestTipsAreUngatedInEveryAttemptState(t *testing.T) {
+	bank := bankWithTips(t, tipsBody)
+
+	for _, tc := range []struct {
+		name  string
+		setup func(*testServer)
+	}{
+		{"no attempt at all", func(*testServer) {}},
+		{"an exam attempt running", func(ts *testServer) {
+			if _, err := ts.mgr.Start(session.ModeExam, 2*time.Hour); err != nil {
+				t.Fatalf("start: %v", err)
+			}
+		}},
+		{"a speed attempt running", func(ts *testServer) {
+			if _, err := ts.mgr.Start(session.ModeSpeed, time.Hour); err != nil {
+				t.Fatalf("start: %v", err)
+			}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newTipsServer(t, bank)
+			tc.setup(ts)
+			if rec := ts.do(t, http.MethodGet, "/api/exam/tips"); rec.Code != http.StatusOK {
+				t.Fatalf("GET /api/exam/tips = %d, want 200 — tips are not gated", rec.Code)
+			}
+		})
+	}
+}
+
+// The client is told once, on /api/exam, so it can decide whether the
+// control should exist at all rather than opening an empty sheet.
+func TestExamAdvertisesWhetherTheBankHasTips(t *testing.T) {
+	type examResp struct {
+		HasTips bool `json:"hasTips"`
+	}
+
+	with := newTipsServer(t, bankWithTips(t, tipsBody))
+	if got := decodeJSON[examResp](t, with.do(t, http.MethodGet, "/api/exam")); !got.HasTips {
+		t.Fatal("hasTips is false for a bank that ships tips.md")
+	}
+
+	without := newTestServer(t)
+	if got := decodeJSON[examResp](t, without.do(t, http.MethodGet, "/api/exam")); got.HasTips {
+		t.Fatal("hasTips is true for a bank with no tips.md")
+	}
+}
+
+func TestTipsAre404ForABankThatShipsNone(t *testing.T) {
+	ts := newTestServer(t)
+
+	rec := ts.do(t, http.MethodGet, "/api/exam/tips")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("GET /api/exam/tips = %d, want 404", rec.Code)
+	}
+}
+
+// An empty file would open a sheet with nothing in it, which is worse
+// than no control — so it does not count as having tips.
+func TestAnEmptyTipsFileIsNoTips(t *testing.T) {
+	ts := newTipsServer(t, bankWithTips(t, ""))
+
+	got := decodeJSON[struct {
+		HasTips bool `json:"hasTips"`
+	}](t, ts.do(t, http.MethodGet, "/api/exam"))
+	if got.HasTips {
+		t.Fatal("hasTips is true for an empty tips.md")
+	}
+}
+
+// Read per request, exactly as question.md and solution.md are, so an
+// author editing the file does not have to restart the facilitator.
+func TestTipsAreReadPerRequestRatherThanCachedAtLoad(t *testing.T) {
+	bank := bankWithTips(t, tipsBody)
+	ts := newTipsServer(t, bank)
+
+	edited := tipsBody + "\n## Pacing\n\nFlag it and move on.\n"
+	if err := os.WriteFile(filepath.Join(bank, "tips.md"), []byte(edited), 0o644); err != nil {
+		t.Fatalf("rewrite tips.md: %v", err)
+	}
+
+	got := decodeJSON[struct {
+		Markdown string `json:"markdown"`
+	}](t, ts.do(t, http.MethodGet, "/api/exam/tips"))
+	if got.Markdown != edited {
+		t.Fatalf("markdown = %q, want the edited file %q", got.Markdown, edited)
+	}
+}

--- a/facilitator/internal/api/history.go
+++ b/facilitator/internal/api/history.go
@@ -64,6 +64,24 @@ func (s *server) requireHistory(w http.ResponseWriter) bool {
 	return true
 }
 
+// requireExam answers 503 and reports false when no exam has been
+// chosen yet.
+//
+// Same shape as requireHistory above, and for a related reason: this is
+// a state the product legitimately has, not an error in it. An
+// environment starts with no exam loaded and stays that way until a
+// candidate picks one, so every route that reads the bank has to be able
+// to say so rather than dereference nil. GET /api/catalog deliberately
+// does NOT use this — the catalog is how an exam gets chosen, so it is
+// the one bank-reading route that must answer without a bank.
+func (s *server) requireExam(w http.ResponseWriter) bool {
+	if s.ex == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "no exam is loaded yet — choose one to build its environment")
+		return false
+	}
+	return true
+}
+
 func (s *server) handleHistoryGet(w http.ResponseWriter, r *http.Request) {
 	if !s.requireHistory(w) {
 		return
@@ -205,8 +223,15 @@ type catalogResponse struct {
 // you have already sat" is a far better answer than an error page. The
 // degraded rows say so themselves — see degradedBanks.
 func (s *server) handleCatalog(w http.ResponseWriter, r *http.Request) {
+	// Deliberately no requireExam. This route is how an exam is chosen,
+	// so it is the one bank-reading endpoint that has to answer when
+	// there is no bank: with no exam loaded, `active` is empty and every
+	// row comes back unchosen, which is exactly what the selector should
+	// render on a fresh environment. The bank LIST never needed the
+	// active bank anyway — it is the conductor's startup scan of
+	// banks/*/exam.yaml.
 	active := s.mgr.Snapshot().Bank
-	if active == "" {
+	if active == "" && s.ex != nil {
 		active = s.ex.Name
 	}
 
@@ -271,20 +296,29 @@ func (s *server) fetchBanks(ctx context.Context) (banksDoc, error) {
 // destructive action (switch banks, which rebuilds the cluster) the
 // thing that discovers the outage.
 func (s *server) degradedBanks(active string, progress map[string]history.ExamProgress) []bankEntry {
-	out := []bankEntry{{
-		ID:                active,
-		Title:             s.ex.Title,
-		Certification:     s.ex.Certification,
-		ExamType:          s.ex.Type,
-		DurationSeconds:   int(s.ex.Duration.Seconds()),
-		PassingScore:      s.ex.PassingScore,
-		KubernetesVersion: s.ex.KubernetesVersion,
-		QuestionCount:     bankLength(s.ex),
-		PoolCount:         len(s.ex.Questions),
-		Available:         true,
-	}}
+	// The loaded bank is the one row this build can vouch for — when
+	// there is one. With no exam chosen there is nothing to vouch for and
+	// no conductor to ask, so the list is whatever the attempt history
+	// remembers, all of it marked unavailable with its reason. An empty
+	// selector that explains itself beats a fabricated row.
+	var out []bankEntry
+	seen := map[string]bool{}
+	if s.ex != nil {
+		out = append(out, bankEntry{
+			ID:                active,
+			Title:             s.ex.Title,
+			Certification:     s.ex.Certification,
+			ExamType:          s.ex.Type,
+			DurationSeconds:   int(s.ex.Duration.Seconds()),
+			PassingScore:      s.ex.PassingScore,
+			KubernetesVersion: s.ex.KubernetesVersion,
+			QuestionCount:     bankLength(s.ex),
+			PoolCount:         len(s.ex.Questions),
+			Available:         true,
+		})
+		seen[active] = true
+	}
 
-	seen := map[string]bool{active: true}
 	for _, r := range historyRows(s.hist) {
 		if seen[r.Bank] {
 			continue

--- a/facilitator/internal/api/prepare.go
+++ b/facilitator/internal/api/prepare.go
@@ -189,6 +189,11 @@ type prepareResponse struct {
 // bank at boot, and re-running setup.sh would cost minutes to arrive
 // back where it already was.
 func (s *server) seedRequired() bool {
+	// No exam, nothing to seed. Called from New before any request, so
+	// this has to hold at construction as well as per attempt.
+	if s.ex == nil {
+		return false
+	}
 	return s.ex.Type != exam.TypeMCQ && exam.Pooled(s.ex)
 }
 

--- a/facilitator/internal/api/testdata/exam.json
+++ b/facilitator/internal/api/testdata/exam.json
@@ -10,6 +10,10 @@
     "duration": "10m",
     "passingScore": 50,
     "kubernetesVersion": "1.30",
+    "environment": {
+      "provider": "kind",
+      "nodes": 3
+    },
     "questions": [
       {
         "id": "q01",

--- a/facilitator/internal/bootstate/bootstate.go
+++ b/facilitator/internal/bootstate/bootstate.go
@@ -25,6 +25,12 @@ const (
 	StateBooting = "booting"
 	StateReady   = "ready"
 	StateFailed  = "failed"
+	// StateIdle is "up, and nothing to build yet": the container is
+	// running and no exam has been chosen, so no cluster exists. It is
+	// deliberately not a kind of booting. A boot screen narrates progress
+	// and asks the candidate to wait; this state wants the opposite, which
+	// is to get out of the way so they can pick an exam.
+	StateIdle = "idle"
 )
 
 // State is one snapshot of the environment's start-up, and is the
@@ -43,6 +49,10 @@ type State struct {
 // Ready reports whether the environment is usable — the one question
 // callers outside this package actually branch on.
 func (s State) Ready() bool { return s.State == StateReady }
+
+// Idle reports whether the environment is waiting to be told what to
+// build. Callers use it to tell "not yet" apart from "not asked".
+func (s State) Idle() bool { return s.State == StateIdle }
 
 // Reader reads the phase file written by k8s-env's bootstrap.
 //
@@ -125,6 +135,11 @@ func (r *Reader) read() State {
 		// Stale, per the reasoning above.
 		s.State = StateBooting
 	}
+	// StateIdle needs no case of its own and must not get one: it is not
+	// ready, so the first arm does not fire, and it is not a stale
+	// "ready", so the second does not either. It passes through as
+	// written, which is correct — the marker's absence is exactly what
+	// idle already claims.
 	return s
 }
 

--- a/facilitator/internal/exam/exam.go
+++ b/facilitator/internal/exam/exam.go
@@ -55,7 +55,20 @@ type Exam struct {
 	SpeedDuration     time.Duration
 	PassingScore      int
 	KubernetesVersion string
-	Questions         []Question // in exam.yaml order
+	// Environment is spec.environment.provider and .nodes: the shape of
+	// the cluster this bank asks for. It stopped being decorative when
+	// images/k8s-env/bootstrap.sh started generating the kind config from
+	// Nodes, and it is surfaced on GET /api/exam so the screens that
+	// describe the environment while it is being built can describe THIS
+	// one — a candidate waiting on a CKA cluster should not be told it
+	// has two nodes because CKAD did.
+	//
+	// Nodes is 0 when the bank declares none, which is what an mcq bank
+	// does: it has no cluster, and a default here would invent one. The
+	// bootstrap's own default lives in the bootstrap, where the cluster
+	// actually gets made.
+	Environment Environment
+	Questions   []Question // in exam.yaml order
 
 	// DomainWeights is spec.domainWeights: each curriculum domain's
 	// published percentage share. Historically read by no Go code (only
@@ -82,6 +95,16 @@ type Exam struct {
 	// of that loop instead and has the drawn subset seeded at the start of
 	// the attempt. See Draw and images/k8s-env/bootstrap.sh.
 	ExamLength int
+	// HasTips reports whether the bank ships a tips.md beside its
+	// exam.yaml. Only the existence is loaded, exactly as HintCount is —
+	// the text is read per request, so editing it needs no restart.
+	//
+	// It exists so the UI can decide whether to draw the control at all. A
+	// bank with no tips must show no entry point rather than one that
+	// opens an empty sheet, and the client cannot know that without being
+	// told: unlike hints, tips are not per-question, so there is no count
+	// on a question to infer it from.
+	HasTips bool
 }
 
 // Pooled reports whether ex draws a strict subset of its questions —
@@ -94,6 +117,17 @@ type Exam struct {
 // before the clock runs rather than trusting boot to have done it.
 func Pooled(ex *Exam) bool {
 	return ex.ExamLength > 0 && ex.ExamLength < len(ex.Questions)
+}
+
+// Environment is the cluster a bank asks to be sat in.
+//
+// Provider names how it is built ("kind" is the only one the simulator
+// has) and Nodes how big it is. Both are the bank's declaration and
+// neither is defaulted here: the code that builds the cluster owns the
+// fallback, and a zero here is the honest "this bank did not say".
+type Environment struct {
+	Provider string
+	Nodes    int
 }
 
 // Domain is one curriculum domain of a bank: its name and the percentage
@@ -179,15 +213,19 @@ type examDoc struct {
 		KubernetesVersion string         `json:"kubernetesVersion"`
 		DomainWeights     map[string]int `json:"domainWeights"`
 		ExamLength        int            `json:"examLength"`
-		Questions         []struct {
-			ID            string   `json:"id"`
-			Title         string   `json:"title"`
-			Instance      string   `json:"instance"`
-			Domain        string   `json:"domain"`
-			Weight        int      `json:"weight"`
-			TargetSeconds int      `json:"targetSeconds"`
-			Options       []string `json:"options"`
-			Correct       []int    `json:"correct"`
+		Environment       struct {
+			Provider string `json:"provider"`
+			Nodes    int    `json:"nodes"`
+		} `json:"environment"`
+		Questions []struct {
+			ID            string        `json:"id"`
+			Title         string        `json:"title"`
+			Instance      string        `json:"instance"`
+			Domain        string        `json:"domain"`
+			Weight        int           `json:"weight"`
+			TargetSeconds int           `json:"targetSeconds"`
+			Options       []string      `json:"options"`
+			Correct       []int         `json:"correct"`
 			Multi         bool          `json:"multi"`
 			Docs          []examDocLink `json:"docs"`
 		} `json:"questions"`
@@ -248,6 +286,11 @@ func Load(examJSONPath, bankDir string) (*Exam, error) {
 		KubernetesVersion: doc.Spec.KubernetesVersion,
 		DomainWeights:     doc.Spec.DomainWeights,
 		ExamLength:        doc.Spec.ExamLength,
+		Environment: Environment{
+			Provider: doc.Spec.Environment.Provider,
+			Nodes:    doc.Spec.Environment.Nodes,
+		},
+		HasTips: hasTips(bankDir),
 	}
 
 	for _, q := range doc.Spec.Questions {
@@ -562,6 +605,25 @@ func countHints(bankDir, qid string) int {
 		return 0
 	}
 	return len(hintHeading.FindAllIndex(raw, -1))
+}
+
+// TipsPath is where a bank's exam technique notes live: one optional
+// file beside exam.yaml, for the whole bank rather than per question.
+//
+// Bank data rather than UI copy, on the same reasoning that drives
+// spec.environment.nodes: what makes a CKAD sitting fast is not what
+// makes a KCNA one fast, and a string in the client would have to claim
+// one of them was the other.
+func TipsPath(bankDir string) string {
+	return filepath.Join(bankDir, "tips.md")
+}
+
+// hasTips reports whether the bank ships a non-empty tips.md. Non-empty
+// rather than merely present: an empty file would open a sheet with
+// nothing in it, which is worse than no control at all.
+func hasTips(bankDir string) bool {
+	info, err := os.Stat(TipsPath(bankDir))
+	return err == nil && !info.IsDir() && info.Size() > 0
 }
 
 // DrawOptions configures one draw. The zero value draws the whole

--- a/facilitator/internal/session/drawnids_test.go
+++ b/facilitator/internal/session/drawnids_test.go
@@ -1,0 +1,162 @@
+package session_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"kubestronaut-sim/facilitator/internal/session"
+)
+
+// DrawnIDs backs `facilitator grade`, which runs as a second process
+// beside the live server. Everything below is about it staying a READER:
+// it must never resume an attempt, arm a timer or write the file back.
+
+func TestDrawnIDsReadsARunningAttemptsSubset(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.json")
+	mgr, err := session.New(path, "ckad-mock-01", time.Hour, time.Now, func() {})
+	if err != nil {
+		t.Fatalf("session.New: %v", err)
+	}
+	want := []string{"q03", "q01", "q07"}
+	if _, err := mgr.StartDraw(session.ModeExam, time.Hour, session.Draw{
+		QuestionIDs: want, Seed: "a1b2c3", PoolDigest: "deadbeef",
+	}); err != nil {
+		t.Fatalf("StartDraw: %v", err)
+	}
+
+	got, err := session.DrawnIDs(path)
+	if err != nil {
+		t.Fatalf("DrawnIDs: %v", err)
+	}
+	// Draw order, not sorted: the attempt presents them in this order and
+	// the scoreboard should print them in it.
+	if len(got) != len(want) {
+		t.Fatalf("DrawnIDs = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("DrawnIDs = %v, want %v", got, want)
+		}
+	}
+}
+
+// An ended attempt still names its questions. This is what makes the
+// warm-restart check in tests/smoke.sh mean anything: the attempt is
+// graded again after `./sim down && ./sim up`, and it has to be graded
+// against the same 22 it was drawn with.
+func TestDrawnIDsSurvivesTheAttemptEnding(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.json")
+	mgr, err := session.New(path, "ckad-mock-01", time.Hour, time.Now, func() {})
+	if err != nil {
+		t.Fatalf("session.New: %v", err)
+	}
+	if _, err := mgr.StartDraw(session.ModeExam, time.Hour, session.Draw{
+		QuestionIDs: []string{"q01", "q02"},
+	}); err != nil {
+		t.Fatalf("StartDraw: %v", err)
+	}
+	if err := mgr.End("submitted"); err != nil {
+		t.Fatalf("End: %v", err)
+	}
+
+	got, err := session.DrawnIDs(path)
+	if err != nil {
+		t.Fatalf("DrawnIDs: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("DrawnIDs = %v, want the ended attempt's two ids", got)
+	}
+}
+
+// Three ways of meaning "there is no attempt to scope to", all of which
+// the caller turns into "grade the whole bank" rather than an error.
+func TestDrawnIDsIsEmptyWithNoAttempt(t *testing.T) {
+	t.Run("no file at all", func(t *testing.T) {
+		got, err := session.DrawnIDs(filepath.Join(t.TempDir(), "absent.json"))
+		if err != nil || len(got) != 0 {
+			t.Fatalf("DrawnIDs = %v, %v; want empty and no error", got, err)
+		}
+	})
+
+	t.Run("an idle session", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "session.json")
+		if _, err := session.New(path, "ckad-mock-01", time.Hour, time.Now, func() {}); err != nil {
+			t.Fatalf("session.New: %v", err)
+		}
+		got, err := session.DrawnIDs(path)
+		if err != nil || len(got) != 0 {
+			t.Fatalf("DrawnIDs = %v, %v; want empty and no error", got, err)
+		}
+	})
+
+	t.Run("an attempt drawn before subsets existed", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "session.json")
+		mgr, err := session.New(path, "ckad-mock-01", time.Hour, time.Now, func() {})
+		if err != nil {
+			t.Fatalf("session.New: %v", err)
+		}
+		if _, err := mgr.Start(session.ModeExam, time.Hour); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		got, err := session.DrawnIDs(path)
+		if err != nil || len(got) != 0 {
+			t.Fatalf("DrawnIDs = %v, %v; want empty and no error", got, err)
+		}
+	})
+}
+
+func TestDrawnIDsRejectsAFileItCannotParse(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := session.DrawnIDs(path); err == nil {
+		t.Fatal("DrawnIDs accepted an unparseable session file")
+	}
+}
+
+// The reason this is a plain reader rather than a second Manager. New
+// resumes, re-arms and can PERSIST an expiry correction; a scoreboard
+// running beside the live server must not write to the file it is
+// reading.
+func TestDrawnIDsDoesNotWriteToTheFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.json")
+	mgr, err := session.New(path, "ckad-mock-01", time.Minute, time.Now, func() {})
+	if err != nil {
+		t.Fatalf("session.New: %v", err)
+	}
+	if _, err := mgr.StartDraw(session.ModeExam, time.Minute, session.Draw{
+		QuestionIDs: []string{"q01"},
+	}); err != nil {
+		t.Fatalf("StartDraw: %v", err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	statBefore, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+
+	if _, err := session.DrawnIDs(path); err != nil {
+		t.Fatalf("DrawnIDs: %v", err)
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	statAfter, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Fatal("DrawnIDs rewrote the session file")
+	}
+	if !statBefore.ModTime().Equal(statAfter.ModTime()) {
+		t.Fatal("DrawnIDs touched the session file's mtime")
+	}
+}

--- a/facilitator/internal/session/session.go
+++ b/facilitator/internal/session/session.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -293,6 +294,40 @@ const persistedVersion = 6
 // running process experiences. Callers that need to notice an
 // already-ended, not-yet-graded session on boot should inspect the first
 // Snapshot themselves.
+// DrawnIDs reads the drawn question ids out of the session file at path,
+// without constructing a Manager, arming a timer, resuming an attempt or
+// writing anything back.
+//
+// It exists for `facilitator grade`, a read-only scoreboard that runs as
+// a second process beside the live server. That command has to know
+// which questions the open attempt asks — on a pooled bank the ones it
+// did not draw were never seeded, so scoring them prints a confident
+// wrong number — and it must not do so by taking a second Manager over
+// the same file: New resumes, re-arms and can PERSIST an expiry
+// correction, which is a running server's business and not a
+// scoreboard's.
+//
+// Returns an empty slice for an idle session, an absent file, or an
+// attempt drawn before subsets existed. The caller decides what to do
+// with that; here it simply is not an error.
+func DrawnIDs(path string) ([]string, error) {
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var doc persistedState
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("session: parse %s: %w", path, err)
+	}
+	if doc.State == stateIdle {
+		return nil, nil
+	}
+	return append([]string(nil), doc.QuestionIDs...), nil
+}
+
 func New(path, bank string, dur time.Duration, clock func() time.Time, onExpire func()) (*Manager, error) {
 	m := &Manager{
 		path:     path,

--- a/hub/cmd/hub/main.go
+++ b/hub/cmd/hub/main.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -36,6 +37,7 @@ import (
 
 	"kubestronaut-sim/hub/internal/api"
 	"kubestronaut-sim/hub/internal/auth"
+	"kubestronaut-sim/hub/internal/catalog"
 	"kubestronaut-sim/hub/internal/kube"
 	"kubestronaut-sim/hub/internal/session"
 	"kubestronaut-sim/hub/internal/store"
@@ -131,12 +133,27 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	srv := &api.Server{Auth: a, Store: st, BaseURL: baseURL, Ingest: ingest, UI: web.FS()}
+	// The exam list, read once. Banks are an image layer staged by an
+	// init container, so a new bank is a new image and therefore a new
+	// hub Pod — there is nothing to reload.
+	//
+	// A deployment with no index is not a failure: it serves identity,
+	// history and seats exactly as it did before exams were choosable,
+	// and its lobby offers a flavour instead.
+	banks, err := catalog.Load(os.Getenv("BANKS_INDEX_DIR"))
+	if err != nil {
+		return err
+	}
+	if banks.Len() > 0 {
+		log.Printf("hub: %d exam(s) available to choose from", banks.Len())
+	}
+
+	srv := &api.Server{Auth: a, Store: st, BaseURL: baseURL, Ingest: ingest, UI: web.FS(), Banks: banks}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	mgr, err := buildManager(newTicketer(ingest, baseURL, envDuration("SESSION_MAX_AGE", 10*time.Hour)))
+	mgr, err := buildManager(newTicketer(ingest, baseURL, envDuration("SESSION_MAX_AGE", 10*time.Hour)), banks)
 	if err != nil {
 		return err
 	}
@@ -213,7 +230,7 @@ func newTicketer(signer *auth.Signer, baseURL string, maxAge time.Duration) func
 // history only — which is a real configuration, not a degraded one: it
 // is what the auth and store halves can be run and proved with before a
 // cluster exists.
-func buildManager(webhook func(string) (string, string, error)) (*session.Manager, error) {
+func buildManager(webhook func(string) (string, string, error), banks *catalog.Catalog) (*session.Manager, error) {
 	upstream := os.Getenv("SESSION_UPSTREAM")
 	practical := os.Getenv("SESSION_POD_TEMPLATE")
 	mcq := os.Getenv("SESSION_POD_TEMPLATE_MCQ")
@@ -302,6 +319,7 @@ func buildManager(webhook func(string) (string, string, error)) (*session.Manage
 		}
 		cfg.Flavours[kind] = session.Flavour{
 			Seats: seats, Template: tmpl, Bank: os.Getenv(spec.bank),
+			BankTemplates: bankTemplates(spec.path, kind, banks),
 		}
 		log.Printf("hub: %s sessions: %d seat(s)", kind, seats)
 	}
@@ -309,6 +327,50 @@ func buildManager(webhook func(string) (string, string, error)) (*session.Manage
 		return nil, errors.New("hub: sessions are configured but no flavour has seats — set PRACTICAL_SEATS and/or MCQ_SEATS")
 	}
 	return session.New(pods, cfg), nil
+}
+
+// bankTemplates finds the per-exam Pod manifests beside the flavour's
+// base one: <dir>/session-bank-<id>.json, written by the chart for every
+// bank given resource overrides under sessions.<kind>.banks.
+//
+// Discovered rather than configured, because the alternative is a second
+// list of bank ids in the environment that has to agree with the first.
+// A bank with no file simply gets the flavour's base manifest, which is
+// every bank today.
+//
+// The catalog decides which flavour a file belongs to, so a bank is
+// never registered against the wrong one: an exam's engine is declared
+// by the bank itself, in exactly one place, and the same mapping decides
+// which seat pool admits it.
+func bankTemplates(basePath string, kind session.Kind, banks *catalog.Catalog) map[string]session.Template {
+	if basePath == "" || banks == nil {
+		return nil
+	}
+	dir := filepath.Dir(basePath)
+	out := map[string]session.Template{}
+	for _, entry := range banks.List() {
+		if session.KindOf(entry.ExamType) != kind {
+			continue
+		}
+		path := filepath.Join(dir, "session-bank-"+entry.ID+".json")
+		raw, err := os.ReadFile(path)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			// Not fatal: the base manifest still works, and refusing to
+			// start the whole hub over one unreadable override would take
+			// every other exam down with it.
+			log.Printf("hub: read %s: %v (using the default session Pod for %s)", path, err, entry.ID)
+			continue
+		}
+		out[entry.ID] = raw
+		log.Printf("hub: %s uses its own session Pod spec", entry.ID)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func envOr(key, fallback string) string {

--- a/hub/internal/api/api.go
+++ b/hub/internal/api/api.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"kubestronaut-sim/hub/internal/auth"
+	"kubestronaut-sim/hub/internal/catalog"
 	"kubestronaut-sim/hub/internal/session"
 	"kubestronaut-sim/hub/internal/store"
 )
@@ -36,8 +37,18 @@ type Server struct {
 	// catch-all. Every session route checks for it.
 	Sessions *session.Manager
 	// DefaultKind is the flavour /api/session/start admits into when the
-	// request does not say.
+	// request names neither an exam nor a kind.
 	DefaultKind session.Kind
+	// Banks is what exams this deployment offers, read at startup from
+	// the index the banks image ships.
+	//
+	// The hub needs its own copy because of when the question is asked:
+	// a candidate in the lobby is choosing a certification and has no
+	// session Pod yet, so there is nothing running to ask. Nil is a
+	// deployment that staged no index — the lobby then has no exams to
+	// offer and falls back to offering a flavour, which is what it did
+	// before exams were choosable.
+	Banks *catalog.Catalog
 	// BaseURL is where a browser reaches the hub, used to build the
 	// OAuth redirect back to it.
 	BaseURL string
@@ -95,6 +106,17 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /api/history/import", s.handleHistoryImport)
 	mux.HandleFunc("GET /api/history/summary", s.handleHistorySummary)
 	mux.HandleFunc("GET /api/history/{attempt}", s.handleAttempt)
+
+	// The exam list, for the lobby.
+	//
+	// Under /hub/ and not /api/ for the reason the whole route table is
+	// split that way: /api/ is the candidate's session surface, and
+	// everything under it is either answered on their behalf or proxied
+	// to their Pod. This is a question about the deployment that has to
+	// be answerable when they have no Pod at all — which is precisely
+	// when they are asking it. A local `./sim up` JSON-404s it, exactly
+	// as it does /api/me, so the SPA can tell the two products apart.
+	mux.HandleFunc("GET /hub/exams", s.handleExams)
 
 	mux.HandleFunc("GET /hub/auth/login", s.handleLogin)
 	mux.HandleFunc("GET /hub/auth/callback", s.handleCallback)
@@ -196,6 +218,48 @@ func (s *Server) seats() map[string]seat {
 		out[string(kind)] = seat{Used: counts[0], Total: counts[1]}
 	}
 	return out
+}
+
+// hubExam is one exam as the lobby renders it: the catalog row plus the
+// seat pool its engine draws from.
+//
+// `kind` is derived here rather than in the browser because it is the
+// hub's rule, not a display detail — it decides which seat pool a click
+// on this card competes for, and the same mapping (session.KindOf) is
+// what admission and the seat guard use. Two independent derivations of
+// it would be two places to get it wrong.
+type hubExam struct {
+	catalog.Entry
+	Kind string `json:"kind"`
+}
+
+// handleExams answers the lobby's exam list.
+//
+// Unauthenticated on purpose, like the seat counts beside it on
+// /api/me: what a deployment offers is not a fact about anybody, and
+// somebody deciding whether to sign in is entitled to see whether the
+// certification they came for is here.
+func (s *Server) handleExams(w http.ResponseWriter, r *http.Request) {
+	// Never null: an empty list has to marshal as [] so the lobby renders
+	// "no exams" rather than crashing on it.
+	exams := []hubExam{}
+	if s.Banks != nil {
+		for _, e := range s.Banks.List() {
+			exams = append(exams, hubExam{Entry: e, Kind: string(session.KindOf(e.ExamType))})
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"exams": exams})
+}
+
+// bank looks an exam up, answering false for a deployment that staged no
+// index. Refusing there is deliberate: a hub that cannot tell whether a
+// bank exists must not stamp the name into a Pod and find out over the
+// twenty minutes it takes to boot one.
+func (s *Server) bank(id string) (catalog.Entry, bool) {
+	if s.Banks == nil {
+		return catalog.Entry{}, false
+	}
+	return s.Banks.Get(id)
 }
 
 // handleHistory serves the user's attempts in the exact shape the

--- a/hub/internal/api/exams_test.go
+++ b/hub/internal/api/exams_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -8,7 +9,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"kubestronaut-sim/hub/internal/auth"
 	"kubestronaut-sim/hub/internal/catalog"
@@ -40,9 +43,90 @@ func testBanks(t *testing.T) *catalog.Catalog {
 	return c
 }
 
+// heldPods is session.Pods with a hold on Delete, so a test can keep a
+// recycle job in flight for as long as it needs to look at something.
+//
+// It exists because the alternative is a race, and the race lost in CI.
+// Recycle registers its job synchronously and then runs it on a
+// goroutine; against fakes that whole run can finish inside the gap
+// between two calls in a test. A test asserting "the hub has a job in
+// flight" is then really asserting "the goroutine has not got there
+// yet" — true on a laptop, false often enough on a loaded runner.
+// Blocking the first thing the job does makes the precondition a fact.
+type heldPods struct {
+	session.Pods
+	mu      sync.Mutex
+	release chan struct{} // closed = not holding
+	entered chan struct{}
+	once    sync.Once
+}
+
+// Starts released, so a caller that never asks for the hold sees the
+// wrapped client's behaviour unchanged.
+func newHeldPods(inner session.Pods) *heldPods {
+	open := make(chan struct{})
+	close(open)
+	return &heldPods{Pods: inner, release: open, entered: make(chan struct{})}
+}
+
+// Hold makes the next Delete block until Release. Guarded, because the
+// goroutine running the job reads this while the test writes it — a bare
+// field swap here is a data race, and -race says so.
+func (h *heldPods) Hold() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.release = make(chan struct{})
+}
+
+func (h *heldPods) Release() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	select {
+	case <-h.release:
+	default:
+		close(h.release)
+	}
+}
+
+func (h *heldPods) gate() chan struct{} {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.release
+}
+
+func (h *heldPods) Delete(ctx context.Context, name string) error {
+	h.once.Do(func() { close(h.entered) })
+	select {
+	case <-h.gate():
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return h.Pods.Delete(ctx, name)
+}
+
+// waitEntered blocks until the job under test has reached the hold, so
+// an assertion after it cannot run early either.
+func (h *heldPods) waitEntered(t *testing.T) {
+	t.Helper()
+	select {
+	case <-h.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the recycle job never reached the pod delete")
+	}
+}
+
 // hostedWithExams is `hosted` plus a bank index and both flavours, which
 // is what a deployment that lets candidates choose actually looks like.
 func hostedWithExams(t *testing.T, upstream http.Handler) (*Server, *http.Cookie) {
+	t.Helper()
+	s, c, _ := hostedWithHeldPods(t, upstream)
+	return s, c
+}
+
+// hostedWithHeldPods is the same, and also hands back the hold. The hold
+// starts released, so every caller that ignores it behaves exactly as
+// before.
+func hostedWithHeldPods(t *testing.T, upstream http.Handler) (*Server, *http.Cookie, *heldPods) {
 	t.Helper()
 	s, _ := newServer(t, auth.ModeGitHub)
 	srv := httptest.NewServer(upstream)
@@ -52,7 +136,8 @@ func hostedWithExams(t *testing.T, upstream http.Handler) (*Server, *http.Cookie
 		t.Fatal(err)
 	}
 	s.Banks = testBanks(t)
-	s.Sessions = session.New(&session.Static{Host: u.Hostname()}, session.Config{
+	pods := newHeldPods(&session.Static{Host: u.Hostname()})
+	s.Sessions = session.New(pods, session.Config{
 		Flavours: map[session.Kind]session.Flavour{
 			session.Practical: {Seats: 1, Template: session.Template(podTemplate), Bank: "ckad-mock-01"},
 			session.MCQ:       {Seats: 1, Template: session.Template(podTemplate), Bank: "kcna-mock"},
@@ -62,7 +147,7 @@ func hostedWithExams(t *testing.T, upstream http.Handler) (*Server, *http.Cookie
 	})
 	s.DefaultKind = session.Practical
 	s.UI = shellFS()
-	return s, login(t, s, "u1", "candidate")
+	return s, login(t, s, "u1", "candidate"), pods
 }
 
 func okHandler() http.Handler {
@@ -251,7 +336,7 @@ func TestAConductorJobInTheSessionIsReportedThrough(t *testing.T) {
 // Pod is gone for most of it, so an answer from the Pod would be either
 // unreachable or about the Pod that is being thrown away.
 func TestTheHubsOwnJobWinsOverThePods(t *testing.T) {
-	s, c := hostedWithExams(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	s, c, pods := hostedWithHeldPods(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/control/status" {
 			w.Write([]byte(`{"busy":true,"job":{"id":"seed-1","op":"seed","phases":[]}}`))
 			return
@@ -262,17 +347,28 @@ func TestTheHubsOwnJobWinsOverThePods(t *testing.T) {
 		t.Fatalf("start: %d %s", w.Code, body(t, w))
 	}
 
+	// Take the hold BEFORE triggering the reset, so the job cannot run to
+	// completion before the assertion below. Without this the reset
+	// finishes against the fakes in microseconds, the hub's job settles,
+	// and the Pod's in-flight seed correctly wins — which is the right
+	// behaviour and the wrong thing for this test to be measuring.
+	pods.Hold()
 	reset := httptest.NewRequest(http.MethodPost, "/api/control/reset", strings.NewReader(`{}`))
 	reset.AddCookie(c)
 	if w := do(s, reset); w.Code != http.StatusAccepted {
 		t.Fatalf("reset: %d %s", w.Code, body(t, w))
 	}
+	pods.waitEntered(t)
+	defer pods.Release()
 
 	r := httptest.NewRequest(http.MethodGet, "/api/control/status", nil)
 	r.AddCookie(c)
 	got := body(t, do(s, r))
 	if strings.Contains(got, "seed-1") {
 		t.Errorf("status = %s, want the hub's own reset job", got)
+	}
+	if !strings.Contains(got, `"op":"reset"`) {
+		t.Errorf("status = %s, want the hub's reset job to be the one reported", got)
 	}
 }
 

--- a/hub/internal/api/exams_test.go
+++ b/hub/internal/api/exams_test.go
@@ -1,0 +1,292 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"kubestronaut-sim/hub/internal/auth"
+	"kubestronaut-sim/hub/internal/catalog"
+	"kubestronaut-sim/hub/internal/session"
+)
+
+// The bank index as the banks image stages it, with one exam of each
+// engine plus one that cannot be sat.
+func testBanks(t *testing.T) *catalog.Catalog {
+	t.Helper()
+	dir := t.TempDir()
+	for name, doc := range map[string]string{
+		"ckad-mock-01.json": `{"metadata":{"name":"ckad-mock-01","title":"CKAD Mock Exam 01","certification":"CKAD"},
+		  "spec":{"examType":"hands-on","duration":"120m","passingScore":66,
+		          "instances":[{"name":"instance-1"},{"name":"instance-2"}],"questions":[{"id":"q01"}]}}`,
+		"kcna-mock.json": `{"metadata":{"name":"kcna-mock","title":"KCNA Mock Exam","certification":"KCNA"},
+		  "spec":{"examType":"mcq","duration":"90m","passingScore":75,"questions":[{"id":"q01"}]}}`,
+		"_catalog.json": `{"comingSoon":[{"id":"cks-mock","title":"CKS Mock Exam","certification":"CKS",
+		  "examType":"hands-on","note":"Not written yet"}]}`,
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(doc), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c, err := catalog.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+// hostedWithExams is `hosted` plus a bank index and both flavours, which
+// is what a deployment that lets candidates choose actually looks like.
+func hostedWithExams(t *testing.T, upstream http.Handler) (*Server, *http.Cookie) {
+	t.Helper()
+	s, _ := newServer(t, auth.ModeGitHub)
+	srv := httptest.NewServer(upstream)
+	t.Cleanup(srv.Close)
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Banks = testBanks(t)
+	s.Sessions = session.New(&session.Static{Host: u.Hostname()}, session.Config{
+		Flavours: map[session.Kind]session.Flavour{
+			session.Practical: {Seats: 1, Template: session.Template(podTemplate), Bank: "ckad-mock-01"},
+			session.MCQ:       {Seats: 1, Template: session.Template(podTemplate), Bank: "kcna-mock"},
+		},
+		Port: atoi(u.Port()),
+		Logf: func(string, ...any) {},
+	})
+	s.DefaultKind = session.Practical
+	s.UI = shellFS()
+	return s, login(t, s, "u1", "candidate")
+}
+
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+type exameRow struct {
+	ID         string `json:"id"`
+	Title      string `json:"title"`
+	Kind       string `json:"kind"`
+	ExamType   string `json:"examType"`
+	Available  bool   `json:"available"`
+	ComingSoon bool   `json:"comingSoon"`
+}
+
+func getExams(t *testing.T, s *Server) []exameRow {
+	t.Helper()
+	w := do(s, httptest.NewRequest(http.MethodGet, "/hub/exams", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /hub/exams: status = %d: %s", w.Code, body(t, w))
+	}
+	var payload struct {
+		Exams []exameRow `json:"exams"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode: %v (body %s)", err, w.Body.String())
+	}
+	return payload.Exams
+}
+
+// The lobby's whole problem: the candidate is choosing a certification
+// and has no session Pod yet, so there is nothing running to ask. This
+// is the answer, and it must work signed out — somebody deciding whether
+// to sign in is entitled to see whether the exam they came for is here.
+func TestExamsAreListedWithoutASession(t *testing.T) {
+	s, _ := hostedWithExams(t, okHandler())
+
+	exams := getExams(t, s)
+	byID := map[string]exameRow{}
+	for _, e := range exams {
+		byID[e.ID] = e
+	}
+	if len(byID) != 3 {
+		t.Fatalf("got %d exams, want 3: %+v", len(byID), exams)
+	}
+	// The seat pool each card competes for, derived by the hub from the
+	// bank's own engine rather than by the browser.
+	if byID["ckad-mock-01"].Kind != "practical" {
+		t.Errorf("ckad kind = %q, want practical", byID["ckad-mock-01"].Kind)
+	}
+	if byID["kcna-mock"].Kind != "mcq" {
+		t.Errorf("kcna kind = %q, want mcq", byID["kcna-mock"].Kind)
+	}
+	if cks := byID["cks-mock"]; cks.Available || !cks.ComingSoon {
+		t.Errorf("cks = %+v, want an unavailable coming-soon row", cks)
+	}
+}
+
+// A deployment that staged no index still answers, with nothing in it:
+// the lobby then falls back to offering a flavour, exactly as it did
+// before exams were choosable.
+func TestExamsAnswersEmptyWithNoIndex(t *testing.T) {
+	s, _ := newServer(t, auth.ModeGitHub)
+
+	w := do(s, httptest.NewRequest(http.MethodGet, "/hub/exams", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	// [] and never null: a lobby that renders `null.map` shows nothing at
+	// all, which is indistinguishable from a hub that is down.
+	if got := strings.TrimSpace(w.Body.String()); !strings.Contains(got, `"exams":[]`) {
+		t.Errorf("body = %s, want an empty exams array", got)
+	}
+}
+
+// The exam decides the seat. The candidate picked a certification, not a
+// flavour, and the flavour is derived from the bank's own engine — the
+// same mapping the seat guard enforces on a switch.
+func TestStartingAnMcqExamTakesAnMcqSeat(t *testing.T) {
+	s, c := hostedWithExams(t, okHandler())
+
+	if w := ready(t, s, c, `{"bank":"kcna-mock"}`); w.Code != http.StatusOK {
+		t.Fatalf("start: %d %s", w.Code, body(t, w))
+	}
+
+	live, err := s.Sessions.Get("u1")
+	if err != nil {
+		t.Fatalf("no session: %v", err)
+	}
+	if live.Kind != session.MCQ {
+		t.Errorf("kind = %q, want mcq: the bank's engine decides the seat", live.Kind)
+	}
+	if live.Bank != "kcna-mock" {
+		t.Errorf("bank = %q, want kcna-mock", live.Bank)
+	}
+}
+
+// A `kind` that disagrees with the named exam loses. The exam is the
+// fact the candidate expressed; the flavour is derived from it, so
+// refusing over a field they should not have had to send would be a
+// refusal about the client's bookkeeping.
+func TestANamedExamOverridesADisagreeingKind(t *testing.T) {
+	s, c := hostedWithExams(t, okHandler())
+
+	if w := ready(t, s, c, `{"kind":"practical","bank":"kcna-mock"}`); w.Code != http.StatusOK {
+		t.Fatalf("start: %d %s", w.Code, body(t, w))
+	}
+	live, _ := s.Sessions.Get("u1")
+	if live.Kind != session.MCQ {
+		t.Errorf("kind = %q, want mcq", live.Kind)
+	}
+}
+
+// Refused before a seat is spent. An unknown bank stamped into a Pod is
+// twenty minutes of boot ending in a facilitator with no exam loaded,
+// and the candidate would have paid a seat and a place in the queue to
+// discover it.
+func TestAnUnknownExamIsRefusedBeforeAdmission(t *testing.T) {
+	s, c := hostedWithExams(t, okHandler())
+
+	r := httptest.NewRequest(http.MethodPost, "/api/session/start", strings.NewReader(`{"bank":"nope-mock"}`))
+	r.AddCookie(c)
+	w := do(s, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", w.Code, body(t, w))
+	}
+	if _, err := s.Sessions.Get("u1"); err == nil {
+		t.Error("a seat was granted for an exam that does not exist")
+	}
+}
+
+// A coming-soon certification has no bank behind it. It is listed so a
+// candidate can see it is on the path; it must not be startable.
+func TestAComingSoonExamCannotBeStarted(t *testing.T) {
+	s, c := hostedWithExams(t, okHandler())
+
+	r := httptest.NewRequest(http.MethodPost, "/api/session/start", strings.NewReader(`{"bank":"cks-mock"}`))
+	r.AddCookie(c)
+	w := do(s, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", w.Code, body(t, w))
+	}
+}
+
+// The conductor inside a session still runs one job of its own: seeding
+// a pooled bank's drawn questions, triggered by the facilitator
+// server-to-server between Start and the clock beginning. The hub
+// answers control status from ITS store, so that job was invisible and
+// the candidate watched a blank hold.
+func TestAConductorJobInTheSessionIsReportedThrough(t *testing.T) {
+	s, c := hostedWithExams(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/control/status":
+			w.Write([]byte(`{"busy":true,"job":{"id":"seed-1","op":"seed","bank":"ckad-mock-01","phases":[]}}`))
+		case "/api/control/log":
+			w.Write([]byte(`{"jobId":"seed-1","lines":["setting up q04"]}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	if w := ready(t, s, c, `{"bank":"ckad-mock-01"}`); w.Code != http.StatusOK {
+		t.Fatalf("start: %d %s", w.Code, body(t, w))
+	}
+
+	for path, needle := range map[string]string{
+		"/api/control/status": "seed",
+		"/api/control/log":    "setting up q04",
+	} {
+		r := httptest.NewRequest(http.MethodGet, path, nil)
+		r.AddCookie(c)
+		w := do(s, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET %s: %d", path, w.Code)
+		}
+		if got := body(t, w); !strings.Contains(got, needle) {
+			t.Errorf("GET %s = %s, want the conductor's own job", path, got)
+		}
+	}
+}
+
+// The hub's own operations still win. A reset is Pod replacement: the
+// Pod is gone for most of it, so an answer from the Pod would be either
+// unreachable or about the Pod that is being thrown away.
+func TestTheHubsOwnJobWinsOverThePods(t *testing.T) {
+	s, c := hostedWithExams(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/control/status" {
+			w.Write([]byte(`{"busy":true,"job":{"id":"seed-1","op":"seed","phases":[]}}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	if w := ready(t, s, c, `{"bank":"ckad-mock-01"}`); w.Code != http.StatusOK {
+		t.Fatalf("start: %d %s", w.Code, body(t, w))
+	}
+
+	reset := httptest.NewRequest(http.MethodPost, "/api/control/reset", strings.NewReader(`{}`))
+	reset.AddCookie(c)
+	if w := do(s, reset); w.Code != http.StatusAccepted {
+		t.Fatalf("reset: %d %s", w.Code, body(t, w))
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/api/control/status", nil)
+	r.AddCookie(c)
+	got := body(t, do(s, r))
+	if strings.Contains(got, "seed-1") {
+		t.Errorf("status = %s, want the hub's own reset job", got)
+	}
+}
+
+// The old client, and the old deployment: no bank in the body means the
+// flavour's configured default, which is what sessions.<kind>.bank has
+// always been. Nothing about this may have changed.
+func TestNoNamedExamFallsBackToTheFlavourDefault(t *testing.T) {
+	s, c := hostedWithExams(t, okHandler())
+
+	if w := ready(t, s, c, `{"kind":"practical"}`); w.Code != http.StatusOK {
+		t.Fatalf("start: %d %s", w.Code, body(t, w))
+	}
+	live, _ := s.Sessions.Get("u1")
+	if live.Bank != "ckad-mock-01" {
+		t.Errorf("bank = %q, want the flavour default ckad-mock-01", live.Bank)
+	}
+}

--- a/hub/internal/api/seat_test.go
+++ b/hub/internal/api/seat_test.go
@@ -38,6 +38,20 @@ func catalogHandler() http.Handler {
 // mid-restart looks like from here.
 func seatOfKind(t *testing.T, kind session.Kind) (*Server, *http.Cookie, *httptest.Server) {
 	t.Helper()
+	bank := "ckad-mock-01"
+	if kind == session.MCQ {
+		bank = "kcna-mock"
+	}
+	return seatFor(t, kind, bank)
+}
+
+// seatFor is seatOfKind with the seat's exam named, including as "" —
+// which is a session that records no exam at all. That is not a
+// hypothetical: it is what a Pod adopted from before exams were
+// choosable looks like, and it is the case the flavour check underneath
+// the bank check exists for.
+func seatFor(t *testing.T, kind session.Kind, bank string) (*Server, *http.Cookie, *httptest.Server) {
+	t.Helper()
 	s, _ := newServer(t, auth.ModeGitHub)
 	pod := httptest.NewServer(catalogHandler())
 	t.Cleanup(pod.Close)
@@ -46,10 +60,6 @@ func seatOfKind(t *testing.T, kind session.Kind) (*Server, *http.Cookie, *httpte
 		t.Fatal(err)
 	}
 	host, port := u.Hostname(), atoi(u.Port())
-	bank := "ckad-mock-01"
-	if kind == session.MCQ {
-		bank = "kcna-mock"
-	}
 	s.Sessions = session.New(&session.Static{Host: host}, session.Config{
 		Flavours: map[session.Kind]session.Flavour{
 			kind: {Seats: 1, Template: session.Template(podTemplate), Bank: bank},
@@ -74,11 +84,47 @@ func switchTo(s *Server, c *http.Cookie, bank string) *httptest.ResponseRecorder
 	return do(s, r)
 }
 
-// The bug. An MCQ seat is two containers and no cluster; switching its
-// bank does not switch its template, so a hands-on exam chosen here
-// booted the hands-on bank into a Pod with no instances and no desktop,
-// graded every check 0 with "could not resolve hostname instance-1", and
-// recorded it as a real attempt.
+// A seat is one exam.
+//
+// The candidate chose the certification in the lobby, and the Pod was
+// created and sized for it. Rebuilding it onto a different exam would
+// hand them an environment they were never admitted for — and would do
+// it silently, since the two hands-on exams look identical from inside
+// the session. The answer to "I want a different exam" is a new session.
+func TestASeatRefusesAnyExamButItsOwn(t *testing.T) {
+	s, c, _ := seatFor(t, session.Practical, "ckad-mock-01")
+
+	w := switchTo(s, c, "ckad-mock-02")
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", w.Code, body(t, w))
+	}
+	if got := body(t, w); !strings.Contains(got, "this seat is for one exam") {
+		t.Errorf("body = %q, want the one-exam refusal", got)
+	}
+}
+
+// The same request naming the seat's own exam is not a refusal: it is
+// the reseed a candidate gets by asking for the exam they are already
+// sitting, and it must go through the ordinary recycle.
+func TestASeatAcceptsItsOwnExam(t *testing.T) {
+	s, c, _ := seatFor(t, session.Practical, "ckad-mock-01")
+
+	w := switchTo(s, c, "ckad-mock-01")
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202: %s", w.Code, body(t, w))
+	}
+}
+
+// The bug this gate was built for. An MCQ seat is two containers and no
+// cluster; switching its bank does not switch its template, so a
+// hands-on exam chosen here booted the hands-on bank into a Pod with no
+// instances and no desktop, graded every check 0 with "could not resolve
+// hostname instance-1", and recorded it as a real attempt.
+//
+// Refused by the one-exam rule now rather than by the flavour rule, and
+// the test stays because what must never happen is unchanged.
 func TestAnMcqSeatRefusesAHandsOnExam(t *testing.T) {
 	s, c, _ := seatOfKind(t, session.MCQ)
 
@@ -86,9 +132,6 @@ func TestAnMcqSeatRefusesAHandsOnExam(t *testing.T) {
 
 	if w.Code != http.StatusConflict {
 		t.Fatalf("status = %d, want 409: %s", w.Code, body(t, w))
-	}
-	if got := body(t, w); !strings.Contains(got, "cannot run that exam") {
-		t.Errorf("body = %q, want the seat refusal", got)
 	}
 }
 
@@ -102,6 +145,23 @@ func TestAPracticalSeatRefusesAnMcqExam(t *testing.T) {
 
 	if w.Code != http.StatusConflict {
 		t.Fatalf("status = %d, want 409: %s", w.Code, body(t, w))
+	}
+}
+
+// A session that records no exam — a Pod adopted from before exams were
+// choosable — cannot be checked against its own bank, so it falls
+// through to the flavour check that was the whole rule before. It must
+// not fall through to no check at all.
+func TestASeatWithNoRecordedExamStillChecksTheFlavour(t *testing.T) {
+	s, c, _ := seatFor(t, session.MCQ, "")
+
+	if w := switchTo(s, c, "ckad-mock-01"); w.Code != http.StatusConflict {
+		t.Fatalf("hands-on into an mcq seat: status = %d, want 409: %s", w.Code, body(t, w))
+	}
+	// And the same-flavour move it always allowed still works, so the
+	// fallback is the old rule intact rather than a blanket refusal.
+	if w := switchTo(s, c, "kcna-mock"); w.Code != http.StatusAccepted {
+		t.Fatalf("mcq into an mcq seat: status = %d, want 202: %s", w.Code, body(t, w))
 	}
 }
 
@@ -122,23 +182,11 @@ func TestARefusedSwitchLeavesTheSessionRunning(t *testing.T) {
 	}
 }
 
-// Same kind, different bank: a practical seat may move between hands-on
-// exams, because the Pod that needs is the one it already has. The gate
-// is on the flavour, not on the bank the seat happened to start with.
-func TestAPracticalSeatMayMoveBetweenHandsOnExams(t *testing.T) {
-	s, c, _ := seatOfKind(t, session.Practical)
-
-	w := switchTo(s, c, "ckad-mock-02")
-
-	if w.Code != http.StatusAccepted {
-		t.Fatalf("status = %d, want 202: %s", w.Code, body(t, w))
-	}
-}
-
 // An exam no catalog knows is a 404, not a rebuild onto a bank that does
-// not exist.
+// not exist. Reached through a seat with no recorded exam, since a seat
+// that has one never gets as far as the catalog.
 func TestAnUnknownExamIsRefused(t *testing.T) {
-	s, c, _ := seatOfKind(t, session.MCQ)
+	s, c, _ := seatFor(t, session.MCQ, "")
 
 	w := switchTo(s, c, "cks-mock-01")
 
@@ -150,7 +198,7 @@ func TestAnUnknownExamIsRefused(t *testing.T) {
 // Fail closed. Not knowing whether a hands-on bank is about to be booted
 // into a Pod with no cluster is not a reason to try it and find out.
 func TestAnUnreadableCatalogRefusesTheSwitch(t *testing.T) {
-	s, c, pod := seatOfKind(t, session.MCQ)
+	s, c, pod := seatFor(t, session.MCQ, "")
 	pod.Close()
 
 	w := switchTo(s, c, "ckad-mock-01")

--- a/hub/internal/api/session.go
+++ b/hub/internal/api/session.go
@@ -45,6 +45,7 @@ func (s *Server) handleSessionStart(w http.ResponseWriter, r *http.Request) {
 
 	var wanted struct {
 		Kind string `json:"kind"`
+		Bank string `json:"bank"`
 	}
 	// A body is optional here, exactly as it is for the facilitator.
 	_ = json.Unmarshal(body, &wanted)
@@ -58,7 +59,33 @@ func (s *Server) handleSessionStart(w http.ResponseWriter, r *http.Request) {
 		kind = k
 	}
 
-	live, err := s.Sessions.Start(r.Context(), user.UserID, kind)
+	// A named exam decides the seat, rather than being checked against
+	// one the caller also sent. The seat is a Pod template and the exam
+	// is what has to run in it, so the exam is the fact and the flavour
+	// is derived from it — the same direction seatCanRun enforces for a
+	// switch. A client that sends both and disagrees gets the exam it
+	// asked for, not a refusal about a field it should not have needed
+	// to send.
+	//
+	// Validated against the hub's own catalog BEFORE a seat is granted:
+	// an unknown bank stamped into a Pod is twenty minutes of boot
+	// ending in a facilitator with no exam loaded, and the candidate
+	// would have spent a seat and a place in the queue to find out.
+	bank := wanted.Bank
+	if bank != "" {
+		entry, ok := s.bank(bank)
+		if !ok {
+			writeError(w, http.StatusBadRequest, "no such exam")
+			return
+		}
+		if !entry.Available {
+			writeError(w, http.StatusBadRequest, "that exam cannot be sat yet")
+			return
+		}
+		kind = session.KindOf(entry.ExamType)
+	}
+
+	live, err := s.Sessions.Start(r.Context(), user.UserID, kind, bank)
 	var queued *session.Queued
 	switch {
 	case errors.As(err, &queued):
@@ -150,15 +177,25 @@ func (s *Server) handleSwitch(w http.ResponseWriter, r *http.Request) {
 	s.recycle(w, r, body.Bank)
 }
 
-// seatCanRun reports whether this candidate's seat is the flavour their
-// chosen exam needs, writing the refusal itself when it is not.
+// seatCanRun reports whether this candidate's seat may run the exam they
+// are asking for, writing the refusal itself when it may not.
 //
-// The authority on what an exam needs is the bank, and the bank is in
-// the session Pod — the hub has no /banks of its own — so this asks the
-// candidate's own facilitator. That is one request against a Pod the
-// proxy is already talking to, and it happens BEFORE anything is
-// destroyed: a switch that wipes the session and then discovers it
-// cannot finish is precisely the failure canRestart() exists to prevent.
+// A seat is now a certification, not a flavour. It is created for one
+// exam — the candidate chose it in the lobby, and the Pod was stamped
+// and sized for it — so the only bank it can run is its own, and the
+// answer to "I want a different exam" is a new session rather than a
+// rebuild of this one.
+//
+// That is stricter than it was, and the strictness is the point. The
+// previous rule allowed any same-flavour bank, which was correct while
+// the exam was a deployment value nobody chose; it is wrong now, because
+// a seat sized for CKAD's two-node cluster is not a seat for CKA's
+// three, and the seat pool a candidate was admitted through was the one
+// their chosen exam draws from.
+//
+// The kind check below stays underneath it as the second line: an empty
+// seat bank is possible for a session adopted from a Pod that predates
+// this, and that session must not fall through to no check at all.
 //
 // Every uncertain answer refuses. Not knowing whether a hands-on bank is
 // about to be booted into a Pod with no cluster is not a reason to try
@@ -176,6 +213,14 @@ func (s *Server) seatCanRun(w http.ResponseWriter, user, bank string) bool {
 	}
 	if live.Addr() == "" {
 		writeError(w, http.StatusConflict, "wait until your environment is ready before changing exams")
+		return false
+	}
+	if live.Bank != "" {
+		if bank == live.Bank {
+			return true
+		}
+		writeError(w, http.StatusConflict,
+			"this seat is for one exam — end this session and start the exam you want")
 		return false
 	}
 
@@ -256,16 +301,28 @@ func (s *Server) recycle(w http.ResponseWriter, r *http.Request, bank string) {
 	writeJSON(w, http.StatusAccepted, map[string]any{"job": job})
 }
 
-// handleControlStatus and handleControlLog answer for the hub's own
-// jobs, never the conductor's.
+// handleControlStatus and handleControlLog answer for the hub's own jobs
+// first, and for the session Pod's conductor when the hub has none
+// running.
 //
-// In a session Pod the conductor produces no jobs of its own: reset and
-// switch are the hub's, and reseed answers synchronously. The one
-// exception is seeding a pooled bank, which the facilitator triggers
-// server-to-server and whose progress would therefore be invisible here.
-// No bank in the product is pooled on the hands-on side, so nothing is
-// currently affected; it is recorded in docs/follow-ups.md rather than
-// guessed at.
+// The hub owns reset and switch here — they are Pod replacement, and the
+// Pod they describe does not exist for most of the time they run — so
+// while one of those is in flight it is the only truthful answer, and
+// the Pod cannot be asked anyway. The conductor inside a session still
+// has one job type of its own: `seed`, which prepares the cluster for
+// the questions a pooled bank's draw picked, triggered by the
+// facilitator server-to-server between the candidate pressing Start and
+// their clock beginning.
+//
+// Without the fall-through below that seed job was invisible: the
+// browser polled the hub, the hub answered from a job store the seed was
+// never in, and the candidate watched a blank hold with no explanation
+// for however long the setup took. docs/follow-ups.md recorded this as
+// waiting for the first pooled hands-on bank.
+//
+// The priority is in-flight over settled. The hub's own settled job
+// still wins over an idle Pod, so a FAILED reset the candidate has not
+// dismissed does not vanish from under them.
 func (s *Server) handleControlStatus(w http.ResponseWriter, r *http.Request) {
 	user, ok := s.requireUser(w, r)
 	if !ok {
@@ -278,6 +335,17 @@ func (s *Server) handleControlStatus(w http.ResponseWriter, r *http.Request) {
 		// and useful answer to that question.
 		writeJSON(w, http.StatusOK, session.Snapshot{})
 		return
+	}
+	if !snap.Busy {
+		if raw, ok := s.podControl(user.UserID, "/api/control/status"); ok {
+			var pod struct {
+				Busy bool `json:"busy"`
+			}
+			if json.Unmarshal(raw, &pod) == nil && pod.Busy {
+				writeRaw(w, raw)
+				return
+			}
+		}
 	}
 	writeJSON(w, http.StatusOK, snap)
 }
@@ -292,8 +360,68 @@ func (s *Server) handleControlLog(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]any{"jobId": "", "lines": []string{}})
 		return
 	}
+	// Same rule as the status above, and it has to be the same rule: the
+	// log pane is opened from the overlay the status put on screen, so a
+	// pane reading from the other job store would be empty for exactly
+	// the job somebody opened it to watch.
+	if snap, statusErr := s.Sessions.Status(user.UserID); statusErr == nil && !snap.Busy {
+		if raw, ok := s.podControl(user.UserID, "/api/control/log"); ok {
+			var pod struct {
+				JobID string `json:"jobId"`
+			}
+			if json.Unmarshal(raw, &pod) == nil && pod.JobID != "" {
+				writeRaw(w, raw)
+				return
+			}
+		}
+	}
 	if lines == nil {
 		lines = []string{}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"jobId": id, "lines": lines})
+}
+
+// podControl asks the candidate's own session for one of the conductor's
+// control routes, returning false for anything that is not a clean 200.
+//
+// Deliberately quiet about failures. This is a fall-through on a polling
+// route: the caller's own answer is always available and always
+// truthful, so a Pod that is restarting, gone, or slow should cost a
+// poll rather than an error the browser has to interpret.
+func (s *Server) podControl(user, path string) ([]byte, bool) {
+	live, err := s.Sessions.Get(user)
+	if err != nil || live.Addr() == "" {
+		return nil, false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+live.Addr()+path, nil)
+	if err != nil {
+		return nil, false
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, false
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, false
+	}
+	raw, err := io.ReadAll(io.LimitReader(res.Body, maxBody))
+	if err != nil {
+		return nil, false
+	}
+	return raw, true
+}
+
+// writeRaw passes a session Pod's JSON answer through untouched.
+//
+// Re-encoding it would mean modelling the conductor's job shape in the
+// hub, which is precisely the coupling that lets the two drift: the
+// overlay renders whatever the conductor sends, and the hub's only
+// interest here is which of the two answers to forward.
+func writeRaw(w http.ResponseWriter, raw []byte) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(raw)
 }

--- a/hub/internal/catalog/catalog.go
+++ b/hub/internal/catalog/catalog.go
@@ -1,0 +1,301 @@
+// Package catalog is the hub's list of exams, read once at startup from
+// the bank index the banks image ships.
+//
+// It exists because of a timing problem that has no other answer: a
+// candidate in the lobby is choosing which certification to sit, and
+// until they have chosen there is no session Pod, so there is nothing
+// running that could be asked what exams exist. The hub has to know by
+// itself.
+//
+// It is a deliberate second implementation of the conductor's scan
+// (conductor/internal/catalog), on the same precedent already recorded
+// in docs/follow-ups.md for the hub re-implementing the facilitator's
+// attempt rollup: the four Go modules never import one another, and the
+// alternative — copying every bank's title, engine and question count
+// into values.yaml — puts the same facts in two places, one of which
+// nobody updates. This reads the bank itself, so it cannot say something
+// the bank does not.
+//
+// What it deliberately does NOT do is the conductor's job. There is no
+// Switchable, no question-id validation and no hidden-bank plumbing:
+// nothing here ever reaches a shell command, and admission is the only
+// decision made from it.
+package catalog
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// bankIDPattern is the only shape a bank id may take. The hub stamps a
+// bank into a Pod spec and into a label value, so a name that is not a
+// slug is rejected before either.
+var bankIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+
+// allowedInstances is the fixed session topology every runnable hands-on
+// bank must fit (see docs/bank-spec.md). Two shells, named, in every
+// deployment: the compose file, the session Pod's hostAliases and its
+// per-instance volumes all agree on it.
+var allowedInstances = map[string]bool{"instance-1": true, "instance-2": true}
+
+// Entry is one exam as the hosted lobby renders it.
+//
+// The JSON names match the local exam selector's `BankEntry` exactly,
+// because the two screens show the same cards and the SPA reads them
+// with one type. A field this hub cannot know is simply absent.
+type Entry struct {
+	ID                string `json:"id"`
+	Title             string `json:"title"`
+	Certification     string `json:"certification,omitempty"`
+	Description       string `json:"description,omitempty"`
+	ExamType          string `json:"examType"`
+	DurationSeconds   int    `json:"durationSeconds,omitempty"`
+	PassingScore      int    `json:"passingScore,omitempty"`
+	KubernetesVersion string `json:"kubernetesVersion,omitempty"`
+	// QuestionCount is what one attempt asks; PoolCount is what the bank
+	// authors. They differ only for a pooled bank, and the card prints
+	// the pair only when they do.
+	QuestionCount int `json:"questionCount,omitempty"`
+	PoolCount     int `json:"poolCount,omitempty"`
+	// Nodes is spec.environment.nodes: how big this exam's cluster is,
+	// and the same number bootstrap.sh generates the kind config from.
+	//
+	// Carried so the hosted boot screen can describe the environment it
+	// is actually building. It used to assert two nodes at everybody,
+	// which was true only because CKAD was the only hands-on exam. Zero
+	// means the bank declared none — every mcq bank, which has no
+	// cluster — and the copy has to survive not knowing.
+	Nodes      int    `json:"nodes,omitempty"`
+	Available  bool   `json:"available"`
+	ComingSoon bool   `json:"comingSoon,omitempty"`
+	Note       string `json:"note,omitempty"`
+
+	// Hidden keeps a bank out of the lobby without removing it from the
+	// catalog. tests/smoke.sh's fixture bank sets it.
+	Hidden bool `json:"-"`
+}
+
+// Catalog is an immutable set of entries. The banks are an image layer;
+// a new bank is a new image and therefore a new hub Pod.
+type Catalog struct {
+	entries map[string]Entry
+}
+
+// bankDoc mirrors the fields this package needs out of a bank's
+// yq-converted exam.yaml.
+type bankDoc struct {
+	Metadata struct {
+		Name          string `json:"name"`
+		Title         string `json:"title"`
+		Certification string `json:"certification"`
+		Description   string `json:"description"`
+		Hidden        bool   `json:"hidden"`
+	} `json:"metadata"`
+	Spec struct {
+		ExamType          string `json:"examType"`
+		Duration          string `json:"duration"`
+		PassingScore      int    `json:"passingScore"`
+		KubernetesVersion string `json:"kubernetesVersion"`
+		ExamLength        int    `json:"examLength"`
+		Environment       struct {
+			Nodes int `json:"nodes"`
+		} `json:"environment"`
+		Instances []struct {
+			Name string `json:"name"`
+		} `json:"instances"`
+		Questions []struct {
+			ID string `json:"id"`
+		} `json:"questions"`
+	} `json:"spec"`
+}
+
+// comingSoonDoc mirrors _catalog.json: certifications advertised on the
+// path whose bank is not written yet.
+type comingSoonDoc struct {
+	ComingSoon []struct {
+		ID            string `json:"id"`
+		Title         string `json:"title"`
+		Certification string `json:"certification"`
+		ExamType      string `json:"examType"`
+		Note          string `json:"note"`
+	} `json:"comingSoon"`
+}
+
+// Load reads every *.json in dir plus the optional _catalog.json.
+//
+// A single unreadable or malformed bank is skipped with a note on
+// stderr rather than failing the load: this runs at hub startup, and one
+// bad bank must not take down the front door of the whole deployment.
+// An empty or missing directory is an empty catalog, not an error — a
+// deployment that has not staged the index yet still serves identity,
+// history and its already-running sessions.
+func Load(dir string) (*Catalog, error) {
+	c := &Catalog{entries: map[string]Entry{}}
+	if dir == "" {
+		return c, nil
+	}
+	paths, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	if err != nil {
+		return nil, fmt.Errorf("catalog: glob %s: %w", dir, err)
+	}
+	for _, p := range paths {
+		base := strings.TrimSuffix(filepath.Base(p), ".json")
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "catalog: read %s: %v (skipped)\n", p, err)
+			continue
+		}
+		if base == "_catalog" {
+			c.mergeComingSoon(p, raw)
+			continue
+		}
+		entry, err := buildEntry(base, raw)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "catalog: %s: %v (skipped)\n", p, err)
+			continue
+		}
+		c.entries[entry.ID] = entry
+	}
+	return c, nil
+}
+
+func (c *Catalog) mergeComingSoon(path string, raw []byte) {
+	var doc comingSoonDoc
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		fmt.Fprintf(os.Stderr, "catalog: parse %s: %v (skipped)\n", path, err)
+		return
+	}
+	for _, cs := range doc.ComingSoon {
+		// A real bank directory with this id wins: the entry here is a
+		// placeholder for something that does not exist yet, and the
+		// moment it does exist the placeholder is stale.
+		if _, exists := c.entries[cs.ID]; exists {
+			continue
+		}
+		c.entries[cs.ID] = Entry{
+			ID:            cs.ID,
+			Title:         cs.Title,
+			Certification: cs.Certification,
+			ExamType:      cs.ExamType,
+			Available:     false,
+			ComingSoon:    true,
+			Note:          cs.Note,
+		}
+	}
+}
+
+// List returns every non-hidden entry, available ones first and then by
+// title, which is the order the lobby renders.
+func (c *Catalog) List() []Entry {
+	out := make([]Entry, 0, len(c.entries))
+	for _, e := range c.entries {
+		if e.Hidden {
+			continue
+		}
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Available != out[j].Available {
+			return out[i].Available
+		}
+		return out[i].Title < out[j].Title
+	})
+	return out
+}
+
+// Get returns the entry for a bank id, hidden ones included: the smoke
+// fixture is startable by name even though it is not offered.
+func (c *Catalog) Get(id string) (Entry, bool) {
+	e, ok := c.entries[id]
+	return e, ok
+}
+
+// Len reports how many exams were loaded, for the startup log.
+func (c *Catalog) Len() int { return len(c.entries) }
+
+// declaredQuestionCount mirrors the facilitator's own: a pooled bank's
+// card shows its draw size, not the authored pool behind it.
+func declaredQuestionCount(examLength, poolSize int) int {
+	if examLength > 0 && examLength < poolSize {
+		return examLength
+	}
+	return poolSize
+}
+
+func buildEntry(id string, raw []byte) (Entry, error) {
+	var doc bankDoc
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return Entry{}, fmt.Errorf("parse: %w", err)
+	}
+	if doc.Metadata.Name != "" && doc.Metadata.Name != id {
+		return Entry{}, fmt.Errorf("metadata.name %q != bank dir %q", doc.Metadata.Name, id)
+	}
+
+	examType := doc.Spec.ExamType
+	if examType == "" {
+		examType = "hands-on" // the facilitator's own default
+	}
+
+	entry := Entry{
+		ID:                id,
+		Title:             doc.Metadata.Title,
+		Certification:     doc.Metadata.Certification,
+		Description:       doc.Metadata.Description,
+		ExamType:          examType,
+		PassingScore:      doc.Spec.PassingScore,
+		KubernetesVersion: doc.Spec.KubernetesVersion,
+		QuestionCount:     declaredQuestionCount(doc.Spec.ExamLength, len(doc.Spec.Questions)),
+		PoolCount:         len(doc.Spec.Questions),
+		Nodes:             doc.Spec.Environment.Nodes,
+		Available:         true,
+		Hidden:            doc.Metadata.Hidden,
+	}
+	if d, err := time.ParseDuration(doc.Spec.Duration); err == nil {
+		entry.DurationSeconds = int(d.Seconds())
+	}
+
+	// Everything below marks a bank unavailable rather than dropping it.
+	// A candidate who can see that CKS exists and why it cannot be sat
+	// has learnt something; a card that silently vanished has not.
+	if !bankIDPattern.MatchString(id) {
+		entry.Available = false
+		entry.Note = "bank id is not a valid slug"
+		return entry, nil
+	}
+	switch examType {
+	case "hands-on":
+		if len(doc.Spec.Instances) == 0 || len(doc.Spec.Instances) > len(allowedInstances) {
+			entry.Available = false
+			entry.Note = "bank must declare 1-2 instances"
+			return entry, nil
+		}
+		for _, inst := range doc.Spec.Instances {
+			if !allowedInstances[inst.Name] {
+				entry.Available = false
+				entry.Note = fmt.Sprintf("instance %q is outside the fixed instance-1/instance-2 topology", inst.Name)
+				return entry, nil
+			}
+		}
+	case "mcq":
+		if len(doc.Spec.Instances) > 0 {
+			entry.Available = false
+			entry.Note = "mcq banks declare no instances"
+			return entry, nil
+		}
+	default:
+		entry.Available = false
+		entry.Note = fmt.Sprintf("no engine for examType %q", examType)
+		return entry, nil
+	}
+	if len(doc.Spec.Questions) == 0 {
+		entry.Available = false
+		entry.Note = "bank declares no questions"
+	}
+	return entry, nil
+}

--- a/hub/internal/catalog/catalog_test.go
+++ b/hub/internal/catalog/catalog_test.go
@@ -1,0 +1,187 @@
+package catalog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeIndex builds the directory the banks image stages: one JSON
+// document per bank, named for its directory, exactly as the image's
+// index stage emits them.
+func writeIndex(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	return dir
+}
+
+const ckad = `{
+  "metadata": {"name": "ckad-mock-01", "title": "CKAD Mock Exam 01", "certification": "CKAD",
+               "description": "Twenty-two hands-on tasks."},
+  "spec": {"examType": "hands-on", "duration": "120m", "passingScore": 66,
+           "kubernetesVersion": "1.35",
+           "instances": [{"name": "instance-1"}, {"name": "instance-2"}],
+           "questions": [{"id": "q01"}, {"id": "q02"}, {"id": "q03"}]}
+}`
+
+const kcna = `{
+  "metadata": {"name": "kcna-mock", "title": "KCNA Mock Exam", "certification": "KCNA"},
+  "spec": {"examType": "mcq", "duration": "90m", "passingScore": 75, "examLength": 2,
+           "questions": [{"id": "q01"}, {"id": "q02"}, {"id": "q03"}, {"id": "q04"}]}
+}`
+
+func entryByID(t *testing.T, c *Catalog, id string) Entry {
+	t.Helper()
+	e, ok := c.Get(id)
+	if !ok {
+		t.Fatalf("%s missing from the catalog", id)
+	}
+	return e
+}
+
+func TestLoadReadsEveryBank(t *testing.T) {
+	c, err := Load(writeIndex(t, map[string]string{
+		"ckad-mock-01.json": ckad,
+		"kcna-mock.json":    kcna,
+	}))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	ck := entryByID(t, c, "ckad-mock-01")
+	if !ck.Available || ck.Certification != "CKAD" || ck.ExamType != "hands-on" {
+		t.Errorf("ckad = %+v, want an available hands-on CKAD entry", ck)
+	}
+	if ck.DurationSeconds != 7200 {
+		t.Errorf("DurationSeconds = %d, want 7200", ck.DurationSeconds)
+	}
+	// Not pooled: both counts are the authored pool, and the card must
+	// not print "3 / 3" as though a draw were happening.
+	if ck.QuestionCount != 3 || ck.PoolCount != 3 {
+		t.Errorf("counts = %d/%d, want 3/3", ck.QuestionCount, ck.PoolCount)
+	}
+
+	// Pooled: the card shows the draw size, never the pool behind it.
+	kc := entryByID(t, c, "kcna-mock")
+	if kc.QuestionCount != 2 || kc.PoolCount != 4 {
+		t.Errorf("kcna counts = %d/%d, want 2/4", kc.QuestionCount, kc.PoolCount)
+	}
+}
+
+// A bank that cannot be sat is listed and explained, not dropped. A
+// candidate who can see that CKS exists and why it is not ready has
+// learnt something; a card that silently vanished has not.
+func TestUnrunnableBanksAreListedWithTheReason(t *testing.T) {
+	c, err := Load(writeIndex(t, map[string]string{
+		// Outside the fixed two-instance topology every session has.
+		"odd-mock.json": `{"metadata":{"name":"odd-mock","title":"Odd"},
+		  "spec":{"examType":"hands-on","duration":"60m",
+		          "instances":[{"name":"instance-9"}],"questions":[{"id":"q01"}]}}`,
+		// An engine that does not exist.
+		"weird-mock.json": `{"metadata":{"name":"weird-mock","title":"Weird"},
+		  "spec":{"examType":"oral","duration":"60m","questions":[{"id":"q01"}]}}`,
+		// mcq banks grade in the facilitator and have no shells at all.
+		"chatty-mock.json": `{"metadata":{"name":"chatty-mock","title":"Chatty"},
+		  "spec":{"examType":"mcq","duration":"60m",
+		          "instances":[{"name":"instance-1"}],"questions":[{"id":"q01"}]}}`,
+	}))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	for _, id := range []string{"odd-mock", "weird-mock", "chatty-mock"} {
+		e := entryByID(t, c, id)
+		if e.Available {
+			t.Errorf("%s is available, want refused", id)
+		}
+		if e.Note == "" {
+			t.Errorf("%s is unavailable with no reason given", id)
+		}
+	}
+}
+
+// One broken bank must not take the front door of the deployment down
+// with it: this runs at hub startup, before anyone can sign in.
+func TestOneBrokenBankDoesNotFailTheLoad(t *testing.T) {
+	c, err := Load(writeIndex(t, map[string]string{
+		"ckad-mock-01.json": ckad,
+		"broken.json":       `{"metadata": {`,
+		// metadata.name disagreeing with the directory is how a copied
+		// bank ends up shadowing the one it was copied from.
+		"misnamed.json": `{"metadata":{"name":"something-else","title":"X"},"spec":{"duration":"1m"}}`,
+	}))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, ok := c.Get("ckad-mock-01"); !ok {
+		t.Error("the good bank was lost with the bad ones")
+	}
+	for _, id := range []string{"broken", "misnamed"} {
+		if _, ok := c.Get(id); ok {
+			t.Errorf("%s was loaded, want skipped", id)
+		}
+	}
+}
+
+// The coming-soon list is how a certification on the path appears before
+// its bank exists — and it must never shadow the real thing once it does.
+func TestComingSoonFillsGapsButNeverShadowsARealBank(t *testing.T) {
+	c, err := Load(writeIndex(t, map[string]string{
+		"ckad-mock-01.json": ckad,
+		"_catalog.json": `{"comingSoon":[
+		  {"id":"cks-mock","title":"CKS Mock Exam","certification":"CKS","examType":"hands-on",
+		   "note":"Needs security add-ons the environment has not got"},
+		  {"id":"ckad-mock-01","title":"STALE","certification":"NOPE","examType":"mcq"}]}`,
+	}))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	cks := entryByID(t, c, "cks-mock")
+	if cks.Available || !cks.ComingSoon || cks.Note == "" {
+		t.Errorf("cks = %+v, want an unavailable coming-soon entry with a note", cks)
+	}
+	if got := entryByID(t, c, "ckad-mock-01"); got.Title == "STALE" {
+		t.Error("a stale coming-soon entry shadowed the real bank")
+	}
+}
+
+// Hidden keeps the smoke fixture out of the lobby without making it
+// unstartable by name — the same split the conductor's catalog draws.
+func TestHiddenBanksAreNotOfferedButAreStillFound(t *testing.T) {
+	c, err := Load(writeIndex(t, map[string]string{
+		"ckad-mock-01.json": ckad,
+		"smoke-01.json": `{"metadata":{"name":"smoke-01","title":"Smoke","hidden":true},
+		  "spec":{"examType":"hands-on","duration":"120m",
+		          "instances":[{"name":"instance-1"}],"questions":[{"id":"q01"}]}}`,
+	}))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	for _, e := range c.List() {
+		if e.ID == "smoke-01" {
+			t.Error("the hidden fixture is offered in the lobby")
+		}
+	}
+	if _, ok := c.Get("smoke-01"); !ok {
+		t.Error("the hidden fixture cannot be found by name")
+	}
+}
+
+// A deployment that staged no index is a hub that serves identity,
+// history and its running sessions. It is not a failure to start.
+func TestNoIndexIsAnEmptyCatalogNotAnError(t *testing.T) {
+	for _, dir := range []string{"", filepath.Join(t.TempDir(), "absent")} {
+		c, err := Load(dir)
+		if err != nil {
+			t.Fatalf("Load(%q): %v", dir, err)
+		}
+		if c.Len() != 0 || len(c.List()) != 0 {
+			t.Errorf("Load(%q) found %d entries, want none", dir, c.Len())
+		}
+	}
+}

--- a/hub/internal/session/session.go
+++ b/hub/internal/session/session.go
@@ -118,9 +118,31 @@ type Pod struct {
 type Flavour struct {
 	Seats    int
 	Template Template
-	// Bank is the exam this flavour starts on. Empty leaves whatever the
-	// template declares.
+	// Bank is the exam this flavour starts on when the candidate names
+	// none. Empty leaves whatever the template declares.
+	//
+	// It used to be the exam, full stop — a deployment value the person
+	// sitting the exam never saw. It is a DEFAULT now: the lobby offers
+	// certifications, and Start takes the one that was chosen.
 	Bank string
+	// BankTemplates are per-exam manifests, keyed by bank id, for exams
+	// that need a differently sized Pod. A bank with no entry gets
+	// Template.
+	//
+	// One seat pool either way: the queue, the seat count and admission
+	// are all per-kind, and an exam does not get its own capacity by
+	// needing more memory. This only changes what is stamped out once a
+	// seat has been granted — a CKA Pod running three kind nodes cannot
+	// be sized by what CKAD measured.
+	BankTemplates map[string]Template
+}
+
+// templateFor returns the manifest this flavour stamps out for a bank.
+func (f Flavour) templateFor(bank string) Template {
+	if t, ok := f.BankTemplates[bank]; ok && len(t) > 0 {
+		return t
+	}
+	return f.Template
 }
 
 // Config is everything the manager needs to be built.
@@ -301,7 +323,10 @@ func (m *Manager) logf(format string, args ...any) {
 // Idempotent: a user who already has a session gets it back rather than a
 // second one. The UI polls this while queued, and each poll is also how a
 // held seat is claimed.
-func (m *Manager) Start(ctx context.Context, user string, kind Kind) (Session, error) {
+// bank names the exam to stamp into the Pod. Empty falls back to the
+// flavour's default, which is what an older client — or a deployment
+// whose lobby has no exam list to offer — sends.
+func (m *Manager) Start(ctx context.Context, user string, kind Kind, bank string) (Session, error) {
 	m.mu.Lock()
 
 	if e, ok := m.sessions[user]; ok {
@@ -315,6 +340,9 @@ func (m *Manager) Start(ctx context.Context, user string, kind Kind) (Session, e
 	if !ok || fl.Seats <= 0 {
 		m.mu.Unlock()
 		return Session{}, fmt.Errorf("%w: %s", ErrNoSuchKind, kind)
+	}
+	if bank == "" {
+		bank = fl.Bank
 	}
 
 	// A seat this user is already holding through the queue counts as
@@ -331,7 +359,7 @@ func (m *Manager) Start(ctx context.Context, user string, kind Kind) (Session, e
 		Session: Session{
 			User:      user,
 			Kind:      kind,
-			Bank:      fl.Bank,
+			Bank:      bank,
 			Pod:       m.podName(user, kind),
 			State:     Pending,
 			StartedAt: now,
@@ -345,7 +373,7 @@ func (m *Manager) Start(ctx context.Context, user string, kind Kind) (Session, e
 	s := e.Session
 	m.mu.Unlock()
 
-	m.logf("hub: admitted %s to a %s seat as %s", user, kind, e.Pod)
+	m.logf("hub: admitted %s to a %s seat as %s, sitting %s", user, kind, e.Pod, bank)
 	// Detached from the request: booting takes minutes and the browser
 	// polls. ctx here would cancel the boot when the admitting request
 	// returned.
@@ -405,7 +433,7 @@ func (m *Manager) createAndWait(ctx context.Context, e *entry, fl Flavour) error
 		}
 		p.WebhookURL, p.WebhookToken = url, token
 	}
-	spec, err := fl.Template.render(p)
+	spec, err := fl.templateFor(e.Bank).render(p)
 	if err != nil {
 		return err
 	}

--- a/hub/internal/session/session_test.go
+++ b/hub/internal/session/session_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -16,6 +17,9 @@ type fakePods struct {
 	mu      sync.Mutex
 	pods    map[string]*Pod
 	created []string
+	// specs are the manifests as they were actually submitted, which is
+	// the only place the rendered template can be observed.
+	specs [][]byte
 	// notReady names Pods that never become ready, to exercise the
 	// waiting paths.
 	notReady   map[string]bool
@@ -46,6 +50,7 @@ func (f *fakePods) Create(_ context.Context, spec []byte) error {
 		return ErrPodExists
 	}
 	f.created = append(f.created, name)
+	f.specs = append(f.specs, append([]byte(nil), spec...))
 	f.pods[name] = &Pod{
 		Name: name, IP: "10.42.0.9", Phase: "Running",
 		Ready: !f.notReady[name], CreatedAt: time.Now(), Labels: pod.Metadata.Labels,
@@ -128,11 +133,81 @@ func waitReady(t *testing.T, m *Manager, user string) Session {
 	return Session{}
 }
 
+func (f *fakePods) lastSpec() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.specs) == 0 {
+		return ""
+	}
+	return string(f.specs[len(f.specs)-1])
+}
+
+// The exam a candidate chooses is what gets stamped into their Pod. It
+// used to be a deployment value they never saw — `sessions.practical.bank`
+// — and the flavour's setting is now the DEFAULT for a request that
+// names none, not the answer.
+func TestTheChosenExamIsWhatTheSessionSits(t *testing.T) {
+	m, pods := newManager(t, 1, nil)
+
+	if _, err := m.Start(context.Background(), "583231", Practical, "cka-mock-01"); err != nil {
+		t.Fatal(err)
+	}
+	live := waitReady(t, m, "583231")
+	if live.Bank != "cka-mock-01" {
+		t.Errorf("bank = %q, want the exam that was chosen", live.Bank)
+	}
+	// Not just recorded on the session: it has to reach the Pod, which is
+	// the only thing the facilitator inside it ever reads.
+	if spec := pods.lastSpec(); !strings.Contains(spec, `"cka-mock-01"`) {
+		t.Errorf("the chosen exam never reached the Pod spec: %s", spec)
+	}
+}
+
+// One seat pool, but not one Pod shape. An exam whose cluster is a
+// different size cannot be sized by what another exam measured, and the
+// chart writes it its own manifest.
+func TestAnExamWithItsOwnPodSpecGetsIt(t *testing.T) {
+	special := `{"kind":"Pod","metadata":{},"spec":{"containers":[` +
+		`{"name":"facilitator","env":[{"name":"BANK","value":"x"}]},` +
+		`{"name":"an-extra-node","env":[]}]}}`
+	m, pods := newManager(t, 1, func(cfg *Config) {
+		fl := cfg.Flavours[Practical]
+		fl.BankTemplates = map[string]Template{"cka-mock-01": Template(special)}
+		cfg.Flavours[Practical] = fl
+	})
+
+	if _, err := m.Start(context.Background(), "583231", Practical, "cka-mock-01"); err != nil {
+		t.Fatal(err)
+	}
+	waitReady(t, m, "583231")
+	if spec := pods.lastSpec(); !strings.Contains(spec, "an-extra-node") {
+		t.Errorf("the exam's own Pod spec was not used: %s", spec)
+	}
+}
+
+// A bank with no manifest of its own gets the flavour's, which is every
+// bank today. The lookup must not be a requirement.
+func TestAnExamWithNoPodSpecOfItsOwnUsesTheFlavours(t *testing.T) {
+	m, pods := newManager(t, 1, func(cfg *Config) {
+		fl := cfg.Flavours[Practical]
+		fl.BankTemplates = map[string]Template{"cka-mock-01": Template(miniTemplate)}
+		cfg.Flavours[Practical] = fl
+	})
+
+	if _, err := m.Start(context.Background(), "583231", Practical, "ckad-mock-01"); err != nil {
+		t.Fatal(err)
+	}
+	waitReady(t, m, "583231")
+	if spec := pods.lastSpec(); !strings.Contains(spec, `"ckad-mock-01"`) {
+		t.Errorf("the default template did not carry the chosen exam: %s", spec)
+	}
+}
+
 func TestStartCreatesAPodAndBecomesReady(t *testing.T) {
 	m, pods := newManager(t, 1, nil)
 	ctx := context.Background()
 
-	s, err := m.Start(ctx, "583231", Practical)
+	s, err := m.Start(ctx, "583231", Practical, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +225,7 @@ func TestStartCreatesAPodAndBecomesReady(t *testing.T) {
 	}
 	// Idempotent: a second start returns the same session, not a second
 	// Pod and not a queue position.
-	if _, err := m.Start(ctx, "583231", Practical); err != nil {
+	if _, err := m.Start(ctx, "583231", Practical, ""); err != nil {
 		t.Fatal(err)
 	}
 	if pods.count() != 1 {
@@ -166,10 +241,10 @@ func TestASeatIsHeldWhileTheSessionIsStillBooting(t *testing.T) {
 	pods.notReady["sim-session-practical-first"] = true
 	ctx := context.Background()
 
-	if _, err := m.Start(ctx, "first", Practical); err != nil {
+	if _, err := m.Start(ctx, "first", Practical, ""); err != nil {
 		t.Fatal(err)
 	}
-	_, err := m.Start(ctx, "second", Practical)
+	_, err := m.Start(ctx, "second", Practical, "")
 	var q *Queued
 	if !errors.As(err, &q) {
 		t.Fatalf("second candidate got %v, want a queue position", err)
@@ -189,14 +264,14 @@ func TestTheQueueHeadGetsAHoldAndOnlyTheyCanClaimIt(t *testing.T) {
 	})
 	ctx := context.Background()
 
-	if _, err := m.Start(ctx, "holder", Practical); err != nil {
+	if _, err := m.Start(ctx, "holder", Practical, ""); err != nil {
 		t.Fatal(err)
 	}
 	waitReady(t, m, "holder")
 
 	// Two candidates queue, in order.
 	for _, u := range []string{"queued-1", "queued-2"} {
-		if _, err := m.Start(ctx, u, Practical); err == nil {
+		if _, err := m.Start(ctx, u, Practical, ""); err == nil {
 			t.Fatalf("%s was admitted with no free seat", u)
 		}
 	}
@@ -208,10 +283,10 @@ func TestTheQueueHeadGetsAHoldAndOnlyTheyCanClaimIt(t *testing.T) {
 	if err := m.End(ctx, "holder"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.Start(ctx, "queued-2", Practical); err == nil {
+	if _, err := m.Start(ctx, "queued-2", Practical, ""); err == nil {
 		t.Error("queued-2 jumped the queue")
 	}
-	if _, err := m.Start(ctx, "queued-1", Practical); err != nil {
+	if _, err := m.Start(ctx, "queued-1", Practical, ""); err != nil {
 		t.Fatalf("the head of the queue could not claim its seat: %v", err)
 	}
 	waitReady(t, m, "queued-1")
@@ -231,12 +306,12 @@ func TestAnUnclaimedHoldLapsesAndThePersonBehindGetsTheSeat(t *testing.T) {
 	})
 	ctx := context.Background()
 
-	if _, err := m.Start(ctx, "holder", Practical); err != nil {
+	if _, err := m.Start(ctx, "holder", Practical, ""); err != nil {
 		t.Fatal(err)
 	}
 	waitReady(t, m, "holder")
-	m.Start(ctx, "ghost", Practical)
-	m.Start(ctx, "patient", Practical)
+	m.Start(ctx, "ghost", Practical, "")
+	m.Start(ctx, "patient", Practical, "")
 	if err := m.End(ctx, "holder"); err != nil {
 		t.Fatal(err)
 	}
@@ -248,7 +323,7 @@ func TestAnUnclaimedHoldLapsesAndThePersonBehindGetsTheSeat(t *testing.T) {
 	if got := m.Position("ghost"); got != 0 {
 		t.Errorf("ghost is still queued at %d", got)
 	}
-	if _, err := m.Start(ctx, "patient", Practical); err != nil {
+	if _, err := m.Start(ctx, "patient", Practical, ""); err != nil {
 		t.Fatalf("patient still cannot start after the hold lapsed: %v", err)
 	}
 }
@@ -264,7 +339,7 @@ func TestPodCreationIsSerialised(t *testing.T) {
 	}
 
 	for _, u := range []string{"a", "b", "c"} {
-		if _, err := m.Start(ctx, u, Practical); err != nil {
+		if _, err := m.Start(ctx, u, Practical, ""); err != nil {
 			t.Fatalf("%s: %v", u, err)
 		}
 	}
@@ -290,7 +365,7 @@ func TestIdleAndAgedSessionsAreReaped(t *testing.T) {
 	ctx := context.Background()
 
 	for _, u := range []string{"idle", "old", "active"} {
-		if _, err := m.Start(ctx, u, Practical); err != nil {
+		if _, err := m.Start(ctx, u, Practical, ""); err != nil {
 			t.Fatal(err)
 		}
 		waitReady(t, m, u)
@@ -328,7 +403,7 @@ func TestIdleAndAgedSessionsAreReaped(t *testing.T) {
 func TestAVanishedPodFreesItsSeat(t *testing.T) {
 	m, pods := newManager(t, 1, nil)
 	ctx := context.Background()
-	if _, err := m.Start(ctx, "unlucky", Practical); err != nil {
+	if _, err := m.Start(ctx, "unlucky", Practical, ""); err != nil {
 		t.Fatal(err)
 	}
 	waitReady(t, m, "unlucky")
@@ -341,7 +416,7 @@ func TestAVanishedPodFreesItsSeat(t *testing.T) {
 	if _, err := m.Get("unlucky"); !errors.Is(err, ErrNoSession) {
 		t.Error("the session outlived its pod")
 	}
-	if _, err := m.Start(ctx, "next", Practical); err != nil {
+	if _, err := m.Start(ctx, "next", Practical, ""); err != nil {
 		t.Errorf("the seat was never released: %v", err)
 	}
 }
@@ -353,7 +428,7 @@ func TestAVanishedPodFreesItsSeat(t *testing.T) {
 func TestAdoptReattachesToRunningSessions(t *testing.T) {
 	m, pods := newManager(t, 2, nil)
 	ctx := context.Background()
-	if _, err := m.Start(ctx, "583231", Practical); err != nil {
+	if _, err := m.Start(ctx, "583231", Practical, ""); err != nil {
 		t.Fatal(err)
 	}
 	waitReady(t, m, "583231")
@@ -383,7 +458,7 @@ func TestAdoptReattachesToRunningSessions(t *testing.T) {
 func TestRecycleReplacesThePodAndReportsPhases(t *testing.T) {
 	m, pods := newManager(t, 1, nil)
 	ctx := context.Background()
-	if _, err := m.Start(ctx, "583231", Practical); err != nil {
+	if _, err := m.Start(ctx, "583231", Practical, ""); err != nil {
 		t.Fatal(err)
 	}
 	waitReady(t, m, "583231")
@@ -443,7 +518,7 @@ func TestStartWaitsOutAPodStillTerminating(t *testing.T) {
 	if err := pods.Create(ctx, []byte(`{"metadata":{"name":"`+name+`"}}`)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.Start(ctx, "583231", Practical); err != nil {
+	if _, err := m.Start(ctx, "583231", Practical, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -460,7 +535,7 @@ func TestStartWaitsOutAPodStillTerminating(t *testing.T) {
 
 func TestUnknownKindIsRefused(t *testing.T) {
 	m, _ := newManager(t, 1, nil)
-	if _, err := m.Start(context.Background(), "u", MCQ); !errors.Is(err, ErrNoSuchKind) {
+	if _, err := m.Start(context.Background(), "u", MCQ, ""); !errors.Is(err, ErrNoSuchKind) {
 		t.Errorf("err = %v, want ErrNoSuchKind for a flavour this deployment does not offer", err)
 	}
 }

--- a/images/banks/Dockerfile
+++ b/images/banks/Dockerfile
@@ -16,5 +16,37 @@
 # context, and that exclusion would apply here too.
 #
 #   docker build -f images/banks/Dockerfile -t <repo>/kubestronaut-sim-banks banks/
+
+# The index: every bank's exam.yaml as JSON, plus catalog.yaml.
+#
+# It exists for the hub, which is the one process that needs to know what
+# exams exist BEFORE any session Pod has been created — a candidate in
+# the lobby is choosing which certification to sit, and there is nothing
+# running yet to ask. Every other consumer reads the YAML in /src.
+#
+# Converted here, at build time, rather than by a yq init container in
+# the hub's Deployment. The hub is a FROM scratch image with no shell,
+# and this repo's rule is that no Go binary parses YAML — so the JSON has
+# to be produced by something, and the image that owns the content is the
+# honest place for it. It is generated, never authored: /src stays the
+# single source of truth and this cannot drift from it.
+#
+# Same layout the conductor's entrypoint produces at runtime
+# (<id>.json plus _catalog.json), so the two scans read the same shape.
+FROM alpine:3.21 AS index
+RUN apk add --no-cache yq
+COPY . /src
+RUN set -eu; \
+    mkdir -p /index; \
+    for f in /src/*/exam.yaml; do \
+      [ -f "$f" ] || continue; \
+      id=$(basename "$(dirname "$f")"); \
+      yq -o=json '.' "$f" > "/index/${id}.json"; \
+    done; \
+    if [ -f /src/catalog.yaml ]; then \
+      yq -o=json '.' /src/catalog.yaml > /index/_catalog.json; \
+    fi
+
 FROM alpine:3.21
 COPY . /src
+COPY --from=index /index /index

--- a/images/instance/entrypoint.sh
+++ b/images/instance/entrypoint.sh
@@ -7,6 +7,20 @@ set -euo pipefail
 # cold cluster bootstrap, but it is finite: a wait that has gone wrong
 # should end as a message in the log, not as a container that looks alive
 # and does nothing.
+# First, wait — without a deadline — for an exam to exist at all.
+#
+# The budget below exists to turn "a cold bootstrap has gone wrong" into a
+# message instead of a container that looks alive and does nothing. That
+# is a different situation from "nobody has chosen an exam yet", which is
+# a perfectly good state to sit in for an hour, and which no longer has a
+# compose health gate holding this container back from reaching it. Timing
+# out on it would kill an instance for being correctly idle, and nothing
+# would restart it.
+if [ ! -s /shared/bank ]; then
+  echo "no exam selected yet; waiting for one to be chosen..."
+  until [ -s /shared/bank ]; do sleep 2; done
+fi
+
 echo "waiting for cluster kubeconfig..."
 wait_deadline=$((SECONDS + ${INSTANCE_WAIT_BUDGET:-2400}))
 # -s, not -f: a zero-byte file is a file, and the whole failure this

--- a/images/k8s-env/bootstrap.sh
+++ b/images/k8s-env/bootstrap.sh
@@ -145,6 +145,34 @@ preload_bank_images() {
   done < /opt/sim/preload.txt
 }
 
+# How many nodes this exam's cluster has, from the bank that asked for
+# it. CKAD needs somewhere to schedule and nothing more; CKA has to be
+# able to drain one node and watch the work land on another, and CKS
+# wants a node it can leave broken. One cluster shape for all of them
+# would be wrong for at least two.
+#
+# /opt/sim/kind-config.yaml holds the control-plane node only — its
+# extraPortMappings and certSANs are the host -> cluster port chain and
+# have to be reproduced exactly — and the workers are appended here. The
+# shipped file is therefore a valid single-node config on its own, which
+# is what it produces when a bank asks for one node.
+#
+# A malformed count fails the boot rather than quietly falling back to
+# two. `nodes: two` in a bank is an authoring mistake, and a cluster
+# silently the wrong size is the kind of thing that is discovered by a
+# CKA drain question grading zero.
+nodes=$(yq -r '.spec.environment.nodes // 2' "${BANK_DIR}/exam.yaml")
+case "$nodes" in
+  ''|*[!0-9]*|0) echo "spec.environment.nodes must be a positive integer, got '${nodes}'"; exit 1 ;;
+esac
+kind_config=/tmp/kind-config.yaml
+cp /opt/sim/kind-config.yaml "${kind_config}"
+worker=1
+while [ "$worker" -lt "$nodes" ]; do
+  printf '  - role: worker\n' >> "${kind_config}"
+  worker=$((worker + 1))
+done
+
 phase create-cluster "Creating the Kubernetes cluster" 3
 created=0
 if ! kind get clusters 2>/dev/null | grep -qx sim; then
@@ -157,7 +185,8 @@ if ! kind get clusters 2>/dev/null | grep -qx sim; then
   # is both correct and the safer pull.
   node_ref="${NODE_IMAGE}"
   [ -f /opt/sim/images/_node.tar ] && node_ref="${NODE_IMAGE%%@*}"
-  kind create cluster --config /opt/sim/kind-config.yaml --image "${node_ref}"
+  echo "creating a ${nodes}-node cluster"
+  kind create cluster --config "${kind_config}" --image "${node_ref}"
   created=1
 fi
 kind get kubeconfig --name sim | sed 's#https://0\.0\.0\.0:6443#https://k8s-env:6443#' | write_shared /shared/kubeconfig

--- a/images/k8s-env/kind-config.yaml
+++ b/images/k8s-env/kind-config.yaml
@@ -55,4 +55,14 @@ nodes:
       - containerPort: 30082
         hostPort: 30082
         protocol: TCP
-  - role: worker
+# The workers are NOT here. bootstrap.sh copies this file and appends one
+# `- role: worker` per extra node the active bank's spec.environment.nodes
+# asks for, because the right number is a property of the certification
+# being rehearsed and not of the image: a CKA bank has to be able to
+# cordon one node and see the work move.
+#
+# So this file describes a single-node cluster, and that is exactly what
+# a bank asking for one node gets. Everything above the node list —
+# especially the port mappings and certSANs, which are the whole
+# host -> cluster chain — is shared by every size and lives here so there
+# is one copy of it.

--- a/images/k8s-env/phase.sh
+++ b/images/k8s-env/phase.sh
@@ -95,3 +95,23 @@ boot_failed() {
   echo "[boot] FAILED: $1" >&2
   _boot_write failed "" "$1"
 }
+
+# boot_idle
+#
+# Resting, not working: the container is up and no exam has been chosen,
+# so there is nothing to build yet. Distinct from `booting` because the
+# two want opposite things from the UI — a boot screen narrates progress
+# and asks the candidate to wait, while this one should get out of the
+# way and let them pick an exam.
+#
+# Reached only under compose with no BANK. A hosted session Pod is
+# always stamped with the exam it was created for, so it never idles.
+boot_idle() {
+  _boot_phase=awaiting-exam
+  _boot_label="Waiting for an exam to be chosen"
+  # The two phases that have run are the ones that are not about any
+  # particular exam: the container runtime and the chart repository.
+  _boot_step=2
+  echo "[boot] no exam selected; nothing to build until one is chosen"
+  _boot_write idle "" ""
+}

--- a/images/k8s-env/start.sh
+++ b/images/k8s-env/start.sh
@@ -115,6 +115,34 @@ start_control_sshd() {
     && echo "control sshd on ${SSHD_LISTEN}:22"
 }
 
+# Nothing above this line is about any particular exam — an inner Docker
+# daemon and a chart repository are the same whichever bank is chosen, and
+# both are once-per-container anyway. Everything below builds ONE exam's
+# environment, so it does not run until there is one to build.
+#
+# The runtime bank file wins over the compose-time env var, exactly as it
+# does inside bootstrap.sh. `./sim up` no longer passes a default, so a
+# bare `up` lands here with neither and the container rests: no cluster,
+# no CNI, no seeded questions, nothing that would have to be torn down
+# when the candidate picks something other than what we guessed. Picking
+# an exam writes /shared/bank and the conductor execs bootstrap.sh in
+# here, which is the same path a bank switch has always taken.
+#
+# A hosted session Pod is always stamped with BANK at creation, so it
+# never takes this branch.
+selected=""
+if [ -s /shared/bank ]; then
+  selected=$(cat /shared/bank)
+elif [ -n "${BANK:-}" ]; then
+  selected="$BANK"
+fi
+
+if [ -z "$selected" ]; then
+  boot_idle
+  start_control_sshd
+  tail -f /dev/null
+fi
+
 if ! /opt/sim/bootstrap.sh; then
   start_control_sshd
   echo "bootstrap failed; holding the container open so the failure is visible and retryable" >&2

--- a/sim
+++ b/sim
@@ -21,11 +21,70 @@ case "$cmd" in
     # The facilitator no longer waits for the cluster, so it answers
     # within seconds and /api/boot can narrate the rest. The browser shows
     # the same phases from the same source at the same time.
-    BANK=${2:-ckad-mock-01} docker compose up -d --build
+    # No default bank. `./sim up` brings the shell up and stops there;
+    # naming one — `./sim up ckad-mock-01` — additionally builds that
+    # exam's environment and waits for it, which is what the smoke suite
+    # and anyone who already knows what they want are doing.
+    #
+    # A warm stack keeps whatever is already active: /shared/bank
+    # survives `down`, and every entrypoint prefers the file over this
+    # variable, so this only decides what a FRESH environment builds.
+    BANK=${2:-} docker compose up -d --build
 
     budget=${SIM_BOOT_BUDGET:-3600}
     deadline=$((SECONDS + budget))
     last=""
+    if [ -z "${2:-}" ]; then
+      # Nothing to BUILD, which is not the same as nothing to wait for.
+      #
+      # This used to return the moment /api/boot answered, which the
+      # facilitator does within a second or two of starting. k8s-env is
+      # not done at that point: it still has the two phases that are not
+      # about any particular exam — the inner Docker daemon, then the
+      # chart repository — and it reports `booting` throughout. So the
+      # line below printed "Choose an exam" while the browser was still
+      # showing a boot screen. Measured at ~8s on a warm laptop; the
+      # smoke suite caught it by sampling the state at ~2s.
+      #
+      # Waiting for the state to SETTLE fixes it and costs those same
+      # seconds. It never waits for an exam: `idle` is the expected
+      # answer, and it means the shell is up with nothing chosen.
+      shell_deadline=$((SECONDS + ${SIM_SHELL_BUDGET:-300}))
+      while :; do
+        if [ "$SECONDS" -ge "$shell_deadline" ]; then
+          echo
+          echo "The environment did not finish starting up. Check with:"
+          echo "  docker compose logs k8s-env"
+          exit 1
+        fi
+        boot=$(curl -fsS --max-time 5 "${UI}/api/boot" 2>/dev/null) || { sleep 2; continue; }
+        state=$(printf '%s' "$boot" | json_field state)
+        label=$(printf '%s' "$boot" | json_field label)
+        if [ -n "$label" ] && [ "$label" != "$last" ]; then
+          echo "  $label"
+          last="$label"
+        fi
+        case "$state" in
+          idle)
+            echo "Ready. Choose an exam at ${UI} — its environment is built when you pick one."
+            exit 0 ;;
+          ready)
+            # A warm stack whose exam survived a `down`. Nothing was
+            # chosen just now, so say what is actually there rather than
+            # inviting a choice that has already been made.
+            echo "Exam environment ready. Exam UI: ${UI} — or ./sim ssh instance-1"
+            exit 0 ;;
+          failed)
+            echo
+            echo "The environment failed to start:"
+            printf '  %s\n' "$(printf '%s' "$boot" | json_field error)"
+            echo
+            echo "Full output:  docker compose logs k8s-env"
+            exit 1 ;;
+        esac
+        sleep 2
+      done
+    fi
     echo "Building the exam environment (first run pulls and seeds; later runs resume)..."
     while :; do
       if [ "$SECONDS" -ge "$deadline" ]; then

--- a/site/index.html
+++ b/site/index.html
@@ -209,9 +209,9 @@
             <p class="section-lede">
               Everything after <code>up</code> happens in the browser: a
               countdown that cannot be paused, a real Linux desktop with
-              terminals, a real two-node Kubernetes cluster to act on, a
-              per-check score with full solutions afterwards, and a record of
-              every graded attempt to measure the next one against.
+              terminals, a real Kubernetes cluster built for the exam you
+              picked, a per-check score with full solutions afterwards, and a
+              record of every graded attempt to measure the next one against.
             </p>
           </div>
 
@@ -229,15 +229,16 @@
                 <span class="term-bar-title">bash — quickstart</span>
               </figcaption>
               <pre class="term-body"><code><span class="term-prompt" aria-hidden="true">$ </span>./sim doctor    <span class="term-note"># optional preflight</span>
-<span class="term-prompt" aria-hidden="true">$ </span>./sim up        <span class="term-note"># first run: several minutes</span>
+<span class="term-prompt" aria-hidden="true">$ </span>./sim up        <span class="term-note"># brings the app up in seconds</span>
 <span class="term-prompt" aria-hidden="true">$ </span>open <span class="term-url">http://localhost:8080</span></code></pre>
             </figure>
 
             <p class="quickstart-note">
               Requires Docker Desktop (or docker + compose v2), python3, and
               about 9GB of free RAM — the XFCE desktop is inside that figure.
-              The UI comes up before the cluster does, so the page shows the
-              same boot progress the terminal does.
+              Nothing is built until you pick an exam: choosing one in the
+              browser is what creates its cluster, and the page shows that
+              build's progress step by step.
             </p>
           </div>
         </div>
@@ -248,10 +249,10 @@
         <h2 id="stats-title" class="sr-only">The numbers behind it</h2>
         <ul class="stat-grid">
           <li class="stat">
-            <p class="stat-figure">119</p>
+            <p class="stat-figure">123</p>
             <h3 class="stat-label">Questions written</h3>
             <p class="stat-note">
-              22 hands-on for CKAD and 97 multiple-choice for KCNA, counted from
+              26 hands-on for CKAD and 97 multiple-choice for KCNA, counted from
               the <code>spec.questions</code> list in each bank's
               <code>exam.yaml</code> file. All original: no third-party exam
               dump may be committed here, because CC BY-SA 4.0 requires the
@@ -319,17 +320,20 @@
                  of line with this one. -->
             <dl class="exam-stats">
               <div><dt>Duration</dt><dd>2h</dd></div>
-              <div><dt>Tasks</dt><dd>22</dd></div>
+              <div>
+                <dt>Drawn / pool</dt>
+                <dd>22 <span class="exam-stat-of">/ 26</span></dd>
+              </div>
               <div><dt>To pass</dt><dd>66%</dd></div>
               <div><dt>Engine</dt><dd class="exam-stat-engine">Practical</dd></div>
             </dl>
 
             <p class="exam-desc">
-              Developer-track exercises across the full CKAD curriculum:
-              workloads and multi-container design, deployments and
-              configuration, security contexts, observability, and services,
-              ingress and network policy. Two instances, kind-backed cluster,
-              Kubernetes 1.35.
+              22 tasks drawn each attempt from a 26-task pool, across the
+              full CKAD curriculum: workloads and multi-container design,
+              deployments and configuration, security contexts,
+              observability, and services, ingress and network policy. Two
+              instances, kind-backed cluster, Kubernetes 1.35.
             </p>
 
             <div class="domains">
@@ -363,9 +367,10 @@
             <dl class="exam-stats">
               <div><dt>Duration</dt><dd>1h 30m</dd></div>
               <!-- The pool pair, and its label, appear only when the two
-                   numbers differ. A card reading "22 / 22" would advertise
-                   a random draw that bank does not do, which is why the
-                   CKAD card says "Tasks, 22" instead. -->
+                   numbers differ. A card reading "65 / 65" would advertise
+                   a random draw that bank does not do. The CKAD card next
+                   to this one drew a flat "Tasks, 22" until its bank
+                   started pooling too. -->
               <div>
                 <dt>Drawn / pool</dt>
                 <dd>65 <span class="exam-stat-of">/ 97</span></dd>

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -38,6 +38,51 @@ bash tests/bank-mcq.sh || fail "mcq banks are malformed"
 
 ./sim purge   # cold start: the fresh-grade-0 assertion needs pristine cluster state
 
+echo "== nothing is built until an exam is chosen =="
+# The state a fresh `./sim up` now lands in, and the only place it is
+# exercised end to end. Cheap on purpose: it is one compose up and down
+# with no cluster in it, and it runs BEFORE the cold boot below so a
+# stack that cannot idle fails in a minute rather than forty.
+#
+# What it is really checking is the compose change underneath. The
+# instances and the desktop used to declare
+# `depends_on: k8s-env: {condition: service_healthy}`, which would have
+# made `docker compose up` block forever on a cluster nobody asked for.
+# Those gates are gone, so the containers now start into an environment
+# that has no kubeconfig and no bank — and they have to WAIT there,
+# without their own deadlines killing them for being correctly idle.
+idle_started=$SECONDS
+if ! ./sim up; then
+  fail "a bare ./sim up did not bring the shell up"
+else
+  echo "bare up took $((SECONDS - idle_started))s"
+
+  [ "$(req GET /api/boot)" = "200" ] || fail "idle: GET /api/boot did not answer 200"
+  [ "$(json_field state)" = "idle" ] || fail "idle: /api/boot state is '$(json_field state)', want idle"
+
+  # The split the facilitator has to hold with no bank loaded: routes
+  # that need one refuse with an explanation, and the catalog — which is
+  # HOW an exam gets chosen — still answers.
+  [ "$(req GET /api/exam)" = "503" ] || fail "idle: /api/exam should be 503 with no exam loaded"
+  [ -n "$(json_field error)" ] || fail "idle: /api/exam refused with no explanation"
+  [ "$(req GET /api/catalog)" = "200" ] || fail "idle: /api/catalog must answer — it is how an exam is chosen"
+  [ "$(json_field active)" = "" ] || fail "idle: /api/catalog names an active bank when none was chosen"
+
+  # Nothing built. A cluster here would mean the guess this whole change
+  # exists to avoid: minutes spent on an exam nobody picked.
+  docker compose exec -T k8s-env kind get clusters 2>/dev/null | grep -qx sim \
+    && fail "idle: a kind cluster exists before any exam was chosen" || true
+
+  # ...and the containers that no longer wait on it are up rather than
+  # dead. `compose ps` prints only running services by default, so their
+  # absence here is the failure.
+  for svc in instance-1 instance-2 desktop facilitator; do
+    docker compose ps --services --filter status=running | grep -qx "$svc" \
+      || fail "idle: ${svc} is not running (it should be waiting for an exam, not exiting)"
+  done
+fi
+./sim down
+
 # Bounded. `./sim up` used to be able to hang indefinitely (compose's
 # --wait defaults to no timeout), and because this script is `set -e`
 # with no timeout of its own, a hung boot hung the whole suite — the one
@@ -45,7 +90,13 @@ bash tests/bank-mcq.sh || fail "mcq banks are malformed"
 # ./sim up internally; this is the belt to that braces.
 SMOKE_BOOT_BUDGET=${SMOKE_BOOT_BUDGET:-3600}
 boot_started=$SECONDS
-if ! SIM_BOOT_BUDGET="$SMOKE_BOOT_BUDGET" ./sim up; then
+# The bank is named on purpose. A bare `./sim up` now brings up the shell
+# and stops — nothing is built until a candidate chooses an exam — so it
+# would return in seconds with no cluster and every assertion below would
+# fail against an environment that was never asked to exist. Naming one
+# is the "I already know what I want" path, and it still blocks until
+# that exam's environment is ready.
+if ! SIM_BOOT_BUDGET="$SMOKE_BOOT_BUDGET" ./sim up ckad-mock-01; then
   echo "SMOKE FAIL: ./sim up did not reach a ready environment within ${SMOKE_BOOT_BUDGET}s"
   docker compose logs --tail 80 k8s-env || true
   exit 1
@@ -194,6 +245,28 @@ bank_title=$(grep -m1 -E '^[[:space:]]*title:' banks/ckad-mock-01/exam.yaml | se
 api_title=$(json_field title)
 [ "$api_title" = "$bank_title" ] || fail "/api/exam title mismatch: bank='$bank_title' api='$api_title'"
 
+# Before any attempt exists, the two counts are the bank's two numbers:
+# `questionCount` is the DECLARED length (spec.examLength) and the
+# `questions` array is still the whole pool. Read off the bank file so
+# this tracks an edit to it rather than pinning today's figures.
+declared=$(grep -m1 -E '^[[:space:]]*examLength:' banks/ckad-mock-01/exam.yaml | sed -E 's/.*:[[:space:]]*//')
+pool=$(grep -cE '^[[:space:]]*- id: q' banks/ckad-mock-01/exam.yaml)
+[ "$(json_field questionCount)" = "$declared" ] \
+  || fail "/api/exam questionCount should be the declared ${declared}, got '$(json_field questionCount)'"
+api_pool=$(RESP="$RESP" python3 -c '
+import json, os
+with open(os.environ["RESP"]) as f:
+    print(len(json.load(f).get("questions", [])))
+')
+[ "$api_pool" = "$pool" ] \
+  || fail "/api/exam should list the whole ${pool}-question pool before an attempt, got ${api_pool}"
+
+# The bank ships tips, and they are readable with no attempt running —
+# the whole point of leaving that endpoint ungated.
+[ "$(json_field hasTips)" = "True" ] || fail "/api/exam hasTips should be True for ckad-mock-01"
+[ "$(req GET /api/exam/tips)" = "200" ] || fail "/api/exam/tips should be 200 with no attempt running"
+[ -n "$(json_field markdown)" ] || fail "/api/exam/tips returned an empty body"
+
 status=$(req GET /)
 grep -q 'assets/' "$RESP" || fail "exam UI '/' did not serve the built assets"
 
@@ -268,13 +341,12 @@ SMOKE_PREPARE_BUDGET=${SMOKE_PREPARE_BUDGET:-900}
 #
 # 202 means the attempt was DRAWN but not started, because a pooled
 # hands-on bank seeds the subset it just drew before the clock may run
-# (docs/api.md, "Preparing an attempt"). No bank here pools on the
-# hands-on engine today — ckad-mock-01 asks all 22 of its 22 questions,
-# and kcna-mock is mcq, which never seeds — so every start below still
-# takes the 200 path and every assertion after one is untouched. This
-# exists so that the day one exam.yaml gains a spec.examLength, the suite
-# waits for the attempt instead of asserting against one that never
-# started.
+# (docs/api.md, "Preparing an attempt"). ckad-mock-01 takes that path:
+# it pools 22 of 26, so nothing is seeded at boot and every start below
+# waits here for the conductor's seed job before the clock exists. This
+# helper was written one milestone before the first bank needed it;
+# kcna-mock is mcq and still takes the 200 path, which is why both are
+# handled.
 #
 # On the 202 path it polls GET /api/session until `preparing` clears.
 # That is the terminal condition, and NOT the control job going idle: the
@@ -425,14 +497,36 @@ wait_workloads() {
     || fail "cluster workloads did not become Available within 300s"
 }
 
-# Solve every question, each on the instance its exam.yaml entry names.
-# Driven from the bank rather than a hand-kept list: a question added
-# without a solution script, or pointed at the wrong instance, fails here
-# instead of quietly costing points in the 100% assertion below.
+# Solve every question THIS ATTEMPT asks, each on the instance its
+# exam.yaml entry names.
+#
+# Driven from GET /api/exam rather than from exam.yaml, and that is not a
+# refactor — it is the difference between passing and failing on a pooled
+# bank. ckad-mock-01 draws 22 of 26, and only the drawn subset is ever
+# seeded (images/k8s-env/bootstrap.sh skips the boot seed loop entirely;
+# the conductor's seed job runs the drawn questions' setup.sh at start).
+# The four questions left out have no Namespace, no workloads and no
+# pre-state, so running their solution scripts would fail against a
+# cluster that was deliberately never given their state — and would say
+# nothing about the exam anyone actually sat.
+#
+# `questions` on that response is narrowed to the draw exactly once an
+# attempt is running (facilitator/internal/api/api.go), which makes it
+# the one honest answer to "what is this attempt". It still lists every
+# question for an unpooled bank, so nothing about the smoke-01 or
+# kcna-mock sections changes.
+#
+# The cross-check that used to come free from reading the bank file is
+# kept explicitly below: a drawn question with no solution script fails
+# here rather than quietly costing points in the 100% assertion.
 solve_bank() {
-  local bank=$1 qid inst
+  local bank=$1 qid inst drawn=0
+  [ "$(req GET /api/exam)" = "200" ] || { fail "solve: GET /api/exam did not answer 200"; return; }
+  [ "$(json_field name)" = "$bank" ] \
+    || { fail "solve: the loaded exam is '$(json_field name)', want ${bank}"; return; }
   while read -r qid inst; do
     [ -n "$qid" ] || continue
+    drawn=$((drawn + 1))
     [ -f "tests/solutions/${bank}/${qid}.sh" ] \
       || { fail "no solution script for ${bank}/${qid}"; continue; }
     # </dev/null is load-bearing: `compose exec -T` reads stdin, and
@@ -442,9 +536,51 @@ solve_bank() {
       -c "bash /tests/solutions/${bank}/${qid}.sh" \
       >"/tmp/smoke-${bank}-${qid}.log" 2>&1 </dev/null \
       || fail "${bank}/${qid} solution failed (see /tmp/smoke-${bank}-${qid}.log)"
-  done < <(docker compose exec -T k8s-env yq -r \
-    ".spec.questions[] | .id + \" \" + .instance" "/banks/${bank}/exam.yaml" | tr -d '\r')
+  done < <(RESP="$RESP" python3 -c '
+import json, os
+with open(os.environ["RESP"]) as f:
+    data = json.load(f)
+for q in data.get("questions", []):
+    print(q["id"], q.get("instance", "instance-1"))
+')
+  echo "  solved ${drawn} drawn question(s) of ${bank}"
+  [ "$drawn" -gt 0 ] || fail "solve: the attempt drew no questions at all"
 }
+
+# Every solution script in the bank must be reachable by SOME draw, which
+# the loop above cannot prove — it only ever sees one attempt's 22. A
+# question authored without one would otherwise sit undetected until the
+# draw that finally picked it, on somebody else's run.
+missing=$(docker compose exec -T k8s-env yq -r '.spec.questions[].id' \
+  /banks/ckad-mock-01/exam.yaml | tr -d '\r' \
+  | while read -r qid; do
+      [ -n "$qid" ] || continue
+      [ -f "tests/solutions/ckad-mock-01/${qid}.sh" ] || printf '%s ' "$qid"
+    done)
+[ -z "$missing" ] || fail "ckad-mock-01 pool questions with no solution script: ${missing}"
+
+# q01 is referenced by id all over this suite (solution and hint gates,
+# the reseed calls). On a pooled bank that only holds while its domain's
+# pool is exactly its draw target — true today, and the reason to assert
+# it is that the failure mode otherwise is a confusing 404 several
+# hundred lines from here rather than a sentence naming the cause.
+[ "$(req GET /api/exam)" = "200" ] || fail "GET /api/exam did not answer 200 during the attempt"
+drawn_ids=$(RESP="$RESP" python3 -c '
+import json, os
+with open(os.environ["RESP"]) as f:
+    print(" ".join(q["id"] for q in json.load(f).get("questions", [])))
+')
+# The pooled draw itself: the response narrowed from the whole pool to
+# exactly the declared length the moment an attempt started. This is the
+# first hands-on bank in the repo to take that path, so it is asserted
+# here rather than reasoned about.
+drawn_n=$(printf '%s' "$drawn_ids" | wc -w | tr -d ' ')
+[ "$drawn_n" = "$declared" ] \
+  || fail "a running attempt should ask the declared ${declared} of ${pool}, got ${drawn_n}"
+case " $drawn_ids " in
+  *" q01 "*) ;;
+  *) fail "q01 was not drawn; the gate assertions below name it by id" ;;
+esac
 
 solve_bank ckad-mock-01
 
@@ -505,16 +641,23 @@ status=$(req GET /api/questions/q01/solution)
 status=$(req GET /desktop/vnc.html)
 [ "$status" = "403" ] || fail "desktop should be 403 once the session has ended, got $status"
 
-status=$(req DELETE /api/session)
-[ "$status" = "204" ] || fail "DELETE /api/session expected 204, got $status"
-
-status=$(req GET /api/session)
-state=$(json_field state)
-[ "$state" = "idle" ] || fail "session should be idle right after DELETE, got $state"
+# The DELETE that used to sit here now runs AFTER the resumed grade
+# below, and the reason is pooling. Grading reads the SESSION's drawn
+# question ids; with no session there are none, and the grader falls back
+# to every question in the bank — all 26, including the four this attempt
+# never drew and whose state was therefore never seeded. That scored
+# 191/217 on a cluster that had just been solved perfectly, which reads
+# as "the restart lost state" and is nothing of the kind. Keeping the
+# ended attempt until it has been re-graded also makes the assertion
+# stronger: it proves the DRAW survived the restart, not just the cluster.
 
 # warm restart: down + up must resume exam state
 ./sim down
-./sim up
+# Named for the same reason as the cold boot above — this needs to block
+# until the cluster is back, not merely until the UI answers. /shared/bank
+# survives `down` and wins over this anyway, so it changes nothing about
+# WHICH exam resumes; it only decides whether `up` waits.
+./sim up ckad-mock-01
 # `./sim up --wait` waits for *container* health; the cluster's own
 # workloads come back well after that, and several checks assert on ready
 # replicas or make live requests. Grading straight away measures how fast
@@ -523,6 +666,16 @@ wait_workloads
 ./sim grade | tee /tmp/grade2.txt
 read -r _ e2 t2 _ < <(grep '^RESULT ' /tmp/grade2.txt)
 [ "$e2" = "$t2" ] || fail "resumed env should keep score ${t2}/${t2}, got ${e2}/${t2}"
+# The drawn subset is persisted with the session, so a facilitator that
+# restarted mid-attempt grades the same questions it started with.
+[ "$t2" = "$t1" ] || fail "resumed attempt is worth ${t2}, the attempt that ended was worth ${t1}"
+
+status=$(req DELETE /api/session)
+[ "$status" = "204" ] || fail "DELETE /api/session expected 204, got $status"
+
+status=$(req GET /api/session)
+state=$(json_field state)
+[ "$state" = "idle" ] || fail "session should be idle right after DELETE, got $state"
 
 # reset: fresh exam state, /opt/course dirs re-created empty, session cleared too
 ./sim reset
@@ -892,6 +1045,10 @@ status=$(start_session '{"mode":"training"}')
 [ "$status" = "200" ] || fail "training: start expected 200, got $status"
 [ "$(json_field mode)" = "training" ] || fail "training: mode is '$(json_field mode)'"
 [ "$(json_field untimed)" = "True" ] || fail "training: untimed is '$(json_field untimed)', want True"
+# Kept for the exam-gate block below, which has to draw the SAME
+# questions to be allowed to start without a cluster rebuild in between.
+training_seed=$(json_field seed)
+[ -n "$training_seed" ] || fail "training: the attempt reported no seed"
 
 # Hints: served one tier at a time, and only in this mode.
 [ "$(req GET /api/questions/q01/hints/1)" = "200" ] || fail "training: hint 1 not served"
@@ -933,19 +1090,36 @@ status=$(req DELETE /api/session)
 # And the same gates must REFUSE in an exam attempt.
 #
 # This is a SECOND attempt with no environment reset since the training
-# one above. Harmless today — ckad-mock-01 is unpooled, so nothing was
-# seeded per-draw and there is nothing of the last draw left over — but
-# it is precisely the sequence a pooled hands-on bank may refuse. A
-# refusal is reported by start_session with the facilitator's own words,
-# and the gates are then SKIPPED rather than run: every one of them
-# answers 403 for an idle session too, so against a failed start they
-# would all pass for the wrong reason and prove nothing.
-status=$(start_session)
+# one above, which a pooled hands-on bank refuses outright: seeding a
+# different draw over the last one's objects would hand a candidate a
+# task that is already half done, so checkClusterFree answers 409 and
+# names the reset that would clear it.
+#
+# Replaying the training attempt's SEED is the way through, and it is not
+# a workaround — it is the documented retry path. The same seed against
+# the same pool draws the same 22 questions, the seeded set matches, and
+# re-running those setup.sh scripts over their own output is the
+# idempotent apply the conductor's seed job already is. So this asserts
+# something real that no unit test can: that a re-seed of an identical
+# draw is allowed and works against a live cluster.
+#
+# A refusal is reported by start_session with the facilitator's own
+# words, and the gates are then SKIPPED rather than run: every one of
+# them answers 403 for an idle session too, so against a failed start
+# they would all pass for the wrong reason and prove nothing.
+status=$(start_session "{\"seed\":\"${training_seed}\"}")
 [ "$status" = "200" ] || fail "exam-gate: start expected 200, got $status"
+[ "$(json_field seed)" = "$training_seed" ] \
+  || fail "exam-gate: replayed seed ${training_seed}, got '$(json_field seed)'"
 if [ "$status" = "200" ]; then
   [ "$(json_field mode)" = "exam" ] || fail "exam-gate: mode is '$(json_field mode)', want exam"
   [ "$(req GET /api/questions/q01/hints/1)" = "403" ] || fail "exam-gate: hints must be 403 in an exam"
   [ "$(req GET /api/questions/q01/solution)" = "403" ] || fail "exam-gate: solutions must be 403 mid-exam"
+  # And the tips are NOT one of these gates, which is the distinction the
+  # endpoint exists to make: hints and solutions carry answers, technique
+  # does not. Asserted beside the two refusals so the difference is one
+  # place rather than an argument in a doc.
+  [ "$(req GET /api/exam/tips)" = "200" ] || fail "exam-gate: tips must stay readable mid-exam"
   [ "$(req POST /api/session/grade)" = "403" ] || fail "exam-gate: mid-attempt scoring must be 403 in an exam"
   curl -s -o "$RESP" -w '%{http_code}' -X POST -H 'Content-Type: application/json' \
     -d '{"question":"q01"}' "${BASE}/api/control/reseed" > /tmp/smoke-reseed-exam.txt
@@ -956,13 +1130,31 @@ status=$(req DELETE /api/session)
 [ "$status" = "204" ] || fail "exam-gate: cleanup DELETE expected 204, got $status"
 
 echo "== auto-end: session expires unattended and re-locks the desktop =="
+# The reset here is load-bearing on a pooled bank, and for two separate
+# reasons that the restart below turns into one failure.
+#
+# The cluster still holds the exam-gate attempt's draw, so a fresh start
+# would be refused by checkClusterFree — that is the same 409 the block
+# above dodges by replaying a seed, and it cannot be dodged twice: the
+# facilitator is about to be recreated, and a new process has no seeded
+# set to match against. What it has instead is probeSeeded, which sees an
+# idle session beside a conductor whose last job was a SEED, correctly
+# concludes that the cluster was prepared for an attempt nobody is
+# sitting, and marks the contents unknown — a set that matches nothing.
+#
+# Resetting settles both: the conductor's last job becomes a reset rather
+# than a seed, and the cluster it leaves behind is empty, because a
+# pooled bank seeds nothing at boot.
+./sim reset
+status=$(req GET /api/session)
+[ "$(json_field state)" = "idle" ] || fail "auto-end: session should be idle after the reset"
+
 SESSION_DURATION_OVERRIDE=20s docker compose up -d --wait facilitator
-# Another second attempt with no environment reset (see the exam-gate
-# block above), and the facilitator has just been recreated on top of it
-# — a restart abandons any in-flight preparation, since a preparation is
-# deliberately in-memory only. Neither matters on an unpooled bank; both
-# would matter on a pooled one, and start_session says so out loud rather
-# than leaving the 25s sleep below to expire an attempt that never began.
+# The clock starts when the seeding SUCCEEDS, not when the request lands
+# — which is exactly why the 20s override is safe here even though
+# preparing this draw takes minutes. start_session returns once the
+# attempt is really running, so the sleep below measures the clock and
+# not the seed.
 status=$(start_session)
 [ "$status" = "200" ] || fail "auto-end: session start expected 200, got $status"
 

--- a/tests/solutions/ckad-mock-01/q23.sh
+++ b/tests/solutions/ckad-mock-01/q23.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl -n lacerta patch svc checkout --type=merge \
+  -p '{"spec":{"selector":{"app":"checkout","release":"green"}}}'
+
+# The selector edit and a reprogrammed kube-proxy are not the same
+# instant. Wait for the Service to actually deliver green before the
+# grader is allowed to look, exactly as the check itself retries.
+for _ in $(seq 1 15); do
+  body=$(kubectl -n lacerta exec deploy/checkout-client -- \
+    wget -q -T 4 -O - http://checkout.lacerta.svc:80/ 2>/dev/null || true)
+  case "$body" in *green*) exit 0 ;; esac
+  sleep 2
+done
+echo "the Service never served the green release" >&2
+exit 1

--- a/tests/solutions/ckad-mock-01/q24.sh
+++ b/tests/solutions/ckad-mock-01/q24.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl -n auriga apply -f - <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: report-runner
+  namespace: auriga
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: report-runner
+  template:
+    metadata:
+      labels:
+        app: report-runner
+    spec:
+      containers:
+        - name: report
+          image: busybox:1.37
+          command: ["sh", "-c", "while true; do echo 'report-runner: nothing to do'; sleep 15; done"]
+          securityContext:
+            runAsUser: 1000
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+EOF
+
+kubectl -n auriga rollout status deploy/report-runner --timeout=180s
+kubectl -n auriga delete pod report-runner --ignore-not-found

--- a/tests/solutions/ckad-mock-01/q25.sh
+++ b/tests/solutions/ckad-mock-01/q25.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# An ephemeral container can never be removed, so adding one that is
+# already there fails. Re-running this script has to be a no-op on that
+# step rather than an error.
+have=$(kubectl -n perseus get pod ledger-api -o json \
+  | jq -r '.spec.ephemeralContainers // [] | map(select(.name == "debugger")) | length')
+if [ "$have" = "0" ]; then
+  # --profile=general only silences kubectl's own deprecation notice
+  # about the implicit `legacy` profile; neither profile changes what the
+  # checks read (name, image, targetContainerName).
+  kubectl -n perseus debug ledger-api \
+    --image=busybox:1.37 -c debugger --target=api --profile=general -- sleep 3600
+fi
+
+# The container is in the spec immediately; the kubelet still has to
+# start it, and an exec that arrives first fails with "container not
+# found". Wait on the status the API reports rather than a guessed sleep.
+state=""
+for _ in $(seq 1 40); do
+  state=$(kubectl -n perseus get pod ledger-api -o json \
+    | jq -r '.status.ephemeralContainerStatuses // [] | map(select(.name == "debugger")) | first | .state | keys[0]? // ""')
+  if [ "$state" = "running" ]; then
+    break
+  fi
+  sleep 3
+done
+if [ "$state" != "running" ]; then
+  echo "the debugger container never started (state '${state}')" >&2
+  exit 1
+fi
+
+kubectl -n perseus exec ledger-api -c debugger -- \
+  wget -q -O - http://127.0.0.1:8080/healthz > /opt/course/25/healthz
+kubectl -n perseus exec ledger-api -c debugger -- ps > /opt/course/25/api-process

--- a/tests/solutions/ckad-mock-01/q26.sh
+++ b/tests/solutions/ckad-mock-01/q26.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# No --type, i.e. the STRATEGIC merge patch kubectl uses by default for a
+# built-in resource. --type=merge is RFC 7386, which replaces a list
+# outright rather than merging it, so the same body under it deletes both
+# containers' images and the API refuses the Deployment as invalid.
+kubectl -n volans patch deploy edge-cache -p '{
+  "spec": {"template": {"spec": {
+    "terminationGracePeriodSeconds": 45,
+    "containers": [
+      {"name": "cache", "imagePullPolicy": "Never"},
+      {"name": "refresher", "imagePullPolicy": "Never"}
+    ]
+  }}}
+}'
+kubectl -n volans rollout status deploy/edge-cache --timeout=180s

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -444,10 +444,18 @@ function SimApp({ hosted }: { hosted?: Hosted } = {}) {
     [runControlAction],
   );
 
+  // A provision retries as a switch, because that is what it is on the
+  // wire: POST /api/control/switch with a bank, which the conductor
+  // labels "provision" only while no exam is active. Falling through to
+  // reset here would have offered to rebuild an environment that has
+  // never been built — and rebuilt it as nothing, since a reset carries
+  // no bank.
   const handleRetry = useCallback(
     (op: string, bank: string) =>
       runControlAction(() =>
-        op === "switch" && bank ? startControlSwitch(bank) : startControlReset(),
+        (op === "switch" || op === "provision") && bank
+          ? startControlSwitch(bank)
+          : startControlReset(),
       ),
     [runControlAction],
   );
@@ -487,9 +495,17 @@ function SimApp({ hosted }: { hosted?: Hosted } = {}) {
   // start gate is bypassed for mcq to match. The cluster keeps building
   // silently behind the lobby so switching back to a hands-on bank
   // stays seamless.
+  //
+  // "idle" is exempt for the opposite reason to all of the above. It does
+  // not mean "not ready yet", it means "nobody has said what to build" —
+  // there is no cluster coming, no progress to narrate, and nothing to
+  // wait for. Showing a progress screen there would ask the candidate to
+  // wait for an event that only THEY can cause. The selector renders
+  // instead, which is where the exam gets chosen.
   const booting =
     boot !== null &&
     boot.state !== "ready" &&
+    boot.state !== "idle" &&
     !isMcq &&
     session?.state !== "running" &&
     !showOverlay &&
@@ -584,6 +600,7 @@ function SimApp({ hosted }: { hosted?: Hosted } = {}) {
             onControlStart={runControlAction}
             catalogVersion={catalogVersion}
             seatKind={hosted?.me.session?.kind}
+            seatBank={hosted?.me.session?.bank}
             onBanksLoaded={handleBanksLoaded}
           />
         );

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -190,6 +190,32 @@ export interface ExamInfo {
    * show the drawn questions as if they were the whole curriculum.
    */
   domains?: DomainInfo[];
+  /**
+   * The cluster this exam is sat in. Absent for a bank that declares
+   * none — every mcq bank, which has no cluster at all — so any copy
+   * built from it has to survive not having it.
+   *
+   * This is the field that lets the product stop asserting CKAD's shape
+   * at candidates sitting something else: `nodes` is what the bank asked
+   * for and what `bootstrap.sh` actually builds, from the same value.
+   */
+  environment?: ExamEnvironment;
+  /**
+   * The bank ships a `tips.md`, so `GET /api/exam/tips` has something to
+   * serve. Absent means it does not, and the entry points must not be
+   * drawn at all — a control that opens an empty sheet is worse than no
+   * control (DESIGN.md: don't draw a control for something the product
+   * cannot yet do).
+   */
+  hasTips?: boolean;
+}
+
+/** See `ExamInfo.environment`. */
+export interface ExamEnvironment {
+  /** How the cluster is built; "kind" is the only one today. */
+  provider?: string;
+  /** How many nodes it has. */
+  nodes?: number;
 }
 
 export interface QuestionDetail {
@@ -432,8 +458,15 @@ export async function getSession(signal?: AbortSignal): Promise<SessionSnapshot>
   return (await res.json()) as SessionSnapshot;
 }
 
-/** Lifecycle of the exam environment's own start-up. */
-export type BootState = "booting" | "ready" | "failed";
+/**
+ * Lifecycle of the exam environment's own start-up.
+ *
+ * "idle" is not a stage of booting — it is the absence of one. The
+ * environment is up and has not been told which exam to be, so no
+ * cluster exists and none is coming until a candidate chooses. Nothing
+ * should render progress for it.
+ */
+export type BootState = "booting" | "ready" | "failed" | "idle";
 
 export interface BootStatus {
   state: BootState;
@@ -471,6 +504,22 @@ export async function getExam(signal?: AbortSignal): Promise<ExamInfo> {
     throw new Error(await readError(res));
   }
   return (await res.json()) as ExamInfo;
+}
+
+/**
+ * The loaded bank's exam technique notes.
+ *
+ * Ungated, unlike solutions and hints: this is how to drive kubectl and
+ * an editor quickly, not what any answer is, and it is most useful before
+ * the clock starts. Only call it when `ExamInfo.hasTips` is true — the
+ * server answers 404 for a bank that ships none.
+ */
+export async function getExamTips(signal?: AbortSignal): Promise<string> {
+  const res = await request("/api/exam/tips", { signal });
+  if (!res.ok) {
+    throw new Error(await readError(res));
+  }
+  return ((await res.json()) as { markdown: string }).markdown;
 }
 
 export async function getQuestion(id: string, signal?: AbortSignal): Promise<QuestionDetail> {
@@ -777,8 +826,14 @@ export interface ControlJob {
    * not started — only ever a pooled hands-on bank, whose boot skips the
    * seed loop precisely because the draw decides what to seed. It renders
    * through the same overlay as the other two, which is why it is a job.
+   *
+   * "provision" is the first exam an environment is ever given: the same
+   * sequence as a switch, minus the phases that need an outgoing one. A
+   * separate op because nothing about it is a switch — there is no
+   * previous bank and nothing is destroyed, and the copy must not say
+   * otherwise to somebody choosing their first exam.
    */
-  op: "reset" | "switch" | "seed";
+  op: "reset" | "switch" | "provision" | "seed";
   bank: string;
   startedAt: string;
   /** RFC3339Nano; absent while the job is in flight. */
@@ -853,6 +908,18 @@ export interface BankEntry {
    * not one.
    */
   poolCount?: number;
+  /**
+   * How many nodes this exam's cluster has — the bank's
+   * `spec.environment.nodes`, and the same number the bootstrap builds
+   * from. Absent for a bank that declares none, which is every
+   * multiple-choice one: they have no cluster, and copy built from this
+   * has to survive not knowing.
+   *
+   * Served by the hub's catalog. The local `/api/control/banks` and
+   * `/api/catalog` do not carry it — the local product asks the loaded
+   * exam directly, through `ExamInfo.environment`.
+   */
+  nodes?: number;
   available: boolean;
   comingSoon?: boolean;
   note?: string;
@@ -1253,8 +1320,35 @@ export type HostedStartResponse =
   | { ok: false; error: string };
 
 /**
- * POST /api/session/start with a flavour — hosted admission, not the
- * start of an attempt.
+ * GET /hub/exams — every exam this deployment offers.
+ *
+ * The lobby's one call, and the reason it exists is timing: a candidate
+ * choosing a certification has no session Pod yet, so the exam selector
+ * they know — served by their own facilitator — is not reachable. The
+ * hub answers from a bank index staged beside it.
+ *
+ * `kind` is the seat pool the card competes for, derived by the hub from
+ * the bank's own engine rather than here, because the same mapping
+ * decides admission.
+ *
+ * An empty list is a hub with no index staged, and the lobby falls back
+ * to offering a flavour — which is what it did before exams were
+ * choosable.
+ */
+export interface HostedExam extends BankEntry {
+  kind: SessionKind;
+}
+
+export async function getHostedExams(signal?: AbortSignal): Promise<HostedExam[]> {
+  const res = await request("/hub/exams", { signal });
+  if (!res.ok) throw new Error(await readError(res));
+  const body = (await res.json()) as { exams?: HostedExam[] };
+  return body.exams ?? [];
+}
+
+/**
+ * POST /api/session/start naming the exam to sit — hosted admission, not
+ * the start of an attempt.
  *
  * The same path does both, in that order: the hub grants a seat and
  * boots a Pod, and only once that Pod answers does it forward the
@@ -1263,19 +1357,26 @@ export type HostedStartResponse =
  * once they have one, the ordinary startSession() reaches the
  * facilitator through the same door and configures the attempt properly.
  *
- * The 200 case is therefore not modelled here: reaching it would mean a
- * ready Pod was handed a body naming a kind and no mode, and starting an
- * unconfigured attempt is precisely what the caller must not do by
+ * `bank` decides the seat: the hub derives the flavour from the exam's
+ * engine, so a caller that knows which exam it wants does not have to
+ * know — or agree about — which pool that draws from. `kind` alone
+ * remains valid and takes the deployment's default exam for that
+ * flavour, which is what a hub with no bank index offers.
+ *
+ * The 200 case is deliberately not modelled: reaching it would mean a
+ * ready Pod was handed a body naming an exam and no mode, and starting
+ * an unconfigured attempt is precisely what the caller must not do by
  * accident.
  */
 export async function startHostedSession(
   kind: SessionKind,
+  bank?: string,
   signal?: AbortSignal,
 ): Promise<HostedStartResponse> {
   const res = await request("/api/session/start", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ kind }),
+    body: JSON.stringify(bank ? { kind, bank } : { kind }),
     signal,
   });
   if (res.status === 409) {

--- a/ui/src/components/BackgroundJobChip.test.tsx
+++ b/ui/src/components/BackgroundJobChip.test.tsx
@@ -67,4 +67,32 @@ describe("BackgroundJobChip", () => {
     await userEvent.click(screen.getByRole("button"));
     expect(reopened).toHaveBeenCalledTimes(1);
   });
+
+  // The chip used to title ANY job carrying a bank as a switch, because a
+  // resolved bankTitle was checked before the op was. Both jobs below
+  // carry one, and neither is a switch: the overlay named them correctly
+  // while the chip for the very same job did not.
+  test("titles a first-time build as a build", () => {
+    render(
+      <BackgroundJobChip
+        job={{ ...job, op: "provision", bank: "ckad-mock-01" }}
+        bankTitle="CKAD Mock Exam 01"
+        onReopen={() => {}}
+      />,
+    );
+    const chip = screen.getByRole("button");
+    expect(chip).toHaveAccessibleName(/building/i);
+    expect(chip).not.toHaveAccessibleName(/switching/i);
+  });
+
+  test("titles a pooled bank's seeding as setup, not as a switch", () => {
+    render(
+      <BackgroundJobChip
+        job={{ ...job, op: "seed", bank: "ckad-mock-01" }}
+        bankTitle="CKAD Mock Exam 01"
+        onReopen={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button")).not.toHaveAccessibleName(/switching/i);
+  });
 });

--- a/ui/src/components/BackgroundJobChip.tsx
+++ b/ui/src/components/BackgroundJobChip.tsx
@@ -1,4 +1,5 @@
 import type { ControlJob } from "../api";
+import { controlJobTitle } from "../lib/controlJob";
 import { formatElapsed } from "../lib/format";
 import { useTick } from "../lib/useTick";
 import { strings } from "../strings";
@@ -26,11 +27,7 @@ export function BackgroundJobChip({ job, bankTitle, onReopen }: BackgroundJobChi
   const total = job.phases.length;
   const done = job.phases.filter((p) => p.state === "done").length;
   const running = job.phases.find((p) => p.state === "running");
-  const label = bankTitle
-    ? strings.control.switchTitle(bankTitle)
-    : job.op === "switch"
-      ? strings.control.switchTitle(job.bank)
-      : strings.control.resetTitle;
+  const label = controlJobTitle(job, bankTitle);
 
   const startedAt = Date.parse(job.startedAt);
   const elapsed = Number.isNaN(startedAt) ? null : formatElapsed(now - startedAt);

--- a/ui/src/components/ControlProgress.test.tsx
+++ b/ui/src/components/ControlProgress.test.tsx
@@ -222,4 +222,67 @@ describe("ControlProgress", () => {
       vi.unstubAllGlobals();
     }
   });
+
+  // Nothing is built until an exam is chosen, so the first choice runs a
+  // job that has no outgoing exam behind it. It reaches this dialog
+  // through the same overlay as every other job, and if it borrowed the
+  // switch's wording the first thing a new candidate would read is that
+  // their environment is being wiped and replaced.
+  describe("the first exam an environment is given", () => {
+    const provisionJob: ControlJob = {
+      id: "job-2",
+      op: "provision",
+      bank: "ckad-mock-01",
+      startedAt: "2026-07-24T12:00:00.000Z",
+      phase: "recreate-cluster",
+      phases: [
+        {
+          id: "write-bank",
+          label: "Select the exam",
+          state: "done",
+          startedAt: "2026-07-24T12:00:00.000Z",
+          finishedAt: "2026-07-24T12:00:00.100Z",
+        },
+        {
+          id: "recreate-cluster",
+          label: "Build the Kubernetes cluster",
+          state: "running",
+          startedAt: "2026-07-24T12:00:00.100Z",
+        },
+        { id: "verify", label: "Verify the exam is live", state: "pending" },
+      ],
+    };
+
+    test("is titled as a build, not as a switch", () => {
+      render(<ControlProgress job={provisionJob} bankTitle="CKAD Mock Exam 01" {...props} />);
+      const heading = screen.getByRole("heading", { level: 2 });
+      expect(heading).toHaveTextContent(/building/i);
+      expect(heading).toHaveTextContent("CKAD Mock Exam 01");
+      expect(heading).not.toHaveTextContent(/switch/i);
+    });
+
+    test("promises the same minutes without claiming anything is being rebuilt", () => {
+      render(<ControlProgress job={provisionJob} bankTitle="CKAD Mock Exam 01" {...props} />);
+      const hint = document.querySelector(".control-hint");
+      expect(hint).toHaveTextContent(/2-4 minutes/);
+      expect(hint).not.toHaveTextContent(/rebuild/i);
+    });
+
+    test("retries as itself: the handler is given the op, and it carries a bank", async () => {
+      const onRetry = vi.fn();
+      const user = setupUser();
+      render(
+        <ControlProgress
+          job={{ ...provisionJob, error: "kind: failed to create cluster" }}
+          bankTitle="CKAD Mock Exam 01"
+          {...props}
+          onRetry={onRetry}
+        />,
+      );
+      // A failed provision must offer retry — unlike a seed, whose retry
+      // would tear down an environment the candidate still has.
+      await user.click(screen.getByRole("button", { name: /retry/i }));
+      expect(onRetry).toHaveBeenCalled();
+    });
+  });
 });

--- a/ui/src/components/ControlProgress.tsx
+++ b/ui/src/components/ControlProgress.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { getControlLog, type ControlJob, type ControlPhase } from "../api";
+import { controlJobHint, controlJobTitle } from "../lib/controlJob";
 import { formatElapsed } from "../lib/format";
 import { useFocusTrap } from "../lib/useFocusTrap";
 import { Icon } from "./Icon";
@@ -103,18 +104,12 @@ export function ControlProgress({
     return () => window.clearInterval(id);
   }, [failed]);
 
-  const target = bankTitle || job.bank;
   // A seed prepares the cluster for an attempt that has already been
-  // drawn; it destroys nothing and the clock has not started. Titled as
-  // itself rather than falling through to the reset's wording, which
-  // would tell a candidate waiting to begin that their environment is
-  // being wiped.
-  const title =
-    job.op === "switch"
-      ? strings.control.switchTitle(target)
-      : job.op === "seed"
-        ? strings.control.seedTitle
-        : strings.control.resetTitle;
+  // drawn; it destroys nothing and the clock has not started. A provision
+  // is the first exam this environment has ever had. Neither falls
+  // through to the reset's wording, which would tell a candidate waiting
+  // to begin that their environment is being wiped.
+  const title = controlJobTitle(job, bankTitle);
   const running = job.phases.find((p) => p.state === "running");
   const reconnecting = running?.id === BLACKOUT_PHASE;
 
@@ -170,10 +165,6 @@ export function ControlProgress({
   const jobStarted = parseStamp(job.startedAt);
   const totalElapsed = jobStarted === null ? null : formatElapsed(now - jobStarted);
   const doneCount = job.phases.filter((p) => p.state === "done").length;
-  // An mcq reset/switch never advertises this phase — see resetPhases/
-  // switchPhases in control.go. Its absence is exactly the "no cluster
-  // rebuild" signal the hint needs, with no extra prop to thread through.
-  const hasClusterRebuild = job.phases.some((p) => p.id === "recreate-cluster");
 
   return (
     <div className="control-overlay">
@@ -298,11 +289,7 @@ export function ControlProgress({
                   runs one setup script per drawn question against a live
                   cluster, so "usually a few seconds" would be a promise it
                   cannot keep on a sixteen-task draw. */}
-              {job.op === "seed"
-                ? strings.control.hintSeed
-                : hasClusterRebuild
-                  ? strings.control.hint
-                  : strings.control.hintFast}
+              {controlJobHint(job)}
               {totalElapsed && (
                 <span className="control-elapsed" aria-hidden="true">
                   {strings.control.elapsed(totalElapsed)}

--- a/ui/src/components/ExamIntro.tsx
+++ b/ui/src/components/ExamIntro.tsx
@@ -1,3 +1,4 @@
+import { formatClock } from "../lib/format";
 import { Dialog } from "./Dialog";
 import { strings } from "../strings";
 
@@ -31,15 +32,31 @@ export function resetIntroSeen(): void {
 // 900px, and it is renderable (and therefore testable) without a live
 // exam behind it, which is also why the lobby can show it before the
 // clock starts.
-export function ExamIntro({ onClose }: { onClose: () => void }) {
+export function ExamIntro({
+  onClose,
+  durationSeconds,
+}: {
+  onClose: () => void;
+  durationSeconds?: number;
+}) {
   const s = strings.intro;
+  // The schematic's countdown chip showed a hardcoded "1:59:58", i.e.
+  // CKAD's two hours, on a diagram explaining every exam's screen. It
+  // reads two seconds off the loaded exam's own clock — enough to look
+  // like a countdown that is running rather than one at its start —
+  // and falls back to the label when no exam is loaded, which is where
+  // the About drawer can open it.
+  const timer =
+    durationSeconds && durationSeconds > 2
+      ? formatClock(durationSeconds - 2)
+      : s.diagramTimerLabel;
 
   return (
     <Dialog title={s.title} onClose={onClose} wide>
       <div className="intro-schematic" role="img" aria-label={s.schematicAlt}>
         <div className="intro-topbar">
           <span className="intro-region-label">3</span>
-          <span className="intro-chip intro-chip-timer">{s.diagramTimer}</span>
+          <span className="intro-chip intro-chip-timer">{timer}</span>
           <span className="intro-region-label">4</span>
           <span className="intro-chip intro-chip-end">{s.diagramEnd}</span>
         </div>

--- a/ui/src/components/ExamTips.test.tsx
+++ b/ui/src/components/ExamTips.test.tsx
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ExamTips } from "./ExamTips";
+import { strings } from "../strings";
+
+const TIPS = [
+  "Two hours is not long.",
+  "",
+  "## Set the terminal up",
+  "",
+  "```bash",
+  "alias k=kubectl",
+  "```",
+  "",
+  "Generate the skeleton with `--dry-run=client -o yaml`, then edit it.",
+].join("\n");
+
+function mockTips(body: () => Response) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/api/exam/tips")) return body();
+      throw new Error(`unexpected fetch: ${url}`);
+    }),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("ExamTips", () => {
+  test("renders the bank's markdown, not copy from this repo", async () => {
+    mockTips(() => new Response(JSON.stringify({ markdown: TIPS }), { status: 200 }));
+
+    render(<ExamTips onClose={() => {}} />);
+
+    // The prose is the BANK's. If this ever passes against a hardcoded
+    // panel, the per-bank part of the feature has been lost — a CKAD
+    // sitting and a KCNA one are not made fast by the same advice.
+    expect(await screen.findByText(/Two hours is not long/)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Set the terminal up" })).toBeInTheDocument();
+  });
+
+  test("inline values are copyable — the page exists to save retyping them", async () => {
+    mockTips(() => new Response(JSON.stringify({ markdown: TIPS }), { status: 200 }));
+
+    render(<ExamTips onClose={() => {}} />);
+
+    // Markdown's default (copyable) rather than the mcq `copyable={false}`
+    // branch: almost every line here is a command meant to be run on the
+    // exam desktop under a clock.
+    expect(
+      await screen.findByRole("button", { name: /--dry-run=client -o yaml/ }),
+    ).toBeInTheDocument();
+  });
+
+  test("a failed fetch is recoverable rather than an empty sheet", async () => {
+    let attempts = 0;
+    mockTips(() => {
+      attempts += 1;
+      return attempts === 1
+        ? new Response(JSON.stringify({ error: "no exam is loaded yet" }), { status: 503 })
+        : new Response(JSON.stringify({ markdown: TIPS }), { status: 200 });
+    });
+    const user = userEvent.setup();
+
+    render(<ExamTips onClose={() => {}} />);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/no exam is loaded yet/);
+
+    await user.click(screen.getByRole("button", { name: strings.exams.catalogRetry }));
+
+    await waitFor(() => expect(screen.getByText(/Two hours is not long/)).toBeInTheDocument());
+  });
+
+  test("it is a dialog, and Escape closes it", async () => {
+    mockTips(() => new Response(JSON.stringify({ markdown: TIPS }), { status: 200 }));
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(<ExamTips onClose={onClose} />);
+
+    expect(screen.getByRole("dialog", { name: strings.tips.title })).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test("the close button closes it", async () => {
+    mockTips(() => new Response(JSON.stringify({ markdown: TIPS }), { status: 200 }));
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(<ExamTips onClose={onClose} />);
+
+    await user.click(screen.getByRole("button", { name: strings.tips.done }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/ExamTips.tsx
+++ b/ui/src/components/ExamTips.tsx
@@ -1,0 +1,61 @@
+import { getExamTips } from "../api";
+import { useAsync } from "../lib/useAsync";
+import { Async } from "./Async";
+import { Dialog } from "./Dialog";
+import { Markdown } from "./Markdown";
+import { strings } from "../strings";
+
+/**
+ * The bank's exam technique notes, as a sheet.
+ *
+ * Technique rather than answers, which is why the endpoint behind it is
+ * ungated where solutions and hints are not: how to alias kubectl, how to
+ * generate a manifest instead of typing one, and where to look when a Pod
+ * will not start are the same advice before, during and after an attempt.
+ * It is most useful before one, which is where the two entry points are.
+ *
+ * The body is the BANK's markdown, not a string in this repo's UI copy.
+ * What makes a CKAD sitting fast is not what makes a KCNA one fast, so a
+ * hardcoded panel here would have to claim one of them was the other —
+ * the same reasoning that moved node counts into spec.environment.
+ *
+ * Fetched when the sheet opens rather than with the exam: it is several
+ * kilobytes of prose that most sessions never open, and the caller
+ * already knows from `ExamInfo.hasTips` whether the control should exist
+ * at all.
+ */
+export function ExamTips({ onClose }: { onClose: () => void }) {
+  const tips = useAsync((signal) => getExamTips(signal), []);
+
+  return (
+    <Dialog title={strings.tips.title} onClose={onClose} wide>
+      <p className="dialog-lead">{strings.tips.lead}</p>
+
+      <div className="tips-body">
+        <Async
+          state={tips}
+          loading={<p className="page-loading">{strings.app.working}</p>}
+          error={(message, reload) => (
+            <div className="catalog-error" role="alert">
+              <p className="catalog-error-body">{strings.tips.failed(message)}</p>
+              <button type="button" className="btn" onClick={reload}>
+                {strings.exams.catalogRetry}
+              </button>
+            </div>
+          )}
+        >
+          {/* Copyable, deliberately: almost every line of this file is a
+              command meant to be run on the exam desktop, and the whole
+              point of the page is not retyping them under a clock. */}
+          {(markdown) => <Markdown>{markdown}</Markdown>}
+        </Async>
+      </div>
+
+      <div className="confirm-actions">
+        <button className="btn btn-primary" onClick={onClose}>
+          {strings.tips.done}
+        </button>
+      </div>
+    </Dialog>
+  );
+}

--- a/ui/src/components/Icon.tsx
+++ b/ui/src/components/Icon.tsx
@@ -7,10 +7,14 @@ import type { ReactNode } from "react";
 // `unicode-range` on each @font-face, which is a hard gate: a codepoint
 // outside every declared range never reaches the woff2 at all. ◆ ◇ ✓ ✗ ⧉
 // ◐ ☀ ☾ are all outside both families' subsets, so they fell through to
-// whatever the operating system had. ⧉ — the copy affordance, and the
-// visual payload of what DESIGN.md calls the system's signature component
-// — renders as a tofu box on many Linux font sets, and ☀/☾ can resolve to
-// Apple Color Emoji on macOS, which DESIGN.md explicitly bans.
+// whatever the operating system had. ⧉ — the copy affordance — renders as
+// a tofu box on many Linux font sets, and ☀/☾ can resolve to Apple Color
+// Emoji on macOS, which DESIGN.md explicitly bans.
+//
+// ⧉ no longer appears on the click-to-copy value itself. It sits on the
+// two copy controls that have a real slot for it: the clipboard panel and
+// the question pane's ssh hint. See `.copy-value` in theme.css for why
+// the inline one has no icon at all.
 //
 // These are hand-authored on a 24 grid with round caps and joins, no
 // fill, and a stroke proportional to the grid. Everything is drawn here

--- a/ui/src/components/Markdown.test.tsx
+++ b/ui/src/components/Markdown.test.tsx
@@ -1,9 +1,9 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { Markdown } from "./Markdown";
+import { InlineCode, Markdown } from "./Markdown";
 import { desktopClipboard } from "../lib/desktopClipboard";
-import { readThemeCss } from "../test/readCss";
+import { readThemeCss, ruleBody } from "../test/readCss";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -80,6 +80,101 @@ describe("Markdown", () => {
     const table = container.querySelector("table");
     expect(table?.parentElement).toHaveClass("md-table-scroll");
   });
+
+  // An mcq attempt has no desktop and no terminal — it starts before the
+  // cluster is up and works on a phone — so a copy button there promises a
+  // paste target that does not exist.
+  test("copyable={false} renders inline code as a value, not a control", () => {
+    const { container } = render(
+      <Markdown copyable={false}>{"Set `runAsNonRoot: true` on the container."}</Markdown>,
+    );
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(container.querySelector("code")?.textContent).toBe("runAsNonRoot: true");
+  });
+
+  test("copyable={false} leaves fenced blocks alone", () => {
+    render(<Markdown copyable={false}>{"```yaml\nkind: Pod\n```"}</Markdown>);
+    // The block's own copy control is a separate affordance with a real
+    // slot for itself, and it survives.
+    expect(screen.getByRole("button", { name: /copy yaml code block/i })).toBeInTheDocument();
+  });
+});
+
+describe("InlineCode", () => {
+  // bank-spec.md has always promised that "inline markdown such as
+  // backticks is fine" in an mcq option. It was not: both option
+  // renderers interpolated the raw string, so the 44 backticked spans in
+  // the KCNA bank reached the candidate with their backticks showing.
+  test("backticked spans become code, and the backticks do not survive", () => {
+    const { container } = render(<InlineCode text="Setting `hostNetwork: true` in the pod spec" />);
+    const code = container.querySelector("code");
+    expect(code?.textContent).toBe("hostNetwork: true");
+    expect(container.textContent).toBe("Setting hostNetwork: true in the pod spec");
+    expect(container.textContent).not.toContain("`");
+  });
+
+  test("an option with no backticks is unchanged", () => {
+    const { container } = render(<InlineCode text="The kube-scheduler" />);
+    expect(container.querySelector("code")).toBeNull();
+    expect(container.textContent).toBe("The kube-scheduler");
+  });
+
+  // A stray backtick is an authoring typo in a bank, not a reason to eat
+  // the rest of the option.
+  test("an unpaired backtick renders as the literal it is", () => {
+    const { container } = render(<InlineCode text="90% of `nodes" />);
+    expect(container.textContent).toBe("90% of `nodes");
+    expect(container.querySelector("code")).toBeNull();
+  });
+
+  // An option is the label of a checkbox. Rendering it through Markdown
+  // would nest a <button> inside that <label> — invalid HTML, and it
+  // takes the click away from the option itself.
+  test("renders no interactive element", () => {
+    render(<InlineCode text="Use `kubectl debug` to attach a container" />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});
+
+describe("the copyable value announces itself at rest", () => {
+  // jsdom has no CSS engine, so these read the stylesheet. They exist
+  // because nothing pinned this component's geometry before, and three
+  // separate hover-icon geometries were tried and reverted without a
+  // single test noticing.
+
+  test("inline code carries a fill AND an edge, so it survives any surface", async () => {
+    const body = ruleBody(await readThemeCss(), ".md code, .mcq-option-text code");
+    expect(body).not.toBeNull();
+    // The fill used to be --bg, which is exactly what .mcq-body is: on the
+    // multiple-choice screen the chip was invisible until hovered.
+    expect(body).not.toMatch(/background:\s*var\(--bg\)/);
+    expect(body).toMatch(/background:\s*var\(--surface-raised\)/);
+    expect(body).toMatch(/border:\s*1px solid var\(--border\)/);
+  });
+
+  test("a copyable value's resting edge marks it as a control", async () => {
+    const body = ruleBody(await readThemeCss(), ".copy-value code");
+    expect(body).not.toBeNull();
+    // DESIGN.md's Two-Tier Hairline rule: --border-strong is for an edge
+    // that identifies a hit area. This was `1px solid transparent`, which
+    // is how the affordance came to be discoverable only by hovering.
+    expect(body).toMatch(/border-color:\s*var\(--border-strong\)/);
+    expect(body).not.toMatch(/transparent/);
+  });
+
+  test("there is no out-of-flow hover icon to collide with the next word", async () => {
+    const css = await readThemeCss();
+    // At the mcq stem's 19px the absolutely-positioned icon ran ~18px past
+    // its chip into a ~4px word gap, and the next chip's opaque fill
+    // painted over it. The chip itself is the whole control now.
+    expect(ruleBody(css, ".copy-value-icon")).toBeNull();
+    expect(css).not.toContain("copy-value-icon");
+  });
+
+  test("a long value wraps inside its chip rather than pushing the pane sideways", async () => {
+    const body = ruleBody(await readThemeCss(), ".copy-value code");
+    expect(body).toMatch(/overflow-wrap:\s*anywhere/);
+  });
 });
 
 describe("Markdown wrapper: pane layout and prose styling do not share a class", () => {
@@ -127,9 +222,12 @@ describe("Markdown wrapper: pane layout and prose styling do not share a class",
       expect(bareMdRule[1]).not.toMatch(/overflow-y:/);
     }
 
-    // Prose selectors stay scoped under `.md`.
+    // Prose selectors stay scoped under `.md`. The inline-code rule now
+    // shares its block with `.mcq-option-text code` — an option is not
+    // markdown but its code spans are the same object — so the selector
+    // may be followed by a comma as well as by its brace.
     expect(css).toMatch(/(?:^|\n)\.md pre\s*\{/);
-    expect(css).toMatch(/(?:^|\n)\.md code\s*\{/);
+    expect(css).toMatch(/(?:^|\n)\.md code\s*[,{]/);
     expect(css).toMatch(/(?:^|\n)\.md pre code\s*\{/);
 
     // Pane layout lives on its own selector, used only by QuestionPanel,

--- a/ui/src/components/Markdown.tsx
+++ b/ui/src/components/Markdown.tsx
@@ -6,7 +6,6 @@ import { desktopClipboard } from "../lib/desktopClipboard";
 import { pasteChordLabel } from "../lib/desktopKeymap";
 import { highlightTo } from "../lib/highlight";
 import { strings } from "../strings";
-import { Icon } from "./Icon";
 import { toastStore } from "./toastStore";
 
 // The single markdown renderer for the app. Questions and solutions come
@@ -18,6 +17,8 @@ import { toastStore } from "./toastStore";
 // resource names, labels, image tags, /opt/course paths — as inline code.
 // Rendering those as buttons turns "retype this without a typo" into one
 // click, and the click pushes the value into the exam desktop's clipboard.
+//
+// Only where there IS a desktop. See the `copyable` prop below.
 function CopyableCode({ children }: { children: ReactNode }) {
   const value = typeof children === "string" ? children : String(children ?? "");
 
@@ -43,9 +44,6 @@ function CopyableCode({ children }: { children: ReactNode }) {
       aria-label={strings.questionPanel.copyValue(value)}
     >
       <code>{children}</code>
-      <span className="copy-value-icon" aria-hidden="true">
-        <Icon name="copy" />
-      </span>
     </button>
   );
 }
@@ -117,7 +115,7 @@ interface CodeChildProps {
   children?: ReactNode;
 }
 
-const COMPONENTS = {
+const SHARED_COMPONENTS = {
   // Bank content is authored as a standalone document: every question.md
   // opens `# Question 8 | ...` and every solution.md opens `# Solution 8`.
   // Dropped into the app as-is that is a second h1 on the exam screen —
@@ -152,12 +150,24 @@ const COMPONENTS = {
       <CodeBlock className={child?.props?.className}>{child?.props?.children}</CodeBlock>
     );
   },
+};
+
+// Two component maps, built once at module scope rather than per render:
+// react-markdown re-renders its whole tree when the object identity
+// changes, and the exam screen re-renders on every clock tick.
+const COMPONENTS = {
+  ...SHARED_COMPONENTS,
   code: ({ children, className }: CodeChildProps) =>
     className ? (
       <code className={className}>{children}</code>
     ) : (
       <CopyableCode>{children}</CopyableCode>
     ),
+};
+
+const COMPONENTS_STATIC = {
+  ...SHARED_COMPONENTS,
+  code: ({ children, className }: CodeChildProps) => <code className={className}>{children}</code>,
 };
 
 // Eight solution files in the CKAD bank are written with GFM pipe tables
@@ -168,12 +178,66 @@ const COMPONENTS = {
 // like everything else; the exam must not depend on the network.
 const PLUGINS = [remarkGfm];
 
-export function Markdown({ children }: { children: string }) {
+/**
+ * `copyable` decides whether an inline value is a button or just a value.
+ *
+ * It is true for the hands-on engine, where the click pushes into the
+ * exam desktop's clipboard and saves the candidate retyping a path under
+ * a clock. It is false for multiple choice, which has no desktop and no
+ * terminal — an mcq attempt starts before the cluster is up and works on
+ * a phone, so a copy button there offers a paste target that does not
+ * exist. The chip looks the same either way; only the promise differs.
+ */
+export function Markdown({
+  children,
+  copyable = true,
+}: {
+  children: string;
+  copyable?: boolean;
+}) {
   return (
     <div className="md">
-      <ReactMarkdown components={COMPONENTS} remarkPlugins={PLUGINS}>
+      <ReactMarkdown
+        components={copyable ? COMPONENTS : COMPONENTS_STATIC}
+        remarkPlugins={PLUGINS}
+      >
         {children}
       </ReactMarkdown>
     </div>
+  );
+}
+
+/**
+ * Inline code for text that is NOT markdown: an mcq option.
+ *
+ * Options are single-line strings in exam.yaml and bank-spec.md has
+ * always promised that "inline markdown such as backticks is fine" in
+ * them. It was not: both option renderers interpolated the raw string, so
+ * the 44 backticked spans in the KCNA bank reached the candidate with
+ * their backticks showing.
+ *
+ * Deliberately not <Markdown>. An option is the label of a radio or
+ * checkbox, and Markdown would wrap it in a <p> and — with copy enabled —
+ * nest a <button> inside that <label>, which is invalid HTML and takes
+ * the click away from the option itself. So: backticks and nothing else.
+ */
+export function InlineCode({ text }: { text: string }) {
+  // Odd indices are the spans between backticks — but only once the
+  // backticks are known to pair up. An odd COUNT of them leaves the final
+  // span unterminated, and treating it as code would silently restyle the
+  // rest of the option and eat the character that was the actual mistake.
+  // A typo in a bank should show as the typo it is, so the unterminated
+  // tail is folded back into the preceding text with its backtick intact.
+  const parts = text.split("`");
+  if (parts.length % 2 === 0) {
+    const tail = parts.pop() as string;
+    parts[parts.length - 1] += "`" + tail;
+  }
+  return (
+    <>
+      {parts.map((part, i) =>
+        i % 2 === 1 ? <code key={i}>{part}</code> : <span key={i}>{part}</span>,
+      )}
+    </>
   );
 }

--- a/ui/src/components/McqAnswerReview.tsx
+++ b/ui/src/components/McqAnswerReview.tsx
@@ -1,5 +1,6 @@
 import type { QuestionResult } from "../api";
 import { Icon } from "./Icon";
+import { InlineCode } from "./Markdown";
 import { strings } from "../strings";
 
 const LETTERS = "ABCDEF";
@@ -50,7 +51,7 @@ export function McqAnswerReview({ question }: { question: QuestionResult }) {
               </span>
               <span className="mcq-option-text">
                 <span className="sr-only">{LETTERS[i]}. </span>
-                {text}
+                <InlineCode text={text} />
               </span>
               {icon && (
                 <span className="mcq-review-state">

--- a/ui/src/lib/controlJob.ts
+++ b/ui/src/lib/controlJob.ts
@@ -1,0 +1,45 @@
+import type { ControlJob } from "../api";
+import { strings } from "../strings";
+
+/**
+ * What to call a conductor job on screen.
+ *
+ * One definition because there are two surfaces — the overlay and the
+ * backgrounded chip — and they must never disagree about what is
+ * happening. They did: the chip titled ANY job carrying a bank as a
+ * switch, so a pooled bank's seed job (which carries one) announced
+ * itself as "Switching to CKAD Mock Exam 01" to a candidate who had
+ * pressed Start and was waiting for their tasks to be set up.
+ *
+ * `target` is the catalog title when the caller has resolved one; the
+ * bank slug is the fallback and is never preferred — the slug is an
+ * implementation detail nobody outside the repo should have to read.
+ */
+export function controlJobTitle(job: ControlJob, bankTitle?: string): string {
+  const target = bankTitle || job.bank;
+  switch (job.op) {
+    case "switch":
+      return strings.control.switchTitle(target);
+    case "provision":
+      return strings.control.provisionTitle(target);
+    case "seed":
+      return strings.control.seedTitle;
+    default:
+      return strings.control.resetTitle;
+  }
+}
+
+/**
+ * The one line of reassurance under the checklist.
+ *
+ * Keyed on the job's own phase list rather than a prop: an mcq switch or
+ * reset simply never declares `recreate-cluster` (see resetPhases and
+ * switchPhases in the conductor), so its absence IS the "no cluster
+ * rebuild, this takes seconds" signal, with nothing to thread through
+ * and nothing that can fall out of sync with what the server is doing.
+ */
+export function controlJobHint(job: ControlJob): string {
+  if (job.op === "seed") return strings.control.hintSeed;
+  if (!job.phases.some((p) => p.id === "recreate-cluster")) return strings.control.hintFast;
+  return job.op === "provision" ? strings.control.hintProvision : strings.control.hint;
+}

--- a/ui/src/screens/Exam.tsx
+++ b/ui/src/screens/Exam.tsx
@@ -494,7 +494,12 @@ export function Exam({ session, fetchedAt, onSessionChange }: ExamProps) {
           </div>
         </Dialog>
       )}
-      {introOpen && <ExamIntro onClose={() => setIntroOpen(false)} />}
+      {introOpen && (
+        <ExamIntro
+          onClose={() => setIntroOpen(false)}
+          durationSeconds={exam?.durationSeconds}
+        />
+      )}
     </div>
   );
 }

--- a/ui/src/screens/Exams.test.tsx
+++ b/ui/src/screens/Exams.test.tsx
@@ -83,12 +83,14 @@ const renderExams = (
   catalogVersion = 0,
   onControlStart = noop as never,
   seatKind?: "practical" | "mcq",
+  seatBank?: string,
 ) =>
   render(
     <Exams
       catalogVersion={catalogVersion}
       onControlStart={onControlStart}
       seatKind={seatKind}
+      seatBank={seatBank}
       onBanksLoaded={noop}
     />,
   );
@@ -282,6 +284,45 @@ describe("choosing an exam", () => {
     expect(window.location.hash).toBe("");
   });
 
+  // A fresh `./sim up` builds nothing and loads nothing, so this screen
+  // is the first thing a candidate sees and `active` is empty. The
+  // confirmation still appears — it is still minutes of building — but
+  // the switch copy would warn them about wiping cluster state they have
+  // not created and replacing an exam they have not chosen.
+  describe("with no exam loaded yet", () => {
+    beforeEach(() => {
+      banks = catalog("");
+    });
+
+    test("confirms a build rather than a destructive switch", async () => {
+      const user = userEvent.setup();
+      renderExams(0, ((start: () => Promise<unknown>) => void start()) as never);
+      await screen.findByRole("heading", { name: "CKAD" });
+
+      await user.click(within(cardFor("CKAD")).getByRole("button", { name: "Choose a mode" }));
+      const dialog = await screen.findByRole("dialog");
+      expect(dialog).not.toHaveTextContent(/wipes/i);
+      expect(dialog).not.toHaveTextContent(/switching/i);
+      expect(dialog).toHaveTextContent(/builds the Kubernetes cluster/i);
+
+      // Same request either way: the conductor decides it is a provision
+      // by reading the bank file, not by being told.
+      await user.click(screen.getByRole("button", { name: "Build it" }));
+      await waitFor(() => expect(switchCalls).toEqual(["ckad-mock-01"]));
+    });
+
+    test("still gates it behind a confirmation — it is minutes of work", async () => {
+      const user = userEvent.setup();
+      renderExams(0, ((start: () => Promise<unknown>) => void start()) as never);
+      await screen.findByRole("heading", { name: "CKAD" });
+
+      await user.click(within(cardFor("CKAD")).getByRole("button", { name: "Choose a mode" }));
+      expect(await screen.findByRole("dialog")).toBeInTheDocument();
+      expect(switchCalls).toEqual([]);
+      expect(window.location.hash).toBe("");
+    });
+  });
+
   test("cancelling starts nothing", async () => {
     const user = userEvent.setup();
     renderExams(0, ((start: () => Promise<unknown>) => void start()) as never);
@@ -384,6 +425,34 @@ describe("a hosted seat", () => {
     await screen.findByRole("heading", { name: "CKAD" });
 
     expect(within(cardFor("CKAD")).getByRole("button", { name: "Choose a mode" })).toBeTruthy();
+    expect(within(cardFor("KCNA")).getByRole("button", { name: "Choose a mode" })).toBeTruthy();
+  });
+
+  // A hosted seat is ONE exam now: the candidate chose the certification
+  // in the lobby and the Pod was created, stamped and sized for it. The
+  // hub refuses anything else, and this is so nobody is offered it first
+  // and the reason is on screen rather than in a 409.
+  test("a seat offers its own exam and no other, even of the same engine", async () => {
+    banks = catalog("ckad-mock-01", [ckad, { ...kcna, examType: "hands-on" }, cks]);
+    renderExams(0, noop as never, "practical", "ckad-mock-01");
+    await screen.findByRole("heading", { name: "CKAD" });
+
+    expect(within(cardFor("CKAD")).getByRole("button", { name: "Choose a mode" })).toBeTruthy();
+    const other = cardFor("KCNA");
+    expect(within(other).queryByRole("button")).toBeNull();
+    expect(within(other).getByText("Not in this seat")).toBeTruthy();
+    // Says what to do, and that finishing an attempt is not at stake.
+    expect(within(other).getByText(/end the session and start this exam/i)).toBeTruthy();
+  });
+
+  // A Pod adopted from before exams were choosable records no bank. It
+  // falls back to the rule that came first — the seat's flavour — rather
+  // than to no rule at all.
+  test("a seat that records no exam still refuses the wrong engine", async () => {
+    renderExams(0, noop as never, "mcq", undefined);
+    await screen.findByRole("heading", { name: "CKAD" });
+
+    expect(within(cardFor("CKAD")).getByText("Not in this seat")).toBeTruthy();
     expect(within(cardFor("KCNA")).getByRole("button", { name: "Choose a mode" })).toBeTruthy();
   });
 });

--- a/ui/src/screens/Exams.tsx
+++ b/ui/src/screens/Exams.tsx
@@ -219,25 +219,43 @@ function SoonCard({ bank, badge }: { bank: BankEntry; badge?: string }) {
  * The seat a hosted candidate is sitting in, or undefined when this is
  * the local product and every exam is theirs to choose.
  *
- * A seat is a Pod template. The multiple-choice one is a facilitator and
- * 128Mi with no cluster in it, so a hands-on exam started there boots the
- * bank into an environment with no instances and no desktop: every task
- * grades zero against "could not resolve hostname instance-1", and the
- * attempt is recorded as if it counted.
+ * A hosted seat is ONE EXAM. The candidate chose the certification in
+ * the lobby and their Pod was created, stamped and sized for it, so
+ * every other exam is greyed out here and the hub refuses it too. That
+ * refusal is the one that matters; this is so nobody is offered it
+ * first, and so the reason is on screen rather than in a 409.
  *
  * The catalog cannot make this distinction itself — the banks image
  * stages every bank into every session, so all of them are `available`
- * from inside any Pod. The hub refuses the switch too, and that refusal
- * is the one that matters; this is so nobody is offered it first.
+ * from inside any Pod.
+ *
+ * `seatBank` is empty for a session adopted from a Pod created before
+ * exams were choosable. Those fall back to the rule that came first: the
+ * seat's FLAVOUR. A multiple-choice Pod is a facilitator and 128Mi with
+ * no cluster in it, so a hands-on exam started there boots the bank into
+ * an environment with no instances and no desktop — every task grades
+ * zero against "could not resolve hostname instance-1", and the attempt
+ * is recorded as if it counted.
  */
 function seatFor(
   exams: CatalogExam[],
   seat: SessionKind | undefined,
+  seatBank: string | undefined,
 ): { offered: CatalogExam[]; wrongSeat: Set<string> } {
   const wrongSeat = new Set<string>();
   if (!seat) return { offered: exams, wrongSeat };
   const offered = exams.map((bank) => {
     if (!bank.available) return bank;
+    if (seatBank) {
+      if (bank.id === seatBank) return bank;
+      wrongSeat.add(bank.id);
+      return {
+        ...bank,
+        available: false,
+        comingSoon: false,
+        note: strings.exams.otherExamNote,
+      };
+    }
     const needs = bank.examType === "mcq" ? "mcq" : "practical";
     if (needs === seat) return bank;
     wrongSeat.add(bank.id);
@@ -261,6 +279,9 @@ interface ExamsProps {
   catalogVersion: number;
   // The hosted seat, if this is a hosted session. Undefined locally.
   seatKind?: SessionKind;
+  // The one exam that seat was created for. Undefined locally, and
+  // undefined for a session adopted from before exams were choosable.
+  seatBank?: string;
   // Takes the *starter*, not its result, so the switch runs inside App's
   // runControlAction — the wrapper that turns both a refused job
   // ({ok:false}) and a rejected fetch into a toast.
@@ -286,8 +307,20 @@ interface ExamsProps {
  * this screen must not smooth over, and it is why every card carries the
  * same "Choose a mode" verb but a card that is not the active bank goes
  * through a confirmation first.
+ *
+ * A fresh environment has no active bank at all: nothing is built until
+ * an exam is chosen, and this screen is where that happens. The
+ * confirmation still appears — it is still minutes of building — but it
+ * describes a build rather than a switch, because there is no outgoing
+ * exam and no candidate work for it to destroy.
  */
-export function Exams({ catalogVersion, seatKind, onControlStart, onBanksLoaded }: ExamsProps) {
+export function Exams({
+  catalogVersion,
+  seatKind,
+  seatBank,
+  onControlStart,
+  onBanksLoaded,
+}: ExamsProps) {
   const [confirm, setConfirm] = useState<CatalogExam | null>(null);
   const [switching, setSwitching] = useState(false);
   // The bank a switch was started FOR, so the mode screen it was meant
@@ -368,7 +401,7 @@ export function Exams({ catalogVersion, seatKind, onControlStart, onBanksLoaded 
           // Only the two lists below are seat-aware. The coverage figure
           // above counts certifications passed on the path, which is a
           // fact about the candidate and not about the Pod they are in.
-          const { offered, wrongSeat } = seatFor(loaded.exams, seatKind);
+          const { offered, wrongSeat } = seatFor(loaded.exams, seatKind, seatBank);
           const live = offered.filter((b) => b.available);
           const soon = offered.filter((b) => !b.available);
           return (
@@ -434,10 +467,19 @@ export function Exams({ catalogVersion, seatKind, onControlStart, onBanksLoaded 
 
       {confirm && (
         <Dialog
-          title={strings.lobby.switchConfirmTitle(examHeading(confirm))}
+          title={
+            active
+              ? strings.lobby.switchConfirmTitle(examHeading(confirm))
+              : strings.lobby.buildConfirmTitle(examHeading(confirm))
+          }
           onClose={() => setConfirm(null)}
         >
-          <p>{strings.lobby.switchConfirmBody}</p>
+          {/* `active` is empty exactly when no exam has ever been chosen
+              in this environment — nothing is built, so there is nothing
+              to wipe and nothing being replaced. The switch copy is a
+              warning about losing state; printing it here would warn a
+              candidate about work they have not done. */}
+          <p>{active ? strings.lobby.switchConfirmBody : strings.lobby.buildConfirmBody}</p>
           <div className="confirm-actions">
             <button className="btn" onClick={() => setConfirm(null)} disabled={switching}>
               {strings.lobby.cancel}
@@ -445,7 +487,11 @@ export function Exams({ catalogVersion, seatKind, onControlStart, onBanksLoaded 
             <button className="btn btn-primary" onClick={handleConfirm} disabled={switching}>
               {/* Both buttons going grey with nothing else changing reads
                   as a stuck dialog rather than a request in flight. */}
-              {switching ? strings.control.starting : strings.lobby.switchConfirm}
+              {switching
+                ? strings.control.starting
+                : active
+                  ? strings.lobby.switchConfirm
+                  : strings.lobby.buildConfirm}
             </button>
           </div>
         </Dialog>

--- a/ui/src/screens/Hosted.test.tsx
+++ b/ui/src/screens/Hosted.test.tsx
@@ -121,6 +121,15 @@ let posted: Posted[];
 let identity: Me | null;
 /** Status for the next POST /api/session/start, and what it answers with. */
 let startAnswer: { status: number; body: unknown };
+/**
+ * What GET /hub/exams answers.
+ *
+ * Empty by default, which is a real deployment state — a hub with no
+ * bank index staged — and the one the flavour-card tests below cover.
+ * The tests that set it are the ordinary case: candidates choose the
+ * certification.
+ */
+let hubExams: unknown[];
 
 function stubFetch() {
   posted = [];
@@ -144,6 +153,7 @@ function stubFetch() {
       if (url.endsWith("/api/session/start") && init?.method === "POST") {
         return json(startAnswer.body, startAnswer.status);
       }
+      if (url.endsWith("/hub/exams")) return json({ exams: hubExams });
       if (url.endsWith("/hub/session/end")) return new Response(null, { status: 204 });
       if (url.endsWith("/api/history")) {
         return json({
@@ -164,6 +174,7 @@ beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true, now });
   identity = me();
   startAnswer = { status: 202, body: { starting: true, state: "pending" } };
+  hubExams = [];
   stubFetch();
   window.location.hash = "";
 });
@@ -243,6 +254,80 @@ test("no login URL means no sign-in button", async () => {
 
   expect(await screen.findByRole("alert")).toBeTruthy();
   expect(screen.queryByRole("link", { name: /continue with github/i })).toBeNull();
+});
+
+// The ordinary lobby: the candidate picks the certification they came
+// for. It used to offer "hands-on" or "multiple choice" and the exam
+// behind each was a chart value they never saw, which worked only while
+// there was exactly one of each.
+test("the lobby offers certifications and starts the one that is chosen", async () => {
+  const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+  hubExams = [
+    {
+      id: "ckad-mock-01",
+      title: "CKAD Mock Exam 01",
+      certification: "CKAD",
+      description: "Twenty-two hands-on tasks.",
+      examType: "hands-on",
+      kind: "practical",
+      durationSeconds: 7200,
+      questionCount: 22,
+      nodes: 2,
+      available: true,
+    },
+    {
+      id: "kcna-mock",
+      title: "KCNA Mock Exam",
+      certification: "KCNA",
+      examType: "mcq",
+      kind: "mcq",
+      durationSeconds: 5400,
+      questionCount: 60,
+      available: true,
+    },
+  ];
+  render(<App />);
+
+  expect(await screen.findByRole("heading", { name: "CKAD" })).toBeTruthy();
+  expect(screen.getByRole("heading", { name: "KCNA" })).toBeTruthy();
+  // Seats stay per ENGINE: what a seat costs is a Pod, and every
+  // hands-on exam is one, so CKAD and CKA draw from the same pool.
+  expect(screen.getByText("2 of 3 free")).toBeTruthy();
+  expect(screen.getByText("30 of 30 free")).toBeTruthy();
+
+  await user.click(screen.getAllByRole("button", { name: "Start" })[1]);
+
+  await waitFor(() => {
+    const start = posted.find((p) => p.url.endsWith("/api/session/start"));
+    expect(start).toBeTruthy();
+    // The exam decides the seat. The kind rides along, but the hub
+    // derives the flavour from the bank's own engine.
+    expect(JSON.parse(start!.body)).toEqual({ kind: "mcq", bank: "kcna-mock" });
+  });
+});
+
+// A certification on the path whose bank is not written is listed —
+// seeing that CKS is coming is worth something — but there is nothing to
+// press, and the card says why rather than failing on the click.
+test("a certification with no bank yet is shown without a start button", async () => {
+  hubExams = [
+    {
+      id: "cks-mock",
+      title: "CKS Mock Exam",
+      certification: "CKS",
+      examType: "hands-on",
+      kind: "practical",
+      available: false,
+      comingSoon: true,
+      note: "Requires security add-ons the environment has not got yet",
+    },
+  ];
+  render(<App />);
+
+  expect(await screen.findByRole("heading", { name: "CKS" })).toBeTruthy();
+  expect(screen.getByText(/security add-ons/i)).toBeTruthy();
+  expect(screen.queryByRole("button", { name: "Start" })).toBeNull();
+  expect(screen.queryByRole("button", { name: /join the queue/i })).toBeNull();
 });
 
 test("signed in with no session, the lobby offers a flavour and posts a kind", async () => {

--- a/ui/src/screens/HostedBooting.tsx
+++ b/ui/src/screens/HostedBooting.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
-import { endHostedSession, startHostedSession, type HostedSession } from "../api";
+import { endHostedSession, getHostedExams, startHostedSession, type HostedSession } from "../api";
 import { PendingBar } from "../components/Pending";
 import { formatElapsed } from "../lib/format";
+import { useAsync } from "../lib/useAsync";
 import { useTick } from "../lib/useTick";
 import { strings } from "../strings";
 
@@ -17,7 +18,7 @@ interface HostedBootingProps {
  * different things to the person waiting. `pending` is "nothing is wrong,
  * someone else is booting first" — the hub builds Pods one at a time
  * because boot is CPU-bound and two at once makes both slow. `starting`
- * is their own Pod, building a real two-node cluster.
+ * is their own Pod, building the cluster their chosen exam asked for.
  *
  * The elapsed counter is the signal that works without motion: it ticks
  * identically whether or not the candidate accepts animation, and the bar
@@ -30,13 +31,27 @@ export function HostedBooting({ session, onChanged }: HostedBootingProps) {
   const started = Date.parse(session.startedAt);
   const elapsed = Number.isNaN(started) ? 0 : now - started;
 
+  // What is actually being built. The session names its exam; the exam
+  // list is what knows that exam's shape. Fetched rather than assumed,
+  // because the alternative is asserting one bank's node and task counts
+  // at whoever is waiting — which is what this screen used to do.
+  //
+  // A failure here costs nothing: the copy below falls back to sentences
+  // that claim no numbers at all.
+  const examsState = useAsync((signal) => getHostedExams(signal), []);
+  const exam = examsState.data?.find((e) => e.id === session.bank);
+
   const retry = async () => {
     setBusy(true);
     // End first, then ask again: a failed session still holds its seat so
     // the candidate can read why, and starting without giving that up
     // would simply hand back the same failed session.
+    //
+    // Retried onto the SAME exam. Without the bank this fell back to the
+    // deployment's default, so a candidate whose CKA environment failed
+    // would press "Try again" and be handed CKAD.
     await endHostedSession().catch(() => undefined);
-    await startHostedSession(session.kind).catch(() => undefined);
+    await startHostedSession(session.kind, session.bank).catch(() => undefined);
     setBusy(false);
     onChanged();
   };
@@ -79,12 +94,23 @@ export function HostedBooting({ session, onChanged }: HostedBootingProps) {
     ? strings.hosted.bootPendingBody
     : session.kind === "mcq"
       ? strings.hosted.bootStartingBodyMcq
-      : strings.hosted.bootStartingBody;
+      : strings.hosted.bootStartingBody(exam?.nodes, exam?.questionCount);
 
   return (
     <div className="page hosted-screen hosted-booting">
       <h1>{title}</h1>
       <p>{body}</p>
+      {/* Keyed on the elapsed counter rather than a range promised up
+          front: a wait that has already blown through the number it was
+          given reads as a hang, and the honest thing to say at four
+          minutes is not the thing to say at ten. Only for the build —
+          a queue's wait is somebody else's boot and this screen cannot
+          narrate it. */}
+      {!pending && session.kind !== "mcq" && (
+        <p className="hosted-boot-reassure" role="status">
+          {strings.hosted.bootReassure(elapsed)}
+        </p>
+      )}
       <div className="score-loading-progress">
         <PendingBar label={title} />
         {/* aria-hidden and tabular, matching the control overlay: a clock

--- a/ui/src/screens/HostedStart.tsx
+++ b/ui/src/screens/HostedStart.tsx
@@ -1,13 +1,18 @@
 import { useState } from "react";
 import {
   endHostedSession,
+  getHostedExams,
   startHostedSession,
+  type HostedExam,
   type Me,
   type SessionKind,
   type Seats,
 } from "../api";
+import { Async } from "../components/Async";
+import { CertMark, hasCertMark } from "../components/CertMark";
 import { Dialog } from "../components/Dialog";
 import { Icon, type IconName } from "../components/Icon";
+import { useAsync } from "../lib/useAsync";
 import { strings } from "../strings";
 
 interface HostedStartProps {
@@ -16,33 +21,102 @@ interface HostedStartProps {
   onChanged: () => void;
 }
 
-/** One flavour's card: what it is, what it costs, and the button. */
-interface Flavour {
+/**
+ * One startable option: an exam if the deployment staged a bank index,
+ * a bare flavour if it did not.
+ *
+ * `bank` is what makes the difference. With one, the hub is told which
+ * certification to build and derives the seat pool from it; without one,
+ * the flavour is all there is to ask for and the deployment's configured
+ * default exam is what turns up.
+ */
+interface Choice {
+  key: string;
   kind: SessionKind;
+  bank?: string;
   title: string;
+  subtitle?: string;
   body: string;
+  certification?: string;
   seats: Seats | undefined;
   /**
    * The tile glyph, in the exam selector's vocabulary — this lobby is
-   * the same product one step earlier, so its cards are that card.
-   * A hands-on seat is the one that needs a keyboard (it is what the
+   * the same product one step earlier, so its cards are that card. A
+   * hands-on seat is the one that needs a keyboard (it is what the
    * mobile gate says too); multiple choice is a grid of options.
    */
   icon: IconName;
+  /** Set for a certification on the path whose bank is not written. */
+  soonNote?: string;
+}
+
+/** The two-card fallback: what this screen offered before exams existed. */
+function flavourChoices(me: Me): Choice[] {
+  return [
+    {
+      key: "practical",
+      kind: "practical",
+      title: strings.hosted.practicalTitle,
+      body: strings.hosted.practicalBody,
+      seats: me.seats?.practical,
+      icon: "keyboard",
+    },
+    {
+      key: "mcq",
+      kind: "mcq",
+      title: strings.hosted.mcqTitle,
+      body: strings.hosted.mcqBody,
+      seats: me.seats?.mcq,
+      icon: "grid",
+    },
+  ].filter((f) => f.seats !== undefined) as Choice[];
+}
+
+/**
+ * One card per exam, in the exam selector's own vocabulary.
+ *
+ * Seats stay per ENGINE and the card says so: what a seat costs the
+ * cluster is a session Pod, and every hands-on exam is one, so CKAD and
+ * CKA draw from the same pool. A per-exam seat count would be inventing
+ * capacity that does not exist.
+ */
+function examChoices(me: Me, exams: HostedExam[]): Choice[] {
+  return exams
+    .filter((e) => me.seats?.[e.kind] !== undefined || !e.available)
+    .map((e) => ({
+      key: e.id,
+      kind: e.kind,
+      bank: e.available ? e.id : undefined,
+      title: e.certification || e.title,
+      subtitle: strings.exams.certNames[e.certification ?? ""] ?? e.title,
+      body: e.description ?? strings.hosted.examFallbackBody,
+      certification: e.certification,
+      seats: me.seats?.[e.kind],
+      icon: e.kind === "mcq" ? "grid" : "keyboard",
+      soonNote: e.available ? undefined : e.note || strings.exams.soon,
+    }));
 }
 
 /**
  * The hosted lobby: signed in, no session yet.
  *
- * It offers a FLAVOUR, not a bank, and that is not a simplification. In
- * hosted mode the bank each flavour runs is a deployment value — the
- * chart's `sessions.practical.bank` — because the candidate has no
- * environment yet and therefore nothing to ask for a bank list from. The
- * exam selector they know is inside the session, served by their own
- * facilitator, and they reach it the moment their Pod answers.
+ * It offers the CERTIFICATION, because that is what somebody came here
+ * to sit. It used to offer a flavour — "hands-on" or "multiple choice" —
+ * and the exam behind each was a deployment value (`sessions.practical.bank`)
+ * that the person sitting it never saw, which was fine only while there
+ * was exactly one of each. The hub reads a bank index staged beside it,
+ * so the list is the banks themselves rather than a second copy of their
+ * names in values.yaml.
+ *
+ * A seat is then THAT exam: the Pod is stamped and sized for it, and the
+ * exam selector inside the session offers no other. Changing exam means
+ * ending the session, which is honest — it is a different environment.
+ *
+ * A deployment with no index staged still works and still offers the two
+ * flavour cards, which is what this screen was before.
  */
 export function HostedStart({ me, onChanged }: HostedStartProps) {
-  const [starting, setStarting] = useState<SessionKind | null>(null);
+  const [starting, setStarting] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   // Two separate things, and conflating them was the bug worth avoiding:
   // `queued` is the standing fact — this candidate is in a queue — and
@@ -56,6 +130,10 @@ export function HostedStart({ me, onChanged }: HostedStartProps) {
   // was issued.
   const place = me.queue?.position ?? queued?.position ?? 0;
 
+  // Fetched once. The exam list is an image layer on the hub's side and
+  // cannot change while this screen is open.
+  const examsState = useAsync((signal) => getHostedExams(signal), []);
+
   const leaveQueue = async () => {
     setQueued(null);
     setDialog(false);
@@ -67,11 +145,11 @@ export function HostedStart({ me, onChanged }: HostedStartProps) {
     onChanged();
   };
 
-  const start = async (kind: SessionKind) => {
-    setStarting(kind);
+  const start = async (choice: Choice) => {
+    setStarting(choice.key);
     setError(null);
     try {
-      const result = await startHostedSession(kind);
+      const result = await startHostedSession(choice.kind, choice.bank);
       if (!result.ok) {
         setError(result.error);
         return;
@@ -92,27 +170,6 @@ export function HostedStart({ me, onChanged }: HostedStartProps) {
       setStarting(null);
     }
   };
-
-  const offered: Flavour[] = [
-    {
-      kind: "practical",
-      title: strings.hosted.practicalTitle,
-      body: strings.hosted.practicalBody,
-      seats: me.seats?.practical,
-      icon: "keyboard",
-    },
-    {
-      kind: "mcq",
-      title: strings.hosted.mcqTitle,
-      body: strings.hosted.mcqBody,
-      seats: me.seats?.mcq,
-      icon: "grid",
-    },
-  ];
-  // A flavour a deployment gave no seats to is not offered at all. The
-  // hub refuses it anyway, and a disabled card explaining an option this
-  // deployment does not have would be a worse way to find that out.
-  const flavours = offered.filter((f) => f.seats !== undefined);
 
   return (
     <div className="page hosted-screen">
@@ -141,52 +198,22 @@ export function HostedStart({ me, onChanged }: HostedStartProps) {
         </div>
       )}
 
-      <ul className="hosted-flavours">
-        {flavours.map((f) => {
-          const full = f.seats !== undefined && f.seats.used >= f.seats.total;
-          return (
-            <li key={f.kind}>
-              <article className="hosted-flavour" data-full={full || undefined}>
-                <div className="hosted-flavour-head">
-                  <span className="exam-avatar hosted-flavour-tile" aria-hidden="true">
-                    <Icon name={f.icon} />
-                  </span>
-                  <div className="hosted-flavour-name">
-                    <h2>{f.title}</h2>
-                    <p className="hosted-flavour-seats">
-                      {f.seats === undefined
-                        ? null
-                        : full
-                          ? strings.hosted.seatsFull(f.seats.total)
-                          : strings.hosted.seatsFree(f.seats.used, f.seats.total)}
-                    </p>
-                  </div>
-                </div>
-                <p className="hosted-flavour-body">{f.body}</p>
-                {/* Enabled even when full, deliberately, and it says what
-                    it will actually do. The answer to a full pool is a
-                    place in the queue: a greyed-out button offers no way
-                    to ask for one, and one labelled "Start" promises a
-                    session that is not what the click produces. */}
-                <div className="hosted-flavour-actions">
-                  <button
-                    type="button"
-                    className="btn btn-primary"
-                    onClick={() => void start(f.kind)}
-                    disabled={starting !== null}
-                  >
-                    {starting === f.kind
-                      ? strings.hosted.starting
-                      : full
-                        ? strings.hosted.startQueue
-                        : strings.hosted.start}
-                  </button>
-                </div>
-              </article>
-            </li>
-          );
-        })}
-      </ul>
+      <Async
+        state={examsState}
+        loading={<p className="page-loading">{strings.app.working}</p>}
+        // A hub whose exam list will not load still has seats. Falling
+        // back is better than a dead lobby, and the deployment default is
+        // the exam it would have started anyway.
+        error={() => <ChoiceList choices={flavourChoices(me)} starting={starting} onStart={start} />}
+      >
+        {(exams) => (
+          <ChoiceList
+            choices={exams.length > 0 ? examChoices(me, exams) : flavourChoices(me)}
+            starting={starting}
+            onStart={start}
+          />
+        )}
+      </Async>
 
       {dialog && place > 0 && (
         <Dialog title={strings.hosted.queueTitle} onClose={() => setDialog(false)}>
@@ -203,5 +230,82 @@ export function HostedStart({ me, onChanged }: HostedStartProps) {
         </Dialog>
       )}
     </div>
+  );
+}
+
+function ChoiceList({
+  choices,
+  starting,
+  onStart,
+}: {
+  choices: Choice[];
+  starting: string | null;
+  onStart: (choice: Choice) => void | Promise<void>;
+}) {
+  if (choices.length === 0) {
+    return <p className="page-empty">{strings.hosted.noExams}</p>;
+  }
+  return (
+    <ul className="hosted-flavours">
+      {choices.map((c) => {
+        const full = c.seats !== undefined && c.seats.used >= c.seats.total;
+        return (
+          <li key={c.key}>
+            <article className="hosted-flavour" data-full={(full && !c.soonNote) || undefined}>
+              <div className="hosted-flavour-head">
+                <span className="exam-avatar hosted-flavour-tile" aria-hidden="true">
+                  {/* An exam card wears its certification's own mark, the
+                      same one the local selector draws. A flavour card
+                      has no certification and keeps the engine glyph. */}
+                  {c.certification && hasCertMark(c.certification) ? (
+                    <CertMark certification={c.certification} />
+                  ) : (
+                    <Icon name={c.icon} />
+                  )}
+                </span>
+                <div className="hosted-flavour-name">
+                  <h2>{c.title}</h2>
+                  <p className="hosted-flavour-seats">
+                    {c.soonNote
+                      ? c.subtitle
+                      : c.seats === undefined
+                        ? null
+                        : full
+                          ? strings.hosted.seatsFull(c.seats.total)
+                          : strings.hosted.seatsFree(c.seats.used, c.seats.total)}
+                  </p>
+                </div>
+              </div>
+              <p className="hosted-flavour-body">{c.soonNote ?? c.body}</p>
+              {/* Enabled even when full, deliberately, and it says what
+                  it will actually do. The answer to a full pool is a
+                  place in the queue: a greyed-out button offers no way
+                  to ask for one, and one labelled "Start" promises a
+                  session that is not what the click produces.
+
+                  A certification with no bank behind it has no button at
+                  all — there is nothing to press it for, and the note
+                  above says why. */}
+              {!c.soonNote && (
+                <div className="hosted-flavour-actions">
+                  <button
+                    type="button"
+                    className="btn btn-primary"
+                    onClick={() => void onStart(c)}
+                    disabled={starting !== null}
+                  >
+                    {starting === c.key
+                      ? strings.hosted.starting
+                      : full
+                        ? strings.hosted.startQueue
+                        : strings.hosted.start}
+                  </button>
+                </div>
+              )}
+            </article>
+          </li>
+        );
+      })}
+    </ul>
   );
 }

--- a/ui/src/screens/McqExam.tsx
+++ b/ui/src/screens/McqExam.tsx
@@ -27,7 +27,7 @@ import { TimerBar } from "../components/TimerBar";
 import { Dialog } from "../components/Dialog";
 import { InfoButton } from "../components/InfoButton";
 import { Icon } from "../components/Icon";
-import { Markdown } from "../components/Markdown";
+import { InlineCode, Markdown } from "../components/Markdown";
 import { CheckList } from "../components/CheckList";
 import { HintTray } from "../components/HintTray";
 import { Navigator, type NavigatorQuestion } from "../components/Navigator";
@@ -519,7 +519,9 @@ function McqQuestion({
         >
           {(data) => (
             <>
-              <Markdown>{data.markdown}</Markdown>
+              {/* copyable={false}: there is no desktop in an mcq session
+                  and therefore nothing to paste into. */}
+              <Markdown copyable={false}>{data.markdown}</Markdown>
               <fieldset className="mcq-options">
                 <legend>
                   {info.multi ? strings.mcq.selectAll : strings.mcq.selectOne}
@@ -542,7 +544,7 @@ function McqQuestion({
                       </span>
                       <span className="mcq-option-text">
                         <span className="sr-only">{LETTERS[i]}. </span>
-                        {text}
+                        <InlineCode text={text} />
                       </span>
                     </label>
                   );
@@ -709,7 +711,7 @@ function McqCheckAnswer({ questionId }: { questionId: string }) {
       </summary>
       {loading && <p>{strings.mcq.loadingAnswer}</p>}
       {error && <p className="error-text">{error}</p>}
-      {solution && <Markdown>{solution.markdown}</Markdown>}
+      {solution && <Markdown copyable={false}>{solution.markdown}</Markdown>}
     </details>
   );
 }

--- a/ui/src/screens/Mode.test.tsx
+++ b/ui/src/screens/Mode.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Mode } from "./Mode";
 import type { ExamInfo, SessionSnapshot } from "../api";
+import { strings } from "../strings";
 
 const modes = [
   {
@@ -110,6 +111,11 @@ function mockApi() {
     "fetch",
     vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
+      if (url.endsWith("/api/exam/tips")) {
+        return new Response(JSON.stringify({ markdown: "## Set the terminal up\n\nalias." }), {
+          status: 200,
+        });
+      }
       if (url.endsWith("/api/exam")) {
         return new Response(JSON.stringify(exam), { status: 200 });
       }
@@ -430,5 +436,41 @@ describe("a route that names an exam the server does not have", () => {
     await waitFor(() => expect(window.location.hash).toBe("#/exams"));
     expect(screen.queryByRole("heading", { name: "Training" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /^Start/ })).not.toBeInTheDocument();
+  });
+});
+
+// The tips sheet is bank data, so the control for it can only exist when
+// the loaded bank actually ships one. Drawing it unconditionally would
+// open an empty sheet on every bank that does not.
+describe("the exam tips opener", () => {
+  test("is absent when the bank ships no tips", async () => {
+    renderMode();
+    await screen.findByRole("heading", { name: "Training" });
+
+    expect(screen.queryByRole("button", { name: strings.tips.open })).not.toBeInTheDocument();
+  });
+
+  test("opens the bank's own tips when it does", async () => {
+    exam = { ...ckad, hasTips: true };
+    const user = userEvent.setup();
+    renderMode();
+
+    await user.click(await screen.findByRole("button", { name: strings.tips.open }));
+
+    expect(screen.getByRole("dialog", { name: strings.tips.title })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Set the terminal up" })).toBeInTheDocument();
+  });
+
+  // Both openers are one flex child of .mode-fine so its space-between
+  // still means "tips list, then buttons"; three loose children spread
+  // the first button into the middle of the row.
+  test("shares a group with the layout card's opener", async () => {
+    exam = { ...ckad, hasTips: true };
+    renderMode();
+
+    const tips = await screen.findByRole("button", { name: strings.tips.open });
+    const group = tips.closest(".mode-fine-actions") as HTMLElement;
+    expect(group).not.toBeNull();
+    expect(within(group).getByRole("button", { name: strings.intro.open })).toBeInTheDocument();
   });
 });

--- a/ui/src/screens/Mode.tsx
+++ b/ui/src/screens/Mode.tsx
@@ -11,6 +11,7 @@ import {
 import { Async } from "../components/Async";
 import { useDesktopGate } from "../components/DesktopRequired";
 import { ExamIntro, markIntroSeen } from "../components/ExamIntro";
+import { ExamTips } from "../components/ExamTips";
 import { Icon } from "../components/Icon";
 import { parseDomainsParam } from "../lib/attemptHistory";
 import { formatDuration } from "../lib/format";
@@ -332,6 +333,7 @@ export function Mode({ bankId, catalogVersion, onSessionChange }: ModeProps) {
   const [starting, setStarting] = useState<SessionMode | null>(null);
   const [startError, setStartError] = useState<string | null>(null);
   const [introOpen, setIntroOpen] = useState(false);
+  const [tipsOpen, setTipsOpen] = useState(false);
 
   const examState = useAsync((signal) => getExam(signal), [catalogVersion]);
   const exam = examState.data;
@@ -466,30 +468,55 @@ export function Mode({ bankId, catalogVersion, onSessionChange }: ModeProps) {
                   ))}
                   <li>{strings.mode.tipTimer}</li>
                 </ul>
-                {/* Marks the card seen: someone who reads it here should
-                    not have it thrown at them again the moment the exam
-                    opens. Hidden for mcq — the card walks through the
-                    split-screen desktop layout, none of which exists
-                    there. */}
-                {!isMcq && (
-                  <button
-                    type="button"
-                    className="btn"
-                    onClick={() => {
-                      markIntroSeen();
-                      setIntroOpen(true);
-                    }}
-                  >
-                    {strings.intro.open}
-                  </button>
-                )}
+                {/* Grouped, so `.mode-fine`'s space-between keeps holding
+                    the tips list against one edge and the buttons against
+                    the other. Ungrouped, a second button became a third
+                    flex child and the first one drifted into the middle
+                    of the row. */}
+                <div className="mode-fine-actions">
+                  {/* Marks the card seen: someone who reads it here should
+                      not have it thrown at them again the moment the exam
+                      opens. Hidden for mcq — the card walks through the
+                      split-screen desktop layout, none of which exists
+                      there. */}
+                  {!isMcq && (
+                    <button
+                      type="button"
+                      className="btn"
+                      onClick={() => {
+                        markIntroSeen();
+                        setIntroOpen(true);
+                      }}
+                    >
+                      {strings.intro.open}
+                    </button>
+                  )}
+                  {/* Drawn only when the bank ships a tips.md. A control
+                      that opens an empty sheet is worse than no control,
+                      and the server is the only thing that knows — tips
+                      are per bank, so there is no per-question count to
+                      infer it from the way the hint tray does. Shown for
+                      both engines: an mcq bank is free to ship its own. */}
+                  {loaded.hasTips && (
+                    <button type="button" className="btn" onClick={() => setTipsOpen(true)}>
+                      {strings.tips.open}
+                    </button>
+                  )}
+                </div>
               </div>
             </>
           );
         }}
       </Async>
 
-      {introOpen && <ExamIntro onClose={() => setIntroOpen(false)} />}
+      {introOpen && (
+        <ExamIntro
+          onClose={() => setIntroOpen(false)}
+          durationSeconds={exam?.durationSeconds}
+        />
+      )}
+
+      {tipsOpen && <ExamTips onClose={() => setTipsOpen(false)} />}
     </div>
   );
 }

--- a/ui/src/screens/Score.test.tsx
+++ b/ui/src/screens/Score.test.tsx
@@ -520,3 +520,65 @@ describe("Score routing to the deep dive", () => {
     expect(await screen.findByText(strings.score.verdictsTitle)).toBeInTheDocument();
   });
 });
+
+// The screen where a candidate finds out they ran out of time is the
+// right place to offer the technique notes — but only when the bank
+// actually ships some. Score has no exam in its props, so it asks.
+describe("the exam tips opener", () => {
+  function stubWithExam(exam: unknown) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/api/results"))
+          return new Response(JSON.stringify(results), { status: 200 });
+        if (url.endsWith("/api/exam/tips"))
+          return new Response(JSON.stringify({ markdown: "## Pacing\n\nMove on." }), {
+            status: 200,
+          });
+        if (url.endsWith("/api/exam")) return new Response(JSON.stringify(exam), { status: 200 });
+        return new Response(JSON.stringify({}), { status: 200 });
+      }),
+    );
+  }
+
+  test("is absent when the bank ships no tips", async () => {
+    stubWithExam({ name: "ckad-mock-01" });
+    render(<Score onNewAttempt={() => {}} endReason="submitted" />);
+
+    await screen.findByRole("button", { name: strings.control.newAttempt });
+    expect(screen.queryByRole("button", { name: strings.tips.open })).not.toBeInTheDocument();
+  });
+
+  test("opens the bank's tips when it does", async () => {
+    stubWithExam({ name: "ckad-mock-01", hasTips: true });
+    const user = userEvent.setup();
+    render(<Score onNewAttempt={() => {}} endReason="submitted" />);
+
+    await user.click(await screen.findByRole("button", { name: strings.tips.open }));
+
+    expect(screen.getByRole("dialog", { name: strings.tips.title })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Pacing" })).toBeInTheDocument();
+  });
+
+  // A failed exam fetch must not grow an error onto a screen that has
+  // just finished grading: the button is an offer, not a result.
+  test("a failed exam fetch costs the offer and nothing else", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/api/results"))
+          return new Response(JSON.stringify(results), { status: 200 });
+        if (url.endsWith("/api/exam"))
+          return new Response(JSON.stringify({ error: "no exam" }), { status: 503 });
+        return new Response(JSON.stringify({}), { status: 200 });
+      }),
+    );
+    render(<Score onNewAttempt={() => {}} endReason="submitted" />);
+
+    await screen.findByRole("button", { name: strings.control.newAttempt });
+    expect(screen.queryByRole("button", { name: strings.tips.open })).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/screens/Score.tsx
+++ b/ui/src/screens/Score.tsx
@@ -1,12 +1,21 @@
 import { useEffect, useRef, useState } from "react";
-import { endSession, getResults, type Results, type ResultsResponse, type SessionMode } from "../api";
+import {
+  endSession,
+  getExam,
+  getResults,
+  type Results,
+  type ResultsResponse,
+  type SessionMode,
+} from "../api";
 import { DomainBreakdown } from "../components/DomainBreakdown";
+import { ExamTips } from "../components/ExamTips";
 import { PendingBar } from "../components/Pending";
 import { ResultsBanner } from "../components/ResultsBanner";
 import { rollupDomains } from "../components/resultsModel";
 import { TaskVerdicts } from "../components/TaskVerdicts";
 import { drillHref } from "../lib/attemptHistory";
 import { formatElapsed } from "../lib/format";
+import { useAsync } from "../lib/useAsync";
 import { navigate, useRoute } from "../lib/useHashRoute";
 import { useTick } from "../lib/useTick";
 import { strings } from "../strings";
@@ -51,6 +60,13 @@ export function Score({ onNewAttempt, endReason, mode }: ScoreProps) {
   // between views inside `idle`. Read unconditionally, above every early
   // return, because it is a hook.
   const route = useRoute();
+
+  // Whether this bank has tips to offer, which decides whether the
+  // control below exists. One fetch, once, and a failure is silent: the
+  // button is an offer, not a result, and a screen that has just finished
+  // grading must not grow an error about a sidebar.
+  const [tipsOpen, setTipsOpen] = useState(false);
+  const hasTips = useAsync((signal) => getExam(signal), []).data?.hasTips === true;
 
   const clearPoll = () => {
     if (intervalRef.current !== null) {
@@ -192,8 +208,18 @@ export function Score({ onNewAttempt, endReason, mode }: ScoreProps) {
         <button className="btn btn-primary" onClick={handleNewAttempt} disabled={starting}>
           {starting ? strings.control.starting : strings.control.newAttempt}
         </button>
+        {/* Beside "New attempt" on purpose. This is the screen where a
+            candidate finds out they ran out of time, and the tips are the
+            answer to that rather than to any question they got wrong. */}
+        {hasTips && (
+          <button type="button" className="btn" onClick={() => setTipsOpen(true)}>
+            {strings.tips.open}
+          </button>
+        )}
         <p className="score-actions-hint">{strings.control.newAttemptHint}</p>
       </div>
+
+      {tipsOpen && <ExamTips onClose={() => setTipsOpen(false)} />}
     </div>
   );
 }

--- a/ui/src/strings.ts
+++ b/ui/src/strings.ts
@@ -59,6 +59,12 @@ export const strings = {
     wrongSeat: "Not in this seat",
     wrongSeatNote: (needs: string) =>
       `This is a ${needs} exam and you are in the other kind of seat. End this session and start a ${needs.toLowerCase()} one to sit it.`,
+    // Hosted, and the ordinary case now: a seat is created for the exam
+    // the candidate chose in the lobby, and the environment was built and
+    // sized for that one. Says what to do rather than only refusing, and
+    // says why the session is worth keeping if they are mid-attempt.
+    otherExamNote:
+      "You started a session for a different exam, and this environment was built for that one. End the session and start this exam to sit it — your finished attempts are kept either way.",
     // The stat strip under each card's title.
     durationLabel: "Duration",
     passingLabel: "To pass",
@@ -429,6 +435,18 @@ export const strings = {
     desktopRestored: "Desktop connection restored.",
   },
 
+  // The sheet's frame only. Everything a candidate reads inside it is the
+  // BANK's tips.md, not copy in this file: what makes a CKAD sitting fast
+  // is not what makes a KCNA one fast, and a string here would have to
+  // claim one of them was the other.
+  tips: {
+    title: "Exam tips",
+    open: "Exam tips",
+    lead: "Technique for this exam, not answers — how to set the terminal up, generate manifests instead of typing them, and find things faster than the documentation can.",
+    done: "Close",
+    failed: (message: string) => `The tips could not be loaded: ${message}`,
+  },
+
   intro: {
     title: "How this exam works",
     open: "How this exam works",
@@ -439,7 +457,11 @@ export const strings = {
       "Layout of the exam screen: a question panel on the left, the exam desktop filling the rest, and a bar across the top holding the countdown and the Submit exam button.",
     diagramQuestions: "Questions",
     diagramDesktop: "Exam desktop",
-    diagramTimer: "1:59:58",
+    // The countdown chip on the schematic. Filled with the loaded exam's
+    // own clock; this is what it says when the drawer is opened with no
+    // exam loaded, because a made-up time on a diagram of the real
+    // screen is the kind of small lie that gets believed.
+    diagramTimerLabel: "Time left",
     diagramEnd: "Submit exam",
     legend: [
       {
@@ -487,11 +509,20 @@ export const strings = {
       ["Documentation", "Firefox limited to allowlisted official sites", "Same"],
       ["Timing", "Fixed countdown, auto-submit at zero", "Same"],
       ["Working directories", "Pre-created /opt/course/<n> paths", "Same"],
-      ["Cluster", "Local kind cluster (one control plane, one worker)", "Managed multi-node environments"],
+      // Not "one control plane, one worker": the size is the bank's
+      // (spec.environment.nodes), so this page — which describes every
+      // exam at once — says how the cluster is made and leaves how big
+      // to the exam card that knows.
+      ["Cluster", "A local kind cluster, sized for the exam you pick", "Managed multi-node environments"],
       ["Proctoring", "None. No webcam, no ID checks, no lockdown browser", "PSI remote proctoring"],
       [
         "Question pool",
-        "One fixed set per exam; you will see the same questions again",
+        // Was "one fixed set per exam; you will see the same questions
+        // again", which stopped being true the moment a bank could
+        // declare spec.examLength — KCNA already draws 65 of 97. Says
+        // what each card then says precisely, rather than a rule that
+        // holds for some banks and not others.
+        "Some exams draw a fresh subset from a larger pool; the rest ask every question they hold",
         "Drawn from a much larger pool",
       ],
       ["Retakes", "Reset and retry as often as you like", "Limited, paid retakes"],
@@ -533,11 +564,24 @@ export const strings = {
   // Choosing an exam that is not the loaded one is not a navigation — it
   // is a 2-4 minute destructive rebuild, and it stays behind a
   // confirmation for that reason alone.
+  //
+  // The FIRST exam is a different sentence, not a softer one. Nothing is
+  // loaded, so nothing is wiped and nothing is replaced; the wait is the
+  // same few minutes and is still worth confirming, but describing it as
+  // a switch would warn a new candidate about losing work they have not
+  // done and an exam they have not chosen.
   lobby: {
     switchConfirmTitle: (title: string) => `Load ${title}?`,
     switchConfirmBody:
       "Only one exam can be loaded at a time. Switching wipes all cluster and instance state and rebuilds from scratch, which usually takes about 2-4 minutes. You can leave the tab open while it runs.",
     switchConfirm: "Load it",
+    buildConfirmTitle: (title: string) => `Set up ${title}?`,
+    buildConfirmBody:
+      "This builds the Kubernetes cluster for this exam and sets up its tasks, which usually takes about 2-4 minutes. You can leave the tab open while it runs, and you can switch to a different exam afterwards.",
+    // "Build it" and not "Start": nothing is timed yet. The clock starts
+    // on the mode screen this lands on, and a candidate must never think
+    // they have begun an attempt by pressing a button in a dialog.
+    buildConfirm: "Build it",
     cancel: "Cancel",
   },
 
@@ -746,7 +790,18 @@ export const strings = {
     // Said plainly because the alternative is a candidate concluding it
     // has hung and killing it partway — which used to be the rational
     // read, since nothing on screen changed for the whole of a first run.
-    hint: "First run builds a two-node Kubernetes cluster and sets up every question, which takes several minutes. Later runs resume in seconds. You can leave this tab open.",
+    // No node count and no task count: both are the bank's to declare
+    // (spec.environment.nodes, and how many questions it holds), and
+    // this screen is shown while an exam is being built rather than
+    // after one is loaded — so it must describe the act, not the shape.
+    //
+    // It must also not claim an exam. This screen covers two windows,
+    // and in the first of them there is no exam at all: k8s-env reports
+    // `booting` for the seconds it spends on the inner Docker daemon and
+    // the chart repository, which run whether or not anything has been
+    // chosen. "This exam's cluster" was a sentence about a bank nobody
+    // had picked yet.
+    hint: "The first run pulls images and builds the environment, which takes several minutes. Later runs resume in seconds. You can leave this tab open.",
     stepOf: (step: number, total: number, label: string) => `Step ${step} of ${total}: ${label}`,
     elapsed: (span: string) => `Elapsed ${span}`,
     progressLabel: "Environment build progress",
@@ -779,6 +834,10 @@ export const strings = {
     // Takes the exam's catalog title ("CKA Mock Exam 01"), never the
     // bank slug — the slug is an implementation detail.
     switchTitle: (exam: string) => `Switching to ${exam}`,
+    // The first exam an environment is given. There is no outgoing bank,
+    // so "Switching to" would name a change that is not happening and
+    // imply work being thrown away that was never done.
+    provisionTitle: (exam: string) => `Building your ${exam} environment`,
     // A pooled bank seeds only the questions the draw picked, so this runs
     // between pressing Start and the clock beginning. It destroys nothing,
     // and the wording has to say what is happening rather than borrow the
@@ -786,10 +845,21 @@ export const strings = {
     // their work be wiped.
     seedTitle: "Setting up your tasks",
     failedTitle: (op: string) =>
-      op === "switch" ? "Switch failed" : op === "seed" ? "Setup failed" : "Reset failed",
+      op === "switch"
+        ? "Switch failed"
+        : op === "provision"
+          ? "Setup failed"
+          : op === "seed"
+            ? "Setup failed"
+            : "Reset failed",
     // The measured cluster rebuild is 90–240s. Promising "1–2 minutes"
     // and then blowing past it turns a normal wait into a perceived hang.
     hint: "Rebuilding the Kubernetes cluster. Usually about 2-4 minutes. You can leave this tab open.",
+    // Same wait, and deliberately not the same sentence: there is nothing
+    // to rebuild the first time, and a candidate who has just chosen an
+    // exam should not be told something is being torn down.
+    hintProvision:
+      "Building the Kubernetes cluster and setting up the tasks. Usually about 2-4 minutes. You can leave this tab open.",
     // For jobs with no recreate-cluster phase (a switch to or reset of a
     // multiple-choice bank): promising minutes for a seconds-long job is
     // the same mistake in the other direction.
@@ -1379,11 +1449,29 @@ export const strings = {
 
     // The lobby: signed in, no session yet.
     startTitle: (login: string) => `Ready when you are, ${login}`,
+    // Says what varies without saying what any one exam's numbers are.
+    // A hands-on session builds a cluster whose SIZE is the bank's to
+    // declare, so naming two nodes here was describing CKAD to everyone
+    // who might be about to sit something else.
     startLead:
-      "Pick what to sit. A hands-on session builds a real two-node cluster and takes a few minutes to come up; multiple choice is ready immediately.",
+      "Pick the exam you want to sit. A hands-on session builds you a real cluster and takes a few minutes to come up; multiple choice is ready immediately.",
+    // Shown on an exam card whose bank writes no description of itself.
+    // Deliberately says nothing about size or length — the card's own
+    // stats carry those, and this is the slot for what kind of thing it
+    // is.
+    examFallbackBody: "A full sitting, graded the way the real exam is.",
+    // No seats configured for either engine, so there is nothing to
+    // start. A deployment can legitimately be in this state (an operator
+    // scaling to zero), and a lobby with an empty space where the cards
+    // go reads as a broken page.
+    noExams: "This deployment has no seats configured, so there is nothing to start here yet.",
+    // The two-card fallback, for a hub with no exam list staged. Both
+    // describe the ENGINE, which is all this path knows: which exam a
+    // flavour starts is the deployment's setting, and the candidate is
+    // not being asked.
     practicalTitle: "Hands-on exam",
     practicalBody:
-      "A two-node cluster, two shells and a desktop with a browser, in your own environment. This is the full simulator.",
+      "A real Kubernetes cluster, two shells and a desktop with a browser, in your own environment. This is the full simulator.",
     mcqTitle: "Multiple choice",
     mcqBody:
       "Answered in this browser. No cluster, no waiting, and it works on a phone.",
@@ -1424,11 +1512,39 @@ export const strings = {
     // it is ready in about twenty seconds — telling that candidate to
     // expect six minutes of cluster building describes someone else's
     // session.
-    bootStartingBody:
-      "A two-node Kubernetes cluster, the exam images and 22 tasks' worth of setup. It usually takes three to six minutes; nothing is lost if you close this tab.",
+    //
+    // The numbers come from the bank being built (spec.environment.nodes
+    // and its question count), because they are per-exam now: this said
+    // "a two-node Kubernetes cluster … 22 tasks" to everyone, which was
+    // only ever CKAD's shape. Both are optional — a bank that declares
+    // neither gets a sentence that claims neither, rather than a
+    // fabricated default.
+    bootStartingBody: (nodes?: number, tasks?: number) => {
+      const cluster =
+        nodes && nodes > 0
+          ? `A ${nodes}-node Kubernetes cluster`
+          : "A real Kubernetes cluster";
+      const setup = tasks && tasks > 0 ? `, the exam images and ${tasks} tasks' worth of setup` : " and the exam images";
+      return `${cluster}${setup}. Nothing is lost if you close this tab.`;
+    },
     bootStartingBodyMcq:
       "No cluster to build for a multiple-choice exam — just the question bank and the marker. This takes a few seconds.",
     bootElapsed: (elapsed: string) => `${elapsed} so far`,
+    // Said as the wait goes on, rather than promising a range up front.
+    //
+    // The old copy promised "three to six minutes", measured on one
+    // exam's cluster on one machine. A bigger cluster, a cold image
+    // cache or a busy node all blow through it, and a promise that has
+    // already expired turns a normal wait into a perceived hang. These
+    // are keyed on the elapsed counter the screen already keeps, so what
+    // is on screen is always something still true.
+    bootReassure: (elapsedMs: number) => {
+      if (elapsedMs < 90_000) return "Pulling images and starting the cluster.";
+      if (elapsedMs < 240_000) return "Still going — the cluster is coming up and its questions are being set up.";
+      if (elapsedMs < 600_000)
+        return "Taking longer than usual. A first build on a cold node pulls several gigabytes; it is still working.";
+      return "This is well past the usual wait. If nothing changes, give up this seat and start again.";
+    },
     bootFailedTitle: "Your environment did not start",
     bootRetry: "Try again",
     bootGiveUp: "Give up this seat",

--- a/ui/src/styles/layout.test.ts
+++ b/ui/src/styles/layout.test.ts
@@ -235,3 +235,53 @@ describe("the task pane's domain chip", () => {
     expect(domain).toContain("min-width: 0");
   });
 });
+
+// The tips sheet is a document, not a question. Both claims below were
+// measured in a browser; jsdom can only see the declarations.
+describe("the exam tips sheet", () => {
+  test("is wider than a confirm dialog, because it is read rather than answered", async () => {
+    const css = await readThemeCss();
+
+    // 560px is the right measure for a sentence and two buttons. The tips
+    // are pipe tables and command lines like
+    // `k create cj nightly --image=... --schedule='0 2 * * *'`, and every
+    // one of those wraps or scrolls sideways at that width — which is
+    // exactly the retyping the page exists to save.
+    expect(ruleBody(css, ".confirm-dialog-wide"), "the base wide dialog was renamed").toContain(
+      "min(560px",
+    );
+    expect(ruleBody(css, ".confirm-dialog-wide:has(> .tips-body)")).toContain("min(760px");
+  });
+
+  test("does not open a second scroll container inside the dialog", async () => {
+    const css = await readThemeCss();
+
+    // `.confirm-dialog` already scrolls (max-height + overflow-y). A body
+    // that scrolled too would give a long document two nested scrollbars,
+    // and the browser's Find, Home and End would all apply to the wrong
+    // one — the bug `.screen:has(> .score-screen)` exists to have fixed
+    // on the score screen.
+    expect(ruleBody(css, ".confirm-dialog")).toContain("overflow-y: auto");
+    expect(ruleBody(css, ".tips-body")).not.toContain("overflow");
+    expect(ruleBody(css, ".tips-body")).not.toContain("max-height");
+  });
+});
+
+// A value chip breaks differently depending on whether anything around
+// it can grow. Both rules are load-bearing and jsdom can see neither.
+describe("value chips that are too long for their column", () => {
+  test("break anywhere in a panel, but keep the token whole in a table", async () => {
+    const css = await readThemeCss();
+
+    // The narrow-panel case: a 31-character /opt/course path in a task
+    // pane dragged to its 280px floor has nowhere to grow, so breaking
+    // inside the chip beats pushing the pane sideways.
+    expect(ruleBody(css, ".copy-value code")).toContain("overflow-wrap: anywhere");
+
+    // The table case is the opposite: `anywhere` also collapses the
+    // cell's intrinsic minimum, which squeezed the exam tips' symptom
+    // column until it rendered "ImagePullBackOf" and a lone "f".
+    // `break-word` lets the column size to the token instead.
+    expect(ruleBody(css, ".md th code, .md td code")).toContain("overflow-wrap: break-word");
+  });
+});

--- a/ui/src/theme.css
+++ b/ui/src/theme.css
@@ -1986,22 +1986,43 @@
   overflow-x: auto;
 }
 
-.md code {
-  background: var(--bg);
+/* Inline code carries TWO channels, and it needs both.
+   The fill alone used to be the whole treatment (`background: var(--bg)`),
+   which worked in the hands-on question panel — that sits on --surface, so
+   a --bg chip reads against it — and was invisible on the multiple-choice
+   screen, where .mcq-body IS --bg. Identical fill, no edge, 0.1em of
+   padding: a keyword in an mcq stem was distinguished from the prose
+   around it by nothing but the monospace face, at a stem size where that
+   is a very quiet signal. Candidates found out a value was a value by
+   hovering it.
+   So: --surface-raised is the chip fill everywhere else in the system
+   (DESIGN.md, Colours), and the hairline is what survives a surface whose
+   tone happens to be close. Neither channel is load-bearing alone.
+
+   .mcq-option-text is here because an option is not markdown and never
+   passes through .md — it is a single-line string out of exam.yaml,
+   rendered by InlineCode. Its code spans are the same object and must
+   not be a second definition of one. base.css already gives every `code`
+   element the mono face, so only the chrome is stated here. */
+.md code,
+.mcq-option-text code {
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
   padding: 0.1em 0.3em;
   border-radius: var(--radius-xs);
 }
 
-/* Every inline value in a question is a click-to-copy button. It has to
-   read as part of the sentence, not as a form control, so it borrows
-   the inline-code look and only reveals its affordance on hover/focus. */
+/* Every inline value in a hands-on question is a click-to-copy button. It
+   has to read as part of the sentence rather than as a form control — but
+   it does have to read as a control, which is the Two-Tier Hairline rule:
+   --border-strong is for an edge that identifies a hit area (and answers
+   WCAG 1.4.11's 3:1 floor), --border for everything structural. This was
+   `1px solid transparent` until now, which is how the affordance came to
+   be hover-only. */
 .copy-value {
-  /* inline-block, not inline: the icon below is absolutely positioned and
-     needs a positioned box to hang off. Baseline alignment keeps it
-     sitting in the sentence exactly as inline did. */
   display: inline-block;
-  position: relative;
   vertical-align: baseline;
+  max-width: 100%;
   padding: 0;
   border: 0;
   background: none;
@@ -2012,7 +2033,25 @@
 }
 
 .copy-value code {
-  border: 1px solid transparent;
+  border-color: var(--border-strong);
+  /* A bank value can be a 31-character /opt/course path in a panel the
+     candidate has dragged down to 280px. Breaking inside the chip is the
+     better failure than pushing the pane sideways. */
+  overflow-wrap: anywhere;
+}
+
+/* Except in a table, where the column can grow instead.
+   `anywhere` also collapses the cell's intrinsic minimum width, so a
+   two-column table squeezed the first column down and split the token
+   inside it: the exam tips' symptom table rendered "ImagePullBackOf" and
+   a lone "f" on the next line. These are strings a candidate greps for,
+   so a broken one is worse than a wide column. `break-word` keeps the
+   token whole and lets the column size to it, only breaking when the
+   token cannot fit on a line of its own — which is the behaviour the
+   rule above wants and cannot have where there is no column to grow. */
+.md th code,
+.md td code {
+  overflow-wrap: break-word;
 }
 
 .copy-value:hover code,
@@ -2022,37 +2061,23 @@
   color: var(--accent-strong);
 }
 
-/* Out of flow, deliberately.
-   This used to be an inline glyph at opacity: 0, which still occupied its
-   own width plus a margin — so every copyable value in a question left a
-   permanent gap in the sentence, and a paragraph with six of them read as
-   though it had been typeset with holes in it. Hiding it with `width: 0`
-   instead would have been worse: the sentence would reflow under the
-   cursor while being read.
-   Absolute keeps the resting text exactly as if the icon did not exist,
-   and hovering shifts nothing. The value's own hover treatment (accent
-   border, accent-soft fill, accent-strong text) is what actually
-   advertises the control; this is a fourth, redundant channel. */
-.copy-value-icon {
-  position: absolute;
-  left: 100%;
-  top: 50%;
-  transform: translateY(-50%);
-  margin-left: 0.15em;
-  font-size: 0.85em;
-  line-height: 1;
-  color: var(--accent-strong);
-  opacity: 0;
-  pointer-events: none;
-}
-
-.copy-value:hover .copy-value-icon,
-.copy-value:focus-visible .copy-value-icon {
-  opacity: 1;
-}
+/* There is no hover icon, and this comment is the record of why not.
+   Three geometries were tried. An inline glyph at `opacity: 0` reserved
+   its own width plus a margin, so a paragraph with six copyable values
+   read as though it had been typeset with holes in it. `width: 0` would
+   have reflowed the sentence under the cursor while it was being read.
+   Absolute positioning at `left: 100%` reserved nothing and therefore
+   collided with everything: at the mcq stem's 19px it ran ~18px past the
+   chip into a ~4px word gap, and because neither the button nor the icon
+   opened a stacking context, the NEXT chip's opaque fill painted over it.
+   An icon that is drawn behind the following word is worse than no icon.
+   The chip's own resting hairline is the affordance now, its accent
+   treatment is the hover state, and the toast is the confirmation. Three
+   channels, none of them out of flow. */
 
 .md pre code {
   background: none;
+  border: 0;
   padding: 0;
 }
 
@@ -2176,6 +2201,52 @@
   justify-content: flex-end;
   gap: var(--space-3);
   margin-top: var(--space-4);
+}
+
+/* ---- exam tips sheet ---- */
+
+/* A dialog that is READ rather than answered.
+   560px is the right measure for a sentence and two buttons, which is
+   what every other dialog here is. The tips are a document — pipe tables,
+   and command lines like `k create cj nightly --image=... --schedule=...`
+   — and at 560px every one of those wraps or scrolls sideways, which is
+   exactly the retyping the page exists to save. Selected off the body
+   rather than by adding a third size to Dialog, because this is the only
+   reading dialog the product has; `.screen:has(> .score-screen)` above
+   sets the same precedent. */
+.confirm-dialog-wide:has(> .tips-body) {
+  width: min(760px, 94%);
+}
+
+.dialog-lead {
+  margin-top: 0;
+  margin-bottom: var(--space-4);
+}
+
+/* The lobby's two sheet openers, kept together as one flex child of
+   .mode-fine so its space-between still means "tips list, then buttons"
+   rather than spreading three items across the row. */
+.mode-fine-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+/* .score-actions centres inline content and had exactly one button in it
+   until the tips opener arrived; JSX puts no whitespace between adjacent
+   elements, so without this the two would touch. */
+.score-actions .btn + .btn {
+  margin-left: var(--space-3);
+}
+
+/* Ruled off from the lead the way .intro-note is ruled off from its
+   legend: what follows is the bank's own prose rather than this app's
+   copy, and the two should not read as one paragraph. The dialog itself
+   scrolls (max-height + overflow-y), so this deliberately does NOT open a
+   second scroll container inside it. */
+.tips-body {
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border);
 }
 
 /* ---- score screen ---- */
@@ -6277,6 +6348,15 @@
   flex-direction: column;
   align-items: flex-start;
   gap: var(--space-4);
+}
+
+/* The line that changes as the wait goes on, under the one that does
+   not. Muted because it is the secondary of the two: the paragraph above
+   says what is being built, this says how it is going. */
+.hosted-boot-reassure {
+  margin: 0;
+  max-width: 64ch;
+  color: var(--text-muted);
 }
 
 /* The header chip: identity, the lease, and the two ways out. */


### PR DESCRIPTION
Four workstreams from one plan. The largest has a single root cause: **the stack assumed one hands-on exam and one multiple-choice exam, chosen before the candidate arrived.**

## What changes

**Nothing is built until an exam is chosen.** `./sim up` used to build CKAD's cluster and seed all 22 questions before anyone picked anything. A new boot state — `idle` — means the shell is up with nothing chosen, and picking an exam runs the switch that already existed as a `provision` job. `spec.environment.nodes` stops being decorative: the kind config is generated from it.

**A hosted seat is a certification, not a flavour.** The candidate picks the exam; the seat then refuses every other one. Per-exam Pod resources come with it, so an exam whose cluster is a different size gets a Pod sized for it.

**A value you can copy looks like one.** The chip takes the resting border DESIGN.md's Two-Tier Hairline rule already required, and the hover icon is gone rather than repositioned — `theme.css` records all three geometries that were tried and why each failed. MCQ options render their backticks, which `bank-spec.md` had promised and neither renderer did.

**Four new CKAD questions, and the bank pools 22 of 26.** Blue/green cutover, a bare Pod replaced by a hardened Deployment, `kubectl debug` with a shared process namespace, and pull policy beside shutdown budget. Plus `tips.md`: technique, served ungated, because it is not answers.

## Why pool at 22

Not for variety. The real CKAD is around twenty tasks in two hours, so the four new questions went into the pool rather than into the sitting. `bank-spec.md` states what that actually buys — three of five domains are asked in full every time, only two rotate — rather than overselling it.

This is the first hands-on bank in the tree to take the pooled path, so it is exercised rather than reasoned about.

## Defects this surfaced

- **`./sim grade` was session-free by design** — right for every unpooled bank, wrong the moment one pools. It scored four questions that were never seeded, so a perfect attempt printed `191/217 (87%)`. Now scoped to the attempt's draw, and still a reader: no resume, no timer, no write.
- **`q26`'s reference solution did not work.** `--type=merge` replaces a container list wholesale; the walkthrough claimed the opposite. Corrected, and the trap is now what the solution teaches.
- **Two checks scored on an untouched cluster.** "Blue is still running" and "the bare Pod is gone" are both true of an environment where nothing was created. Both now require the work to have been done.
- **`ImagePullBackOff` split mid-token** in a table cell — a string people grep for. Found in the browser, fixed, pinned by a CSS test.

## Verification

`SMOKE PASS (191/191 solved, 0/191 fresh, 191/191 resumed, 0 after reset)` — zero failures, all 12 sections, including the pooled path end to end.

Offline: 5 bank gates, 4 Go modules (build/vet/test), 707 UI tests, `tsc`, `lint` at zero warnings, helm lint and render, `site/build.sh --check`, shell syntax, `docker compose config`.

Browser pass done against the running app: the tips sheet, chips at rest, and the MCQ option renderer.

## Reviewing the commits

The four commits are thematic and follow the workstreams. A handful of files carry hunks from more than one — `theme.css`, `strings.ts`, `api.ts`, `facilitator/internal/api/api.go` and `exam.go` — and are committed with the workstream whose change dominates them, so an individual commit is not guaranteed to build on its own. The branch tip is the tree that was verified.