### PR TITLE
A rebuild the app owns, and a header that fits a phone

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1263,8 +1263,8 @@ in"}` without one.
 |---|---|
 | — | Proxied to the candidate's Pod, unchanged. `X-Forwarded-*` is deliberately NOT set: the facilitator trusts its inputs, and a header the hub uses for auth must not be one a candidate can set. |
 | 404 | The candidate has no session. Not 502 — nothing is wrong, they have not started one. |
-| 503 | Their Pod exists and is not ready. Carries `Retry-After: 5` and `{"state": "..."}`. |
-| 502 | The Pod is unreachable. |
+| 503 | Not proxyable right now, which is not always the same thing as "not ready": either the Pod is genuinely booting, or a control job has just begun and `Manager.Get` has cleared the address while it replaces the Pod. Carries `Retry-After: 5` and `{"error": "...", "code": "environment_starting", "state": "..."}`. `state` can read `ready` here — during a reset or switch's stop phase the session's own `State` has not moved yet, only its address has, so the body's `state` and the fact of the 503 can disagree on purpose. |
+| 502 | The Pod is unreachable. `{"error": "...", "code": "environment_unreachable"}`. |
 
 The upgrade to the desktop's WebSocket is carried by the same proxy
 (`httputil.ReverseProxy` hijacks on a 101), with `FlushInterval: -1` so
@@ -1283,7 +1283,7 @@ Answers 200 whether or not anyone is signed in — a 401 would conflate
   "user": {"id": "583231", "login": "octocat"},
   "session": {
     "kind": "practical", "pod": "sim-session-practical-583231",
-    "state": "starting", "startedAt": "...", "expiresAt": "...",
+    "state": "starting", "op": "reset", "startedAt": "...", "expiresAt": "...",
     "lastSeen": "..."
   },
   "seats": {"practical": {"used": 1, "total": 3}, "mcq": {"used": 0, "total": 30}}
@@ -1299,6 +1299,13 @@ whether there is anywhere to sit.
 `state` is `pending` (a seat is held, someone else is booting first),
 `starting` (their own Pod is building), `ready`, or `failed` — which
 keeps the seat so they can read why before it is reaped.
+
+`op` is `reset` or `switch` while a control job is replacing the Pod —
+which is what a hosted reset or exam switch actually is — and absent
+the rest of the time, including on a first boot. It is server truth,
+set by the hub rather than remembered from a click, so it is still
+correct after a reload lands mid-rebuild; a client's own memory of
+having pressed "New attempt" would not survive that reload.
 
 ### POST /api/session/start
 

--- a/docs/follow-ups.md
+++ b/docs/follow-ups.md
@@ -131,9 +131,10 @@ Known, chosen, and not currently worth the cost of changing.
   screen — that screen has its own topbar with its own clock, and a
   second countdown beside it would be read as the exam's. Two
   consequences, one good and one not. The good one: there is no way to
-  destroy an environment mid-attempt by misclick, because the End
-  session control is on the same chip. The cost: a session whose hard
-  cap falls inside an attempt ends it with no warning on screen. Narrow
+  destroy an environment mid-attempt by misclick, because the whole
+  header — End session included — is simply not rendered over a running
+  exam; there is no control there to misclick. The cost: a session whose
+  hard cap falls inside an attempt ends it with no warning on screen. Narrow
   in practice — the cap defaults to ten hours against a two-hour exam —
   and the honest fix is a lease indicator in the exam's own topbar
   rather than a second header, which is a change to two exam screens

--- a/docs/history/plans/2026-08-05-hosted-rebuild-and-responsive-header.md
+++ b/docs/history/plans/2026-08-05-hosted-rebuild-and-responsive-header.md
@@ -1,0 +1,2386 @@
+# Hosted rebuild and responsive header — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a hosted "New attempt" read as the rebuild it is instead of as a
+facilitator outage, and make the app header usable on a phone.
+
+**Architecture:** Two independent halves. The first adds two machine-readable
+facts to the hub (a `code` on the proxy's own error bodies, an `op` on the
+session in `/api/me`), teaches `ui/src/api.ts` to carry them on a typed error,
+and uses both to suppress a false toast, retitle the boot screen, and route the
+candidate somewhere deliberate when the Pod comes back. The second splits
+`SessionChip` so the header can own the End-session confirmation, adds a
+`HeaderMenu` popover, and collapses the nav and session controls into it below
+one breakpoint.
+
+**Tech Stack:** Go 1.24 (`hub/`), React 18 + TypeScript + Vite (`ui/`), vitest 2
+with jsdom and vitest-axe.
+
+Design spec: `docs/history/specs/2026-08-05-hosted-rebuild-and-responsive-header-design.md`.
+
+## Global Constraints
+
+- Branch is `fix/hosted-rebuild-and-responsive-header`, already created off `main`.
+- **Commit trailers:** no `Co-Authored-By` and no `Claude-Session` lines on this repo.
+- **Go:** run `go test ./... && go vet ./...` from inside `hub/`. Both must pass.
+- **UI:** run `npx tsc --noEmit`, `npm run lint`, `npm test` from inside `ui/`, never
+  from the repo root — from the root vitest misses `ui/vite.config.ts` and every
+  DOM test fails.
+- **Do not bump vitest past v2.** It is pinned for vite 5 compatibility.
+- All user-facing copy goes in `ui/src/strings.ts`. Static text is a plain string;
+  text with runtime values is a function. Never inline a sentence in a component.
+- `.app-header`'s `height: 56px` and `flex-shrink: 0` must survive every CSS change;
+  `ui/src/styles/layout.test.ts` asserts the second one and the comment at
+  `ui/src/theme.css:145` records the regression it prevents.
+- The local product (`./sim up`) must stay byte-identical in behaviour. Nothing in
+  this plan may add a request that a local facilitator would 404.
+- Icons are hand-authored in `ui/src/components/Icon.tsx`. Never use a Unicode
+  glyph literal for a functional icon — the bundled fonts declare a `unicode-range`
+  that most of them fall outside.
+
+---
+
+## File Structure
+
+**Hub (Go)**
+
+- `hub/internal/api/api.go` — two new error-code constants and a `writeErrorCode`
+  helper beside the existing `writeError`.
+- `hub/internal/api/proxy.go` — the 502 and 503 bodies gain `code`.
+- `hub/internal/session/session.go` — `Session.Op`, populated by `Get`; `StartedAt`
+  restamped when a recycle begins rather than partway through it.
+- `hub/internal/api/session_test.go` — a stalled-Pod stub and the proxy 503 test.
+- `hub/internal/session/session_test.go` — the `Op` and `StartedAt` tests.
+
+**UI — part one**
+
+- `ui/src/api.ts` — `ApiError`, `apiError()`, `isEnvironmentStarting()`, `op` on
+  `HostedSession`.
+- `ui/src/api.test.ts` — **new.** Unit tests for the error type.
+- `ui/src/App.tsx` — the toast rule in `handlePollError`; `useSeatLanding` call.
+- `ui/src/lib/useSeatLanding.ts` — **new.** Where a hosted candidate lands when
+  their environment comes up.
+- `ui/src/screens/HostedBooting.tsx` — rebuild mode.
+- `ui/src/strings.ts` — rebuild copy, menu copy.
+- `ui/src/screens/Hosted.test.tsx` — rebuild-screen and landing tests.
+
+**UI — part two**
+
+- `ui/src/components/SessionChip.tsx` — split into `SessionChip` (clock),
+  `SessionActions` (buttons), `EndSessionDialog` (confirmation).
+- `ui/src/components/HeaderMenu.tsx` — **new.** The popover.
+- `ui/src/components/HeaderMenu.test.tsx` — **new.**
+- `ui/src/components/AppHeader.tsx` — takes a typed `session` prop, owns the
+  confirmation dialog, collapses below the breakpoint.
+- `ui/src/components/AppHeader.test.tsx` — collapsed-mode cases.
+- `ui/src/components/Icon.tsx` — a `menu` glyph.
+- `ui/src/lib/useMediaQuery.ts` — `HEADER_COMPACT_QUERY`.
+- `ui/src/theme.css` — one breakpoint system, menu styles, desktop grouping.
+- `ui/src/a11y.test.tsx` — updated `SessionChip` call site, open menu in the sweep.
+
+---
+
+## Task 1: The hub says which kind of wait a 503 is
+
+**Files:**
+- Modify: `hub/internal/api/api.go` (after `writeError`, ~line 401)
+- Modify: `hub/internal/api/proxy.go:41-43` and `proxy.go:96-103`
+- Test: `hub/internal/api/session_test.go`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: the JSON string constants `"environment_starting"` and
+  `"environment_unreachable"`, emitted as the `code` field of the proxy's own
+  error bodies. Task 4 consumes the first from the browser.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `hub/internal/api/session_test.go`. It needs `"context"` and `"sync"`
+in the import block — add them if absent.
+
+```go
+// stalledPods creates Pods that never become ready. That is exactly the
+// state the proxy's 503 branch exists for — a session admitted, holding a
+// seat, with nowhere to send traffic yet — and it is the state a hosted
+// "New attempt" spends its first minutes in, because a reset here is Pod
+// replacement.
+type stalledPods struct {
+	mu   sync.Mutex
+	live map[string]bool
+}
+
+func (p *stalledPods) Create(_ context.Context, spec []byte) error {
+	var pod struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(spec, &pod); err != nil {
+		return err
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.live == nil {
+		p.live = map[string]bool{}
+	}
+	if p.live[pod.Metadata.Name] {
+		return session.ErrPodExists
+	}
+	p.live[pod.Metadata.Name] = true
+	return nil
+}
+
+func (p *stalledPods) Get(_ context.Context, name string) (session.Pod, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.live[name] {
+		return session.Pod{}, session.ErrPodGone
+	}
+	return session.Pod{Name: name, IP: "10.42.0.9", Phase: "Running", Ready: false}, nil
+}
+
+func (p *stalledPods) Delete(_ context.Context, name string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.live[name] {
+		return session.ErrPodGone
+	}
+	delete(p.live, name)
+	return nil
+}
+
+func (p *stalledPods) List(context.Context, string) ([]session.Pod, error) {
+	return nil, nil
+}
+
+// The SPA has to tell an expected wait from an outage, and the sentence
+// in the body is copy — the next person to reword it would silently
+// break whatever was matching on it.
+func TestProxySaysWhetherAWaitIsAWaitOrAFault(t *testing.T) {
+	s, _ := newServer(t, auth.ModeGitHub)
+	s.Sessions = session.New(&stalledPods{}, session.Config{
+		Flavours: map[session.Kind]session.Flavour{
+			session.Practical: {Seats: 1, Template: session.Template(podTemplate)},
+		},
+		Logf: func(string, ...any) {},
+	})
+	s.DefaultKind = session.Practical
+
+	c := login(t, s, "583231", "octocat")
+	start := httptest.NewRequest(http.MethodPost, "/api/session/start", strings.NewReader("{}"))
+	start.AddCookie(c)
+	if w := do(s, start); w.Code != http.StatusAccepted {
+		t.Fatalf("start = %d, want 202", w.Code)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/api/session", nil)
+	r.AddCookie(c)
+	w := do(s, r)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", w.Code)
+	}
+	var body struct {
+		Error string `json:"error"`
+		Code  string `json:"code"`
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Code != "environment_starting" {
+		t.Errorf("code = %q, want environment_starting; body was %q", body.Code, body.Error)
+	}
+	if body.Error == "" {
+		t.Error("the sentence for a person went away — both are wanted, not one or the other")
+	}
+	if body.State == "" {
+		t.Error("state went away; the boot screen reads it")
+	}
+}
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `cd hub && go test ./internal/api/ -run TestProxySaysWhether -v`
+Expected: FAIL — `code = "", want environment_starting`.
+
+- [ ] **Step 3: Add the constants and the helper**
+
+In `hub/internal/api/api.go`, immediately after `writeError` (which ends at
+line 403):
+
+```go
+// Error codes on the proxy's own answers.
+//
+// The `error` field is a sentence for a person and stays that way. These
+// are for the SPA, which has to tell an expected wait from a fault and
+// must not do it by matching prose — the copy is a UI string living in a
+// Go file, and it will be reworded by someone with no idea a client is
+// parsing it.
+const (
+	codeEnvironmentStarting    = "environment_starting"
+	codeEnvironmentUnreachable = "environment_unreachable"
+)
+
+func writeErrorCode(w http.ResponseWriter, status int, code, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg, "code": code})
+}
+```
+
+- [ ] **Step 4: Emit them from the proxy**
+
+In `hub/internal/api/proxy.go`, replace the `ErrorHandler` body's `writeError`
+call (line 42) with:
+
+```go
+			writeErrorCode(w, http.StatusBadGateway, codeEnvironmentUnreachable,
+				"your exam environment is not reachable right now")
+```
+
+and replace the 503 write (lines 99-103) with:
+
+```go
+		w.Header().Set("Retry-After", "5")
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error": "your exam environment is still starting",
+			"code":  codeEnvironmentStarting,
+			"state": live.State,
+		})
+```
+
+- [ ] **Step 5: Run the test and the package**
+
+Run: `cd hub && go test ./... && go vet ./...`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hub/internal/api/api.go hub/internal/api/proxy.go hub/internal/api/session_test.go
+git commit -m "fix(hub): a wait and a fault should not read the same
+
+The proxy answers a request during a Pod replacement with 503 and a
+sentence, and answers an unreachable Pod with 502 and a sentence. The
+SPA has to tell those apart and had only the prose to do it with. Both
+bodies now carry a code; the sentences are unchanged."
+```
+
+---
+
+## Task 2: `/api/me` reports the control op in flight
+
+**Files:**
+- Modify: `hub/internal/session/session.go:72-89` (the `Session` struct) and
+  `session.go:493-502` (`Manager.Get`)
+- Test: `hub/internal/session/session_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Session.Op string` with JSON tag `op,omitempty`, set to `"reset"` or
+  `"switch"` while a recycle is in flight and empty otherwise. It reaches the
+  browser through `/api/me` because `handleMe` serialises `session.Session`
+  directly (`hub/internal/api/api.go:168`). Task 6 branches on it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `hub/internal/session/session_test.go`:
+
+```go
+// A rebuild is a Pod replacement, and the screen shown while it runs has
+// to be able to say so. Without this the only signal is "not ready",
+// which is also exactly what a first boot looks like — so the candidate
+// who pressed "New attempt" got a screen welcoming them to a new
+// environment and offering to give their seat up.
+func TestGetReportsTheControlOpWhileARebuildRuns(t *testing.T) {
+	m, pods := newManager(t, 1, nil)
+	if _, err := m.Start(context.Background(), "583231", Practical, ""); err != nil {
+		t.Fatal(err)
+	}
+	waitReady(t, m, "583231")
+
+	if s, _ := m.Get("583231"); s.Op != "" {
+		t.Errorf("op = %q on a settled session, want empty", s.Op)
+	}
+
+	// Hold the replacement un-ready so the recycle stays in flight for the
+	// length of this test rather than racing it.
+	name := pods.created[0]
+	pods.mu.Lock()
+	pods.notReady[name] = true
+	pods.mu.Unlock()
+
+	if _, err := m.Recycle("583231", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		s, err := m.Get("583231")
+		if err == nil && s.Op == "reset" {
+			if s.Addr() != "" {
+				t.Errorf("addr = %q mid-rebuild, want empty", s.Addr())
+			}
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("Get never reported the reset in flight")
+}
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `cd hub && go test ./internal/session/ -run TestGetReportsTheControlOp -v`
+Expected: FAIL — `s.Op` undefined (compile error).
+
+- [ ] **Step 3: Add the field**
+
+In `hub/internal/session/session.go`, inside `type Session struct`, after the
+`Error` field (line 79):
+
+```go
+	// Op is the control operation running against this session right now
+	// — "reset" or "switch" — and empty when there is none.
+	//
+	// On the session rather than left to GET /api/control/status because
+	// of who asks and when. The SPA polls /api/me every 2s while a session
+	// is not ready, and this is the field that lets the screen shown
+	// during that wait tell a first boot from a rebuild the candidate
+	// asked for. It is server truth, so it survives a reload mid-rebuild,
+	// which a remembered click would not.
+	Op string `json:"op,omitempty"`
+```
+
+- [ ] **Step 4: Populate it in Get**
+
+Replace `Manager.Get` (`session.go:493-502`) with:
+
+```go
+// Get returns a user's session.
+func (m *Manager) Get(user string) (Session, error) {
+	m.mu.Lock()
+	e, ok := m.sessions[user]
+	if !ok {
+		m.mu.Unlock()
+		return Session{}, ErrNoSession
+	}
+	out := e.Session
+	m.mu.Unlock()
+	// Deliberately read outside m.mu. The job store has a lock of its own
+	// and nothing that holds it ever reaches for m.mu, so nesting the two
+	// here would make this the first place in the package that could
+	// deadlock — for no gain, since `out` is already a copy.
+	if snap := e.jobs.snapshot(); snap.Busy && snap.Job != nil {
+		out.Op = snap.Job.Op
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cd hub && go test ./... && go vet ./...`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hub/internal/session/session.go hub/internal/session/session_test.go
+git commit -m "feat(hub): a session says when it is being rebuilt
+
+A recycled Pod is not ready, and neither is one that has never been
+built. Every screen that waits on a hosted session had only that one bit
+to go on, so a candidate who asked for another attempt was shown a first
+boot."
+```
+
+---
+
+## Task 3: The rebuild's clock starts when the rebuild does
+
+**Files:**
+- Modify: `hub/internal/session/session.go:567-595` (`Recycle`) and
+  `session.go:624-633` (the `start` phase of `runRecycle`)
+- Test: `hub/internal/session/session_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Session.StartedAt` is restamped when `Recycle` accepts the job, not
+  when the replacement Pod is created. Task 6's elapsed counter depends on it.
+
+**Why:** `runRecycle` restamps `StartedAt` in its `start` phase, which is after
+the old Pod is deleted and drained. The boot screen computes its elapsed counter
+from `StartedAt`, so during the whole `stop` phase it would count from the
+session's original start — a rebuild reading "4:21:07 so far" thirty seconds in.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `hub/internal/session/session_test.go`:
+
+```go
+// The boot screen's elapsed counter is (now - StartedAt), and a rebuild
+// shows that screen. Restamping only once the old Pod has drained meant
+// the first phase of every rebuild counted from the session's original
+// start — hours, on a long seat.
+func TestRecycleRestampsTheClockWhenItBeginsNotWhenThePodIsRecreated(t *testing.T) {
+	m, pods := newManager(t, 1, nil)
+	if _, err := m.Start(context.Background(), "583231", Practical, ""); err != nil {
+		t.Fatal(err)
+	}
+	waitReady(t, m, "583231")
+
+	before, _ := m.Get("583231")
+
+	// Never ready, so the recycle cannot reach its start phase and any
+	// restamping observed below is the one Recycle itself did.
+	pods.mu.Lock()
+	pods.notReady[pods.created[0]] = true
+	pods.mu.Unlock()
+
+	if _, err := m.Recycle("583231", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	after, err := m.Get("583231")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !after.StartedAt.After(before.StartedAt) {
+		t.Errorf("startedAt = %v, want later than the original %v", after.StartedAt, before.StartedAt)
+	}
+}
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `cd hub && go test ./internal/session/ -run TestRecycleRestampsTheClock -v`
+Expected: FAIL — `startedAt = <original>, want later than the original`.
+
+- [ ] **Step 3: Restamp in Recycle**
+
+In `hub/internal/session/session.go`, inside `Recycle`, replace the block that
+begins the job (lines 588-594) with:
+
+```go
+	j, ok := e.jobs.begin(op, bank, phases)
+	if !ok {
+		return Job{}, ErrBusy
+	}
+
+	// The clock the boot screen counts from. It used to be restamped in
+	// the start phase, i.e. after the old Pod had been deleted and
+	// drained, so the first stretch of every rebuild counted from the
+	// session's original start. ExpiresAt stays where it is: it is the
+	// lease, and extending it a few seconds earlier is a different
+	// decision from fixing a displayed counter.
+	m.mu.Lock()
+	e.StartedAt = m.now()
+	m.mu.Unlock()
+
+	go m.runRecycle(e, fl, bank)
+	return j, nil
+```
+
+- [ ] **Step 4: Drop the duplicate restamp**
+
+In `runRecycle`'s `start` phase (`session.go:624-633`), replace:
+
+```go
+		now := m.now()
+		e.StartedAt, e.LastSeen = now, now
+		e.ExpiresAt = now.Add(m.cfg.MaxAge)
+```
+
+with:
+
+```go
+		// StartedAt is not touched here: Recycle stamped it when the job
+		// was accepted, which is when the wait the candidate is watching
+		// actually began.
+		now := m.now()
+		e.LastSeen = now
+		e.ExpiresAt = now.Add(m.cfg.MaxAge)
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cd hub && go test ./... && go vet ./...`
+Expected: PASS, including `TestRecycleReplacesThePodAndReportsPhases`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hub/internal/session/session.go hub/internal/session/session_test.go
+git commit -m "fix(hub): a rebuild's clock started after the wait it measures
+
+StartedAt was restamped once the old Pod had drained, which is a phase
+into the job. The screen that counts from it spent that phase reporting
+the age of the session being replaced."
+```
+
+---
+
+## Task 4: `ApiError` carries the status and the code
+
+**Files:**
+- Modify: `ui/src/api.ts:401-412` and all 20 `throw new Error(await readError(res))` sites
+- Modify: `ui/src/api.ts:1251-1261` (`HostedSession`)
+- Test: `ui/src/api.test.ts` (**create**)
+
+**Interfaces:**
+- Consumes: the `code` field from Task 1.
+- Produces:
+  - `export class ApiError extends Error` with `readonly status: number` and
+    `readonly code?: string`.
+  - `export function isEnvironmentStarting(err: unknown): boolean`
+  - `HostedSession.op?: "reset" | "switch"` (from Task 2's JSON).
+  - `String(err)` on a thrown API error is byte-identical to today.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ui/src/api.test.ts`:
+
+```ts
+import { describe, expect, test } from "vitest";
+import { ApiError, isEnvironmentStarting } from "./api";
+
+describe("ApiError", () => {
+  // Everything that renders one of these renders `${err}`, and the
+  // toast copy is asserted elsewhere by its full text. Setting `name`
+  // would silently reword every one of them.
+  test("stringifies exactly as a plain Error does", () => {
+    const err = new ApiError(503, "your exam environment is still starting", "environment_starting");
+    expect(String(err)).toBe("Error: your exam environment is still starting");
+  });
+
+  test("keeps the parts a caller branches on", () => {
+    const err = new ApiError(503, "still starting", "environment_starting");
+    expect(err.status).toBe(503);
+    expect(err.code).toBe("environment_starting");
+    expect(err instanceof Error).toBe(true);
+  });
+
+  test("recognises the hub's Pod-replacement wait and nothing else", () => {
+    expect(isEnvironmentStarting(new ApiError(503, "x", "environment_starting"))).toBe(true);
+    expect(isEnvironmentStarting(new ApiError(502, "x", "environment_unreachable"))).toBe(false);
+    expect(isEnvironmentStarting(new ApiError(500, "x"))).toBe(false);
+    expect(isEnvironmentStarting(new Error("your exam environment is still starting"))).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `cd ui && npm test -- src/api.test.ts`
+Expected: FAIL — `ApiError` is not exported from `./api`.
+
+- [ ] **Step 3: Add the type and the helper**
+
+In `ui/src/api.ts`, replace the block at lines 401-412 with:
+
+```ts
+interface ApiErrorBody {
+  error: string;
+  code?: string;
+}
+
+/**
+ * An HTTP error from the API, with the machine-readable parts kept.
+ *
+ * `name` is deliberately left as "Error", so `String(err)` is unchanged
+ * and every call site that renders one reads exactly as it did. What is
+ * added is `code`: the hub answers a proxied request with 503
+ * `environment_starting` for the minutes it spends replacing a session
+ * Pod, and that is an expected wait rather than a fault — a distinction
+ * no amount of reading the sentence can make safely.
+ */
+export class ApiError extends Error {
+  readonly status: number;
+  readonly code?: string;
+
+  constructor(status: number, message: string, code?: string) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+/** The hub's answer while a session Pod is being replaced. */
+export const ENVIRONMENT_STARTING = "environment_starting";
+
+export function isEnvironmentStarting(err: unknown): boolean {
+  return err instanceof ApiError && err.code === ENVIRONMENT_STARTING;
+}
+
+/**
+ * The error a failed response should throw.
+ *
+ * readError stays beside it and is still used: the `{ ok: false, error }`
+ * call sites want the sentence and nothing else.
+ */
+async function apiError(res: Response): Promise<ApiError> {
+  try {
+    const body = (await res.json()) as ApiErrorBody;
+    return new ApiError(res.status, body.error || `HTTP ${res.status}`, body.code);
+  } catch {
+    return new ApiError(res.status, `HTTP ${res.status}`);
+  }
+}
+
+async function readError(res: Response): Promise<string> {
+  try {
+    const body = (await res.json()) as ApiErrorBody;
+    return body.error || `HTTP ${res.status}`;
+  } catch {
+    return `HTTP ${res.status}`;
+  }
+}
+```
+
+- [ ] **Step 4: Route every throwing site through it**
+
+All 20 sites are the identical string `throw new Error(await readError(res));`
+(plus one single-line variant at `api.ts:1344`). Replace them:
+
+```bash
+cd ui && perl -pi -e 's/throw new Error\(await readError\(res\)\);/throw await apiError(res);/g' src/api.ts
+```
+
+- [ ] **Step 5: Add `op` to the hosted session type**
+
+In `ui/src/api.ts`, inside `export interface HostedSession` (line 1251), after
+`error?: string;`:
+
+```ts
+  /**
+   * The control operation running against this session right now. Set by
+   * the hub while it replaces the Pod, which is what a hosted reset or
+   * exam switch is. Absent means nothing is running — including on a
+   * first boot, which is the distinction this exists to draw.
+   */
+  op?: "reset" | "switch";
+```
+
+- [ ] **Step 6: Run the checks**
+
+Run: `cd ui && npx tsc --noEmit && npm run lint && npm test`
+Expected: PASS. `readError` is still referenced by the `{ ok: false, error }`
+sites, so no unused-symbol lint error.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ui/src/api.ts ui/src/api.test.ts
+git commit -m "feat(ui): API failures keep their status and their code
+
+Every failed request threw a bare Error carrying the server's sentence
+and nothing else, so a caller wanting to tell an expected wait from a
+fault had only the prose. String(err) is unchanged."
+```
+
+---
+
+## Task 5: The toast stops firing on a rebuild the app asked for
+
+**Files:**
+- Modify: `ui/src/App.tsx:278-285` (`handlePollError`)
+- Test: `ui/src/screens/Hosted.test.tsx`
+
+**Interfaces:**
+- Consumes: `isEnvironmentStarting` from Task 4; `wasBusy` (a `useRef(false)`
+  already declared at `App.tsx:210`, set to `true` optimistically by
+  `applyControlResult` at `App.tsx:405`).
+- Produces: no new exports. `pollError` state is still set on every failure, so
+  the pre-first-session loading screen at `App.tsx:583` is unaffected.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `ui/src/screens/Hosted.test.tsx`. It reuses that file's existing
+`me()`, `stubFetch()`, `identity` and `localStubs`.
+
+```ts
+/** A ready hosted seat, so SimApp mounts and its session poller runs. */
+function readySeat() {
+  return {
+    kind: "practical" as const,
+    bank: "ckad-mock-01",
+    pod: "sim-session-practical-583231",
+    state: "ready" as const,
+    startedAt: new Date(now - 600_000).toISOString(),
+    expiresAt: new Date(now + 2 * 3600_000).toISOString(),
+    lastSeen: new Date(now).toISOString(),
+  };
+}
+
+// The reported bug, in the window it actually happens in.
+//
+// SimApp has to be MOUNTED and its session poller running, because that
+// poller is what raises the toast. /api/me flips to "pending" about two
+// seconds after the POST and unmounts SimApp — but a toast pushed before
+// then lives in a module singleton and outlives it. So the fixture holds
+// /api/me at "ready" while the proxy has already started answering 503,
+// which is exactly the race.
+test("a Pod replacement raises no outage toast", async () => {
+  identity = me({ session: readySeat() });
+  render(<App />);
+  await screen.findByRole("heading", { name: /path to kubestronaut/i });
+
+  // The hub begins replacing the Pod. Every proxied request is a 503 from
+  // here on; /api/me has not caught up.
+  localStubs["/api/session"] = null;
+  window.dispatchEvent(new Event("focus")); // pollSession re-fetches on focus
+
+  await waitFor(() => {
+    expect(screen.queryByText(/cannot reach facilitator/i)).toBeNull();
+  });
+});
+
+// The other half, and the reason the guard is a code and not a blanket
+// mute: a facilitator that has genuinely fallen over must still say so.
+test("a real failure still raises the toast", async () => {
+  identity = me({ session: readySeat() });
+  render(<App />);
+  await screen.findByRole("heading", { name: /path to kubestronaut/i });
+
+  localStubs["/api/session"] = "boom"; // forces the 500 branch in stubFetch
+  window.dispatchEvent(new Event("focus"));
+
+  expect(await screen.findByText(/cannot reach facilitator/i)).toBeInTheDocument();
+});
+```
+
+Add the 503 branch to that file's `stubFetch`, immediately before the
+`localStubs` loop:
+
+```ts
+      // Two failure fixtures for the session poll, opted into by writing
+      // a sentinel into localStubs. `null` is the hub's answer while it
+      // replaces a Pod — an expected wait. "boom" is a facilitator that
+      // has actually fallen over, which must still be reported.
+      if (url.endsWith("/api/session")) {
+        if (localStubs["/api/session"] === null) {
+          return json(
+            {
+              error: "your exam environment is still starting",
+              code: "environment_starting",
+              state: "pending",
+            },
+            503,
+          );
+        }
+        if (localStubs["/api/session"] === "boom") {
+          return json({ error: "the facilitator is not answering" }, 500);
+        }
+      }
+```
+
+and restore the stub in that file's `beforeEach`, after `identity = me();`:
+
+```ts
+  localStubs["/api/session"] = readySessionStub;
+```
+
+where `readySessionStub` is a new module-level const holding the object
+currently written inline at `localStubs["/api/session"]`:
+
+```ts
+/** A settled idle session, as the facilitator reports one. */
+const readySessionStub = {
+  state: "idle",
+  bank: "ckad-mock-01",
+  startedAt: "",
+  durationSeconds: 7200,
+  remainingSeconds: 0,
+  endReason: "",
+  mode: "exam",
+  untimed: false,
+};
+```
+
+and `localStubs["/api/session"]` becomes `readySessionStub`.
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `cd ui && npm test -- src/screens/Hosted.test.tsx -t "outage toast"`
+Expected: the "no outage toast" test FAILS — the toast is found. The "a real
+failure still raises the toast" test PASSES already, which is the point: it is
+the control, and it must stay green through the fix.
+
+- [ ] **Step 3: Import the guard**
+
+In `ui/src/App.tsx`, add `isEnvironmentStarting` to the existing import from
+`./api`.
+
+- [ ] **Step 4: Teach handlePollError the difference**
+
+Replace `handlePollError` (`App.tsx:278-285`) with:
+
+```tsx
+  const handlePollError = useCallback((err: unknown) => {
+    setPollError(String(err));
+    if (!seenSession.current) return;
+    // Two ways to know this is not a fault, and both are wanted.
+    //
+    // The hub answers every proxied request with 503 environment_starting
+    // while it replaces a session Pod, and a hosted "New attempt" IS a Pod
+    // replacement. That is the durable signal: it survives a reload
+    // landing mid-rebuild, where nothing in this tab remembers a click.
+    //
+    // A control job in flight covers the rest — the window between the
+    // 202 and /api/me reporting it, and the LOCAL product, where a reset
+    // restarts the facilitator in place and the poll fails for exactly
+    // the same non-reason. The overlay is already narrating it; a warning
+    // toast over the top says the thing the candidate asked for has gone
+    // wrong.
+    //
+    // pollError is set above either way, so the pre-first-session loading
+    // screen keeps its message.
+    if (isEnvironmentStarting(err) || wasBusy.current) return;
+    pollToastId.current = toastStore.push({
+      kind: "warning",
+      message: strings.app.cannotReach(String(err)),
+      dedupeKey: "session-poll",
+    });
+  }, []);
+```
+
+- [ ] **Step 5: Run the whole UI suite**
+
+Run: `cd ui && npx tsc --noEmit && npm run lint && npm test`
+Expected: PASS, both new tests included.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui/src/App.tsx
+git commit -m "fix(ui): the session poll stopped calling a rebuild an outage
+
+A hosted New attempt replaces the Pod, so the poll gets a 503 for
+minutes. It was reported as a warning about reaching the facilitator —
+about the rebuild the app itself had just requested."
+```
+
+---
+
+## Task 6: The boot screen tells a rebuild from a first boot
+
+**Files:**
+- Modify: `ui/src/screens/HostedBooting.tsx`
+- Modify: `ui/src/strings.ts` (the `hosted` block, after `bootGiveUp` at line 1550)
+- Test: `ui/src/screens/Hosted.test.tsx` (the test from Task 5 goes green here)
+
+**Interfaces:**
+- Consumes: `HostedSession.op` from Task 4.
+- Produces: no new exports. New copy keys: `strings.hosted.rebuildTitle`,
+  `rebuildBody(exam?: string)`, `rebuildGiveUp`.
+
+- [ ] **Step 1: Add the copy**
+
+In `ui/src/strings.ts`, in the `hosted` block immediately after
+`bootGiveUp: "Give up this seat",` (line 1550):
+
+```ts
+    // A rebuild, not a first boot. The same wait, a different fact: this
+    // candidate already has a seat and asked for another attempt, so copy
+    // that welcomes them to a new environment and offers to give the seat
+    // up is describing somebody else's situation entirely.
+    rebuildTitle: "Rebuilding your environment",
+    // Named when the exam is known, because a candidate mid-rebuild wants
+    // to be sure it is being rebuilt as the exam they were sitting.
+    rebuildBody: (exam?: string) =>
+      exam
+        ? `Your last attempt is being cleared and a clean ${exam} environment built in its place. This takes a few minutes, and nothing is lost if you close this tab.`
+        : "Your last attempt is being cleared and a clean environment built in its place. This takes a few minutes, and nothing is lost if you close this tab.",
+    // Says what it does. "Give up this seat" during a rebuild reads as
+    // "cancel the rebuild", which is not what the button does — it ends
+    // the session and hands the seat back to the pool.
+    rebuildGiveUp: "End session and free the seat",
+```
+
+- [ ] **Step 2: Write the failing assertions**
+
+Append to `ui/src/screens/Hosted.test.tsx`:
+
+```ts
+// The rebuild screen names the exam and offers the honest way out. A
+// first boot must be untouched by all of this.
+test("a rebuild says so, and a first boot still reads as a first boot", async () => {
+  hubExams = [
+    {
+      id: "ckad-mock-01",
+      title: "CKAD Mock Exam 01",
+      certification: "CKAD",
+      examType: "hands-on",
+      kind: "practical",
+      available: true,
+      nodes: 2,
+      questionCount: 22,
+    },
+  ];
+  const booting = {
+    kind: "practical" as const,
+    bank: "ckad-mock-01",
+    pod: "sim-session-practical-583231",
+    state: "starting" as const,
+    startedAt: new Date(now).toISOString(),
+    expiresAt: new Date(now + 3_600_000).toISOString(),
+    lastSeen: new Date(now).toISOString(),
+  };
+
+  identity = me({ session: { ...booting, op: "reset" } });
+  const rebuild = render(<App />);
+  await screen.findByRole("heading", { name: strings.hosted.rebuildTitle });
+  expect(screen.getByText(/clean CKAD environment/i)).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: strings.hosted.rebuildGiveUp }),
+  ).toBeInTheDocument();
+  rebuild.unmount();
+
+  identity = me({ session: booting });
+  render(<App />);
+  await screen.findByRole("heading", { name: strings.hosted.bootStartingTitle });
+  expect(
+    screen.getByRole("button", { name: strings.hosted.bootGiveUp }),
+  ).toBeInTheDocument();
+});
+```
+
+Add `import { strings } from "../strings";` to that file if it is not already
+imported.
+
+- [ ] **Step 3: Run and watch it fail**
+
+Run: `cd ui && npm test -- src/screens/Hosted.test.tsx -t "a rebuild says so"`
+Expected: FAIL — no heading named "Rebuilding your environment".
+
+- [ ] **Step 4: Branch the screen**
+
+In `ui/src/screens/HostedBooting.tsx`, after the `const exam = …` line (line 42),
+add:
+
+```tsx
+  // The hub says what it is doing to this Pod. Without it "not ready" is
+  // the only signal, and a first boot and a rebuild are indistinguishable
+  // — which is how the candidate who pressed "New attempt" ended up on a
+  // screen written to greet them.
+  const rebuilding = session.op === "reset" || session.op === "switch";
+```
+
+Then replace the `title` and `body` derivation (lines 88-97) with:
+
+```tsx
+  const pending = session.state === "pending";
+  const title = rebuilding
+    ? strings.hosted.rebuildTitle
+    : pending
+      ? strings.hosted.bootPendingTitle
+      : strings.hosted.bootStartingTitle;
+  // The queue reads the same whatever is being queued for; the build does
+  // not. A multiple-choice seat has no cluster to build and is up in
+  // seconds, so the hands-on copy would be describing someone else's wait.
+  //
+  // A rebuild outranks both: it is the same work as a first build, but
+  // the sentence a candidate needs is what is happening to the attempt
+  // they just finished, not what a new environment contains.
+  const body = rebuilding
+    ? strings.hosted.rebuildBody(exam?.certification || exam?.title)
+    : pending
+      ? strings.hosted.bootPendingBody
+      : session.kind === "mcq"
+        ? strings.hosted.bootStartingBodyMcq
+        : strings.hosted.bootStartingBody(exam?.nodes, exam?.questionCount);
+```
+
+Then wrap the title in a heading role — it already is an `<h1>` — and replace
+the give-up button (lines 122-124) with:
+
+```tsx
+      <button type="button" className="btn" onClick={() => void giveUp()} disabled={busy}>
+        {rebuilding ? strings.hosted.rebuildGiveUp : strings.hosted.bootGiveUp}
+      </button>
+```
+
+- [ ] **Step 5: Run the suite**
+
+Run: `cd ui && npx tsc --noEmit && npm run lint && npm test`
+Expected: PASS, including Task 5's "no outage toast" test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui/src/screens/HostedBooting.tsx ui/src/strings.ts ui/src/screens/Hosted.test.tsx
+git commit -m "fix(ui): a rebuild is not a first boot and should not read as one
+
+A candidate who pressed New attempt was shown the screen that welcomes
+someone to a new environment, with a button offering to give up the seat
+they had just asked to keep using."
+```
+
+---
+
+## Task 7: Landing somewhere deliberate when the environment comes up
+
+**Files:**
+- Create: `ui/src/lib/useSeatLanding.ts`
+- Modify: `ui/src/App.tsx:93-96` (the `App` component's opening)
+- Test: `ui/src/screens/Hosted.test.tsx`
+
+**Interfaces:**
+- Consumes: `HostedState` from `./useHosted`; `navigate` from `./useHashRoute`.
+- Produces: `export function useSeatLanding(state: HostedState): void`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `ui/src/screens/Hosted.test.tsx`:
+
+```ts
+// A hosted seat is scoped to one exam — the Pod is stamped and sized for
+// it — so the picker at the end of a boot has one card on it and asks the
+// candidate to re-confirm what they chose in the lobby. After a rebuild
+// it reads as having been thrown out of the attempt they asked to repeat.
+test("an environment that comes up lands on its exam, not on the picker", async () => {
+  identity = me({
+    session: {
+      kind: "practical",
+      bank: "ckad-mock-01",
+      pod: "sim-session-practical-583231",
+      state: "starting",
+      op: "reset",
+      startedAt: new Date(now).toISOString(),
+      expiresAt: new Date(now + 3_600_000).toISOString(),
+      lastSeen: new Date(now).toISOString(),
+    },
+  });
+  render(<App />);
+  await screen.findByRole("heading", { name: strings.hosted.rebuildTitle });
+
+  identity = me({
+    session: {
+      kind: "practical",
+      bank: "ckad-mock-01",
+      pod: "sim-session-practical-583231",
+      state: "ready",
+      startedAt: new Date(now).toISOString(),
+      expiresAt: new Date(now + 3_600_000).toISOString(),
+      lastSeen: new Date(now).toISOString(),
+    },
+  });
+
+  await waitFor(() => {
+    expect(window.location.hash).toBe("#/exams/ckad-mock-01/mode");
+  });
+});
+
+// A tab that was already on a ready session is not mid-anything, and
+// yanking it to the mode screen would lose whatever the candidate was
+// reading.
+test("a page load into a ready seat is left where it is", async () => {
+  window.location.hash = "#/progress";
+  identity = me({
+    session: {
+      kind: "practical",
+      bank: "ckad-mock-01",
+      pod: "sim-session-practical-583231",
+      state: "ready",
+      startedAt: new Date(now).toISOString(),
+      expiresAt: new Date(now + 3_600_000).toISOString(),
+      lastSeen: new Date(now).toISOString(),
+    },
+  });
+  render(<App />);
+  await waitFor(() => expect(window.location.hash).toBe("#/progress"));
+});
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `cd ui && npm test -- src/screens/Hosted.test.tsx -t "lands on its exam"`
+Expected: FAIL — hash stays `#/` (or whatever the previous test left).
+
+- [ ] **Step 3: Write the hook**
+
+Create `ui/src/lib/useSeatLanding.ts`:
+
+```ts
+import { useEffect, useRef } from "react";
+import { navigate } from "./useHashRoute";
+import type { HostedState } from "./useHosted";
+
+/**
+ * Where a hosted candidate lands when their environment comes up.
+ *
+ * A hosted seat is scoped to one exam: the Pod is stamped and sized for
+ * it, and the selector inside the session offers no other. So the exam
+ * picker at the end of a boot is a screen with a single card on it,
+ * asking the candidate to re-confirm the choice they made in the lobby —
+ * and at the end of a rebuild it reads as having been thrown out of the
+ * attempt they asked to repeat.
+ *
+ * Two guards, and both matter:
+ *
+ *   - It fires only on a transition into ready that this tab WATCHED. A
+ *     page load that finds a session already ready is not mid-anything,
+ *     and moving it would take a candidate off whatever they had open.
+ *   - It yields to a route they are deliberately on. Progress and a past
+ *     attempt are about their record rather than their environment, and a
+ *     rebuild finishing behind them must not close what they are reading.
+ *
+ * Mode.tsx bounces to /exams when the facilitator's active exam is not
+ * the bank in the route, so a wrong guess here costs exactly the screen
+ * this replaces and nothing more.
+ */
+export function useSeatLanding(state: HostedState): void {
+  const seen = useRef(false);
+  const wasReady = useRef(false);
+
+  useEffect(() => {
+    const session = state.status === "hosted" ? state.me.session : undefined;
+    const ready = session?.state === "ready";
+    const bank = session?.bank;
+
+    // The first observation establishes a baseline and never navigates.
+    if (!seen.current) {
+      seen.current = true;
+      wasReady.current = ready;
+      return;
+    }
+    const arrived = ready && !wasReady.current;
+    wasReady.current = ready;
+    if (!arrived || !bank) return;
+
+    const here = window.location.hash.replace(/^#\/?/, "").split("/")[0];
+    if (here === "progress" || here === "history" || here === "exams") return;
+    navigate(`/exams/${bank}/mode`, { replace: true });
+  }, [state]);
+}
+```
+
+- [ ] **Step 4: Call it**
+
+In `ui/src/App.tsx`, add the import:
+
+```tsx
+import { useSeatLanding } from "./lib/useSeatLanding";
+```
+
+and call it inside `App`, immediately after `const route = useRoute();` (line 95):
+
+```tsx
+  // Before the gate below, not inside a branch: hooks may not be
+  // conditional, and this one has to keep watching across every state the
+  // gate switches between.
+  useSeatLanding(state);
+```
+
+- [ ] **Step 5: Run the suite**
+
+Run: `cd ui && npx tsc --noEmit && npm run lint && npm test`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui/src/lib/useSeatLanding.ts ui/src/App.tsx ui/src/screens/Hosted.test.tsx
+git commit -m "feat(ui): a seat that comes up lands on its exam
+
+The picker at the end of a hosted boot holds one card, because the seat
+is the exam. After a rebuild it read as being thrown out of the attempt
+the candidate had just asked to repeat."
+```
+
+---
+
+## Task 8: The header owns the End-session confirmation
+
+**Files:**
+- Modify: `ui/src/components/SessionChip.tsx` (split into three exports)
+- Modify: `ui/src/components/AppHeader.tsx` (new `session` prop, owns the dialog)
+- Modify: `ui/src/App.tsx:169-175` and `App.tsx:653-681` (the two call sites)
+- Modify: `ui/src/a11y.test.tsx:841` (the `SessionChip` call site)
+- Test: `ui/src/components/AppHeader.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `SessionChip({ login, session }: { login: string; session?: HostedSession })` —
+    the clock only, no buttons, no dialog.
+  - `SessionActions({ session, onEnd }: { session?: HostedSession; onEnd: () => void })` —
+    the two buttons.
+  - `EndSessionDialog({ onClose, onChanged }: { onClose: () => void; onChanged: () => void })`.
+  - `AppHeaderProps.session?: { login: string; session?: HostedSession; onChanged: () => void }`.
+
+**Why:** Task 10 puts the session buttons inside a popover that unmounts when it
+closes. A confirmation dialog rendered by those buttons would be destroyed by the
+very click that opens it. The state has to live above both, and the header is the
+lowest component that contains both.
+
+There is no visual change in this task. The desktop header renders identically.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `ui/src/components/AppHeader.test.tsx`, inside the outer `describe`:
+
+```tsx
+  describe("session", () => {
+    const liveSession = {
+      kind: "practical" as const,
+      bank: "ckad-mock-01",
+      pod: "sim-session-practical-583231",
+      state: "ready" as const,
+      startedAt: "2026-08-05T09:00:00Z",
+      expiresAt: "2026-08-05T19:00:00Z",
+      lastSeen: "2026-08-05T09:00:00Z",
+    };
+
+    test("carries the login, the countdown and both ways out", () => {
+      renderHeader(
+        <AppHeader session={{ login: "octocat", session: liveSession, onChanged: () => {} }} />,
+      );
+      expect(screen.getByText("octocat")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: strings.hosted.endSession }),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: strings.hosted.signOut })).toBeInTheDocument();
+    });
+
+    // The dialog has to be a sibling of the controls that raise it, not a
+    // child. Task 10 puts those controls inside a popover that unmounts on
+    // close, and a dialog underneath them would go with it.
+    test("raises the confirmation from the header, not from the button", async () => {
+      const user = userEvent.setup();
+      renderHeader(
+        <AppHeader session={{ login: "octocat", session: liveSession, onChanged: () => {} }} />,
+      );
+      await user.click(screen.getByRole("button", { name: strings.hosted.endSession }));
+      const dialog = await screen.findByRole("dialog");
+      expect(dialog).toHaveTextContent(strings.hosted.endConfirmTitle);
+      expect(screen.getByRole("banner").contains(dialog)).toBe(false);
+    });
+
+    test("shows only sign-out when there is no environment", () => {
+      renderHeader(<AppHeader session={{ login: "octocat", onChanged: () => {} }} />);
+      expect(screen.getByRole("button", { name: strings.hosted.signOut })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: strings.hosted.endSession })).toBeNull();
+    });
+  });
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `cd ui && npm test -- src/components/AppHeader.test.tsx`
+Expected: FAIL — `AppHeader` has no `session` prop.
+
+- [ ] **Step 3: Split SessionChip**
+
+Replace the whole of `ui/src/components/SessionChip.tsx` with:
+
+```tsx
+import { useState } from "react";
+import { endHostedSession, logout, type HostedSession } from "../api";
+import { Dialog } from "./Dialog";
+import { formatClock } from "../lib/format";
+import { useTick } from "../lib/useTick";
+import { strings } from "../strings";
+
+/** Under this much lease left, the countdown starts insisting. */
+const SOON_SECONDS = 15 * 60;
+
+/**
+ * Who you are and how long you have.
+ *
+ * The countdown is the part that earns its place: a hosted session has a
+ * hard cap and is taken back at it whatever the candidate is doing, so
+ * the one thing they cannot be left to guess is how long that is. It is
+ * recomputed from the server's `expiresAt` on every tick rather than
+ * decremented, so a throttled background tab resyncs instead of drifting.
+ *
+ * Presentational, and deliberately so. The controls that used to sit
+ * beside it are SessionActions below, and the confirmation they raise is
+ * owned by the header — because on a narrow viewport those controls live
+ * inside a popover that unmounts when it closes, and a dialog rendered
+ * underneath them would be destroyed by the click that opened it.
+ */
+export function SessionChip({
+  login,
+  session,
+}: {
+  login: string;
+  session?: HostedSession;
+}) {
+  const expires = session ? Date.parse(session.expiresAt) : NaN;
+  const live = session !== undefined && !Number.isNaN(expires);
+  const now = useTick(live);
+  const secondsLeft = live ? Math.max(0, Math.round((expires - now) / 1000)) : 0;
+  const soon = live && secondsLeft <= SOON_SECONDS;
+
+  return (
+    <div className="session-chip">
+      <span className="session-chip-user">{login}</span>
+      {live && (
+        <span
+          className="session-chip-clock"
+          data-soon={soon || undefined}
+          // Announced only when it starts mattering. A clock in a live
+          // region that re-reads every second is unusable with a screen
+          // reader on, and for most of a ten-hour lease it is not news.
+          role={soon ? "status" : undefined}
+        >
+          {secondsLeft === 0
+            ? strings.hosted.chipExpired
+            : soon
+              ? strings.hosted.chipEndingSoon(formatClock(secondsLeft))
+              : strings.hosted.chipTimeLeft(formatClock(secondsLeft))}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// A full reload rather than a state update. Signing out invalidates a
+// cookie that every open fetch and the desktop's WebSocket are carrying,
+// and there is no partial version of that.
+async function signOut() {
+  await logout().catch(() => undefined);
+  window.location.assign("/");
+}
+
+/**
+ * The two ways out.
+ *
+ * `onEnd` raises the confirmation rather than performing anything: see
+ * SessionChip above for why the dialog cannot live here.
+ */
+export function SessionActions({
+  session,
+  onEnd,
+}: {
+  session?: HostedSession;
+  onEnd: () => void;
+}) {
+  return (
+    <>
+      {session && (
+        <button type="button" className="btn btn-quiet" onClick={onEnd}>
+          {strings.hosted.endSession}
+        </button>
+      )}
+      <button type="button" className="btn btn-quiet" onClick={() => void signOut()}>
+        {strings.hosted.signOut}
+      </button>
+    </>
+  );
+}
+
+/** The confirmation, and the call it makes if confirmed. */
+export function EndSessionDialog({
+  onClose,
+  onChanged,
+}: {
+  onClose: () => void;
+  onChanged: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const end = async () => {
+    setBusy(true);
+    setError(null);
+    const result = await endHostedSession();
+    setBusy(false);
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+    onClose();
+    onChanged();
+  };
+
+  return (
+    <Dialog title={strings.hosted.endConfirmTitle} onClose={onClose}>
+      <p>{strings.hosted.endConfirmBody}</p>
+      {error && <p className="error-text">{strings.hosted.endFailed(error)}</p>}
+      <div className="confirm-actions">
+        <button type="button" className="btn" onClick={onClose} disabled={busy}>
+          {strings.hosted.endCancel}
+        </button>
+        <button
+          type="button"
+          className="btn btn-danger"
+          onClick={() => void end()}
+          disabled={busy}
+        >
+          {strings.hosted.endConfirm}
+        </button>
+      </div>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 4: Give AppHeader the session prop**
+
+In `ui/src/components/AppHeader.tsx`:
+
+Add to the imports:
+
+```tsx
+import { useState } from "react";
+import type { HostedSession } from "../api";
+import { EndSessionDialog, SessionActions, SessionChip } from "./SessionChip";
+```
+
+Add to `AppHeaderProps`, before `children`:
+
+```tsx
+  /**
+   * Hosted only: the lease clock and the two ways out.
+   *
+   * A typed prop rather than more `children` because the header has to
+   * know which of the things it carries collapse into the menu on a
+   * narrow viewport and which stay in the bar — and because the
+   * confirmation the End control raises has to be rendered here, outside
+   * that menu, to survive it closing.
+   */
+  session?: { login: string; session?: HostedSession; onChanged: () => void };
+```
+
+Change the `children` doc comment to:
+
+```tsx
+  /**
+   * Ambient status that never collapses — today the backgrounded-rebuild
+   * chip, which must be visible on every screen it can reach or a 2-4
+   * minute teardown happens behind an idle-looking page.
+   */
+  children?: ReactNode;
+```
+
+Add `session` to the destructured params, and at the top of the function body:
+
+```tsx
+  // Owned here, not by the control that raises it. See SessionChip.
+  const [confirming, setConfirming] = useState(false);
+```
+
+Render the chip and actions in `.app-header-tail`, before `{children}`:
+
+```tsx
+      <div className="app-header-tail">
+        {session && (
+          <>
+            <SessionChip login={session.login} session={session.session} />
+            <SessionActions session={session.session} onEnd={() => setConfirming(true)} />
+          </>
+        )}
+        {children}
+```
+
+and render the dialog after the closing `</header>`, wrapping the whole return in
+a fragment:
+
+```tsx
+  return (
+    <>
+      <header className={`app-header app-header-${variant}`}>
+        …unchanged…
+      </header>
+      {confirming && session && (
+        <EndSessionDialog
+          onClose={() => setConfirming(false)}
+          onChanged={session.onChanged}
+        />
+      )}
+    </>
+  );
+```
+
+- [ ] **Step 5: Update the two call sites**
+
+In `ui/src/App.tsx`, replace lines 169-175 (`HostedHome`) with:
+
+```tsx
+      <AppHeader
+        {...headerProps}
+        session={{ login: me.user?.login ?? "", session: me.session, onChanged: refresh }}
+      />
+```
+
+and in `SimApp` replace the `{hosted && (<SessionChip … />)}` block (lines
+664-671) by moving it to a prop on the `AppHeader` opening tag:
+
+```tsx
+        <AppHeader
+          {...headerProps}
+          // Hosted only. It carries the lease countdown, which is the one
+          // thing about a hosted session a candidate cannot be left to
+          // guess: the seat is taken back at the cap whatever they are
+          // doing. Deliberately NOT rendered over a running exam — that
+          // screen has its own topbar with its own clock, and a second
+          // countdown beside it would be read as the exam's. One good
+          // consequence and one recorded cost: there is no way to destroy
+          // an environment mid-attempt by misclick, and a lease that
+          // expires mid-attempt gives no warning. See docs/follow-ups.md.
+          session={
+            hosted
+              ? {
+                  login: hosted.me.user?.login ?? "",
+                  session: hosted.me.session,
+                  onChanged: hosted.refresh,
+                }
+              : undefined
+          }
+        >
+```
+
+leaving the `{backgroundedJob && <BackgroundJobChip … />}` block as the only
+child. Remove the now-unused `SessionChip` import from `App.tsx`.
+
+- [ ] **Step 6: Update the a11y call site**
+
+In `ui/src/a11y.test.tsx`, the `SessionChip` render at line 841 passes
+`onChanged`. Drop that prop — the component no longer takes it — and leave
+`login` and `session` as they are.
+
+- [ ] **Step 7: Run everything**
+
+Run: `cd ui && npx tsc --noEmit && npm run lint && npm test`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add ui/src/components/SessionChip.tsx ui/src/components/AppHeader.tsx ui/src/App.tsx ui/src/a11y.test.tsx ui/src/components/AppHeader.test.tsx
+git commit -m "refactor(ui): the header owns the end-session confirmation
+
+The chip rendered its own dialog. On a narrow viewport its controls move
+into a popover that unmounts when it closes, and a dialog underneath them
+would be destroyed by the click that opened it. No visual change."
+```
+
+---
+
+## Task 9: The header menu
+
+**Files:**
+- Create: `ui/src/components/HeaderMenu.tsx`
+- Create: `ui/src/components/HeaderMenu.test.tsx`
+- Modify: `ui/src/components/Icon.tsx` (a `menu` glyph)
+- Modify: `ui/src/strings.ts` (the `header` block, after `navProgress` at line 33)
+- Modify: `ui/src/theme.css` (menu styles)
+
+**Interfaces:**
+- Consumes: `useFocusTrap` from `../lib/useFocusTrap`.
+- Produces: `HeaderMenu({ label, children }: { label: string; children: ReactNode })`.
+  Renders a button that toggles a popover containing `children`. Closes on
+  Escape, on click outside, and on any click inside the panel — the last so a nav
+  link or an action does not leave the menu hanging open behind the screen it
+  just changed.
+
+- [ ] **Step 1: Add the copy and the glyph**
+
+In `ui/src/strings.ts`, in the `header` block after `navProgress` (line 33):
+
+```ts
+    // The narrow-viewport menu. The button is icon-only, so this is the
+    // whole of its accessible name.
+    menuLabel: "Menu",
+    menuAccount: "Account",
+```
+
+In `ui/src/components/Icon.tsx`, add `| "menu"` to the `IconName` union after
+`"help"`, and add to `PATHS`:
+
+```tsx
+  menu: (
+    <>
+      <path d="M4 7h16" />
+      <path d="M4 12h16" />
+      <path d="M4 17h16" />
+    </>
+  ),
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `ui/src/components/HeaderMenu.test.tsx`:
+
+```tsx
+import { describe, expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HeaderMenu } from "./HeaderMenu";
+
+describe("HeaderMenu", () => {
+  test("starts closed and says so", () => {
+    render(
+      <HeaderMenu label="Menu">
+        <button type="button">Exams</button>
+      </HeaderMenu>,
+    );
+    const trigger = screen.getByRole("button", { name: "Menu" });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("button", { name: "Exams" })).toBeNull();
+  });
+
+  test("opens, and the trigger points at what it opened", async () => {
+    const user = userEvent.setup();
+    render(
+      <HeaderMenu label="Menu">
+        <button type="button">Exams</button>
+      </HeaderMenu>,
+    );
+    const trigger = screen.getByRole("button", { name: "Menu" });
+    await user.click(trigger);
+
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    const panel = screen.getByRole("group");
+    expect(trigger).toHaveAttribute("aria-controls", panel.id);
+    expect(screen.getByRole("button", { name: "Exams" })).toBeInTheDocument();
+  });
+
+  test("Escape closes it and hands focus back", async () => {
+    const user = userEvent.setup();
+    render(
+      <HeaderMenu label="Menu">
+        <button type="button">Exams</button>
+      </HeaderMenu>,
+    );
+    const trigger = screen.getByRole("button", { name: "Menu" });
+    await user.click(trigger);
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("button", { name: "Exams" })).toBeNull();
+    expect(trigger).toHaveFocus();
+  });
+
+  // A menu left open behind the screen its own link just changed is the
+  // classic mobile-nav bug.
+  test("choosing something closes it", async () => {
+    const user = userEvent.setup();
+    render(
+      <HeaderMenu label="Menu">
+        <button type="button">Exams</button>
+      </HeaderMenu>,
+    );
+    await user.click(screen.getByRole("button", { name: "Menu" }));
+    await user.click(screen.getByRole("button", { name: "Exams" }));
+    expect(screen.queryByRole("button", { name: "Exams" })).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 3: Run and watch it fail**
+
+Run: `cd ui && npm test -- src/components/HeaderMenu.test.tsx`
+Expected: FAIL — cannot resolve `./HeaderMenu`.
+
+- [ ] **Step 4: Write the component**
+
+Create `ui/src/components/HeaderMenu.tsx`:
+
+```tsx
+import { useCallback, useId, useRef, useState, type ReactNode } from "react";
+import { Icon } from "./Icon";
+import { useFocusTrap } from "../lib/useFocusTrap";
+
+/**
+ * The narrow-viewport home for everything in the header that is not
+ * time-critical: the nav links and the session controls.
+ *
+ * A popover rather than a full-screen sheet because of what is behind it.
+ * The bar keeps the lease countdown, and a takeover would hide the one
+ * number a hosted candidate cannot be left to guess while they are
+ * reading a menu.
+ *
+ * `role="group"` on the panel, not `role="menu"`. The ARIA menu pattern
+ * comes with a keyboard contract — arrow keys move between items, Tab
+ * leaves — that this does not implement and does not want: the contents
+ * are ordinary links and buttons, and Tab through them is the behaviour
+ * everyone already has.
+ */
+export function HeaderMenu({ label, children }: { label: string; children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const panelId = useId();
+  // Stable across renders: useFocusTrap holds it in a dependency array,
+  // and a fresh closure each render would re-run the effect — tearing
+  // down and re-adding the key handler, and re-stealing focus, on every
+  // parent render while the menu is open.
+  const close = useCallback(() => setOpen(false), []);
+
+  return (
+    <div className="header-menu">
+      <button
+        type="button"
+        className="header-menu-button"
+        aria-label={label}
+        aria-expanded={open}
+        aria-controls={open ? panelId : undefined}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <Icon name="menu" />
+      </button>
+      {open && (
+        <>
+          {/* Catches the click that dismisses. Not focusable and not in
+              the a11y tree: Escape is the keyboard way out, and this is
+              only for a pointer. */}
+          <div className="header-menu-scrim" aria-hidden="true" onClick={close} />
+          <div
+            ref={panelRef}
+            id={panelId}
+            role="group"
+            aria-label={label}
+            className="header-menu-panel"
+            // Any activation inside closes. The contents are links and
+            // one-shot actions, so there is nothing here a candidate
+            // presses twice — and a menu still open over the screen its
+            // own link just changed is the failure this avoids.
+            onClick={close}
+          >
+            <FocusTrap containerRef={panelRef} onClose={close} />
+            {children}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// useFocusTrap must run against a mounted container, and the panel only
+// exists while open. A child component keeps the hook unconditional — a
+// hook called inside `{open && …}` in the parent would be a conditional
+// hook — while still mounting and unmounting with the panel.
+function FocusTrap({
+  containerRef,
+  onClose,
+}: {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  onClose: () => void;
+}) {
+  useFocusTrap(containerRef, onClose);
+  return null;
+}
+```
+
+- [ ] **Step 5: Style it**
+
+Append to `ui/src/theme.css`, immediately before the final
+`@media (max-width: 40rem)` block (which Task 11 removes):
+
+```css
+/* ---- header menu ----
+   Everything in the header that is not time-critical, on a viewport too
+   narrow to hold it. See HeaderMenu.tsx for why this is a popover and not
+   a sheet. */
+
+.header-menu {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.header-menu-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  background: none;
+  border: 0;
+  border-radius: var(--radius-s);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.header-menu-button:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+/* Sits under the panel and over everything else, so a pointer anywhere
+   outside dismisses. */
+.header-menu-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-panel);
+}
+
+.header-menu-panel {
+  position: absolute;
+  top: calc(100% + var(--space-2));
+  right: 0;
+  z-index: var(--z-dialog);
+  min-width: 13rem;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-2);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-m);
+  box-shadow: var(--shadow-2);
+}
+
+/* Every child is a full-width row with a real target, whatever element
+   it happens to be — the panel takes nav links, session buttons and a
+   plain label. */
+.header-menu-panel > button,
+.header-menu-panel > .header-menu-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 44px;
+  padding: 0 var(--space-3);
+  background: none;
+  border: 0;
+  border-radius: var(--radius-s);
+  color: var(--text);
+  font: inherit;
+  font-size: var(--text-s);
+  text-align: left;
+  cursor: pointer;
+}
+
+.header-menu-panel > button:hover {
+  background: var(--surface-hover);
+}
+
+.header-menu-label {
+  padding: var(--space-2) var(--space-3) var(--space-1);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+}
+
+.header-menu-rule {
+  height: 1px;
+  margin: var(--space-1) 0;
+  background: var(--border);
+}
+```
+
+- [ ] **Step 6: Run everything**
+
+Run: `cd ui && npx tsc --noEmit && npm run lint && npm test`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ui/src/components/HeaderMenu.tsx ui/src/components/HeaderMenu.test.tsx ui/src/components/Icon.tsx ui/src/strings.ts ui/src/theme.css
+git commit -m "feat(ui): a header menu for the controls a phone cannot hold
+
+A popover, not a sheet: the bar keeps the lease countdown behind it, and
+that is the one number a hosted candidate cannot be left to guess."
+```
+
+---
+
+## Task 10: The header collapses
+
+**Files:**
+- Modify: `ui/src/lib/useMediaQuery.ts` (a new exported query)
+- Modify: `ui/src/components/AppHeader.tsx`
+- Test: `ui/src/components/AppHeader.test.tsx`
+
+**Interfaces:**
+- Consumes: `HeaderMenu` from Task 9; `AppHeaderProps.session` from Task 8.
+- Produces: `export const HEADER_COMPACT_QUERY = "(max-width: 48rem)"`.
+
+**What collapses:** the nav links, the login, End session, Sign out.
+**What stays in the bar:** brand mark, the countdown, About, the theme toggle,
+the menu button, and `children`. About and theme stay because both own overlay or
+mode state of their own — `InfoButton` renders `InfoDrawer` — and a popover that
+unmounts on close would take the drawer with it, which is the same trap Task 8
+exists to close for the confirmation dialog.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `ui/src/components/AppHeader.test.tsx`. Add these imports at the top of
+the file: `import { HEADER_COMPACT_QUERY } from "../lib/useMediaQuery";` and
+`import { matchMediaMock } from "../test/setup";`.
+
+```tsx
+  describe("compact", () => {
+    const liveSession = {
+      kind: "practical" as const,
+      bank: "ckad-mock-01",
+      pod: "sim-session-practical-583231",
+      state: "ready" as const,
+      startedAt: "2026-08-05T09:00:00Z",
+      expiresAt: "2026-08-05T19:00:00Z",
+      lastSeen: "2026-08-05T09:00:00Z",
+    };
+
+    beforeEach(() => matchMediaMock([HEADER_COMPACT_QUERY]));
+    afterEach(() => matchMediaMock([]));
+
+    test("puts the nav and the session controls behind one button", async () => {
+      const user = userEvent.setup();
+      renderHeader(
+        <AppHeader
+          nav={[{ label: "Exams", to: "/exams" }, { label: "Progress", to: "/progress" }]}
+          session={{ login: "octocat", session: liveSession, onChanged: () => {} }}
+        />,
+      );
+
+      expect(screen.queryByRole("button", { name: "Exams" })).toBeNull();
+      expect(screen.queryByRole("button", { name: strings.hosted.signOut })).toBeNull();
+
+      await user.click(screen.getByRole("button", { name: strings.header.menuLabel }));
+      expect(screen.getByRole("button", { name: "Exams" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Progress" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: strings.hosted.endSession })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: strings.hosted.signOut })).toBeInTheDocument();
+      expect(screen.getByText("octocat")).toBeInTheDocument();
+    });
+
+    // Every control has exactly one accessible name at any width. Rendering
+    // both copies and hiding one in CSS would give a screen reader two of
+    // each, which is worse than the overflow it would be fixing.
+    test("does not render a second copy of anything", async () => {
+      const user = userEvent.setup();
+      renderHeader(
+        <AppHeader
+          nav={[{ label: "Exams", to: "/exams" }]}
+          session={{ login: "octocat", session: liveSession, onChanged: () => {} }}
+        />,
+      );
+      await user.click(screen.getByRole("button", { name: strings.header.menuLabel }));
+      expect(screen.getAllByRole("button", { name: "Exams" })).toHaveLength(1);
+      expect(screen.getAllByRole("button", { name: strings.hosted.signOut })).toHaveLength(1);
+    });
+
+    // The lease is taken back at its cap whatever the candidate is doing.
+    // It must never be a tap away.
+    test("keeps the countdown, About and the theme control in the bar", () => {
+      renderHeader(
+        <AppHeader session={{ login: "octocat", session: liveSession, onChanged: () => {} }} />,
+      );
+      const bar = screen.getByRole("banner");
+      expect(bar).toHaveTextContent(/left|Ends in|Session over/);
+      expect(screen.getByRole("button", { name: strings.info.open })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /theme/i })).toBeInTheDocument();
+    });
+
+    // The dialog is raised from inside the popover and must outlive it.
+    test("the end-session confirmation survives the menu closing", async () => {
+      const user = userEvent.setup();
+      renderHeader(
+        <AppHeader session={{ login: "octocat", session: liveSession, onChanged: () => {} }} />,
+      );
+      await user.click(screen.getByRole("button", { name: strings.header.menuLabel }));
+      await user.click(screen.getByRole("button", { name: strings.hosted.endSession }));
+
+      const dialog = await screen.findByRole("dialog");
+      expect(dialog).toHaveTextContent(strings.hosted.endConfirmTitle);
+      // The menu itself is gone.
+      expect(screen.queryByRole("group", { name: strings.header.menuLabel })).toBeNull();
+    });
+  });
+```
+
+Add `beforeEach, afterEach` to the vitest import in that file if absent.
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `cd ui && npm test -- src/components/AppHeader.test.tsx -t "compact"`
+Expected: FAIL — `HEADER_COMPACT_QUERY` is not exported.
+
+- [ ] **Step 3: Add the query**
+
+Append to `ui/src/lib/useMediaQuery.ts`:
+
+```ts
+/**
+ * Too narrow for the header's full row.
+ *
+ * At its fullest that row is a wordmark, a rule, a crumb, a detail line,
+ * two nav links, a login, a lease countdown and four buttons. It starts
+ * colliding well above the 560px the old rule used, which only ever hid
+ * the crumb and let the rest overflow.
+ */
+export const HEADER_COMPACT_QUERY = "(max-width: 48rem)";
+```
+
+- [ ] **Step 4: Branch the header**
+
+In `ui/src/components/AppHeader.tsx`, add the imports:
+
+```tsx
+import { HeaderMenu } from "./HeaderMenu";
+import { HEADER_COMPACT_QUERY, useMediaQuery } from "../lib/useMediaQuery";
+```
+
+Add to the function body, beside `confirming`:
+
+```tsx
+  // Branched in JS rather than hidden in CSS, and that is the whole
+  // point: the controls MOVE. Rendering both copies and hiding one would
+  // give every button two accessible names, which is a worse bug than the
+  // overflow it fixes.
+  const compact = useMediaQuery(HEADER_COMPACT_QUERY);
+```
+
+Extract the nav links into a helper so both layouts render the same markup.
+Above the component:
+
+```tsx
+function NavLinks({ nav }: { nav: NavItem[] }) {
+  return (
+    <>
+      {nav.map((item) =>
+        item.current ? (
+          <span key={item.to} className="app-header-link app-header-link-on" aria-current="page">
+            {item.label}
+          </span>
+        ) : (
+          <button
+            key={item.to}
+            type="button"
+            className="app-header-link"
+            onClick={() => navigate(item.to)}
+          >
+            {item.label}
+          </button>
+        ),
+      )}
+    </>
+  );
+}
+```
+
+Replace the whole `.app-header-tail` block with:
+
+```tsx
+      <div className="app-header-tail">
+        {!compact && session && (
+          <>
+            <SessionChip login={session.login} session={session.session} />
+            <SessionActions session={session.session} onEnd={() => setConfirming(true)} />
+          </>
+        )}
+        {!compact && nav && nav.length > 0 && (
+          <nav className="app-header-nav" aria-label={strings.header.navLabel}>
+            <NavLinks nav={nav} />
+          </nav>
+        )}
+        {/* The countdown never collapses: a hosted seat is taken back at
+            its cap whatever the candidate is doing, so the number they
+            cannot guess must not be behind a tap. */}
+        {compact && session?.session && (
+          <SessionChip login="" session={session.session} />
+        )}
+        {children}
+        <InfoButton />
+        <ThemeToggle />
+        {compact && (nav?.length || session) && (
+          <HeaderMenu label={strings.header.menuLabel}>
+            {nav && nav.length > 0 && <NavLinks nav={nav} />}
+            {session && (
+              <>
+                <div className="header-menu-rule" />
+                <span className="header-menu-label">{strings.header.menuAccount}</span>
+                <span className="header-menu-item">{session.login}</span>
+                <SessionActions
+                  session={session.session}
+                  onEnd={() => setConfirming(true)}
+                />
+              </>
+            )}
+          </HeaderMenu>
+        )}
+      </div>
+```
+
+`SessionChip` renders `login` in a span; passing `""` in compact mode leaves an
+empty span, which the CSS in Task 11 hides. Add to `SessionChip`'s body, in place
+of the unconditional user span:
+
+```tsx
+      {login && <span className="session-chip-user">{login}</span>}
+```
+
+- [ ] **Step 5: Run everything**
+
+Run: `cd ui && npx tsc --noEmit && npm run lint && npm test`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui/src/components/AppHeader.tsx ui/src/lib/useMediaQuery.ts ui/src/components/SessionChip.tsx ui/src/components/AppHeader.test.tsx
+git commit -m "feat(ui): the header collapses instead of overflowing
+
+Below 48rem the nav links and the session controls move into the menu.
+They move rather than being hidden in CSS: two copies would give every
+control two accessible names."
+```
+
+---
+
+## Task 11: One breakpoint, and a desktop bar that is grouped
+
+**Files:**
+- Modify: `ui/src/theme.css:273-287` (the 560px block) and `theme.css:6433-6437`
+  (the stray 40rem block)
+- Modify: `ui/src/theme.css:231-271` (link and nav rules)
+- Test: `ui/src/styles/layout.test.ts` (unchanged, must still pass)
+
+**Interfaces:**
+- Consumes: the `48rem` value from Task 10's `HEADER_COMPACT_QUERY`. The two must
+  agree; a comment in each points at the other.
+- Produces: no exports.
+
+- [ ] **Step 1: Give the links a real target and a visible current state**
+
+In `ui/src/theme.css`, replace the block at lines 231-271 with:
+
+```css
+.app-header-back,
+.app-header-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  /* 44px, which is the floor for a pointer target. This was
+     `var(--space-1) 0` — about 24px tall and no wider than its word. */
+  min-height: 44px;
+  padding: 0 var(--space-3);
+  background: none;
+  border: 0;
+  border-radius: var(--radius-s);
+  font: inherit;
+  font-size: var(--text-s);
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.app-header-back {
+  color: var(--accent);
+  white-space: nowrap;
+}
+
+.app-header-back:hover {
+  color: var(--accent-strong);
+  background: var(--surface-hover);
+}
+
+/* Tight, because the links are now padded: the gap used to be doing the
+   separating that the targets do. */
+.app-header-nav {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.app-header-link {
+  color: var(--text-secondary);
+}
+
+.app-header-link:hover {
+  color: var(--text);
+  background: var(--surface-hover);
+}
+
+/* A rule under the word, not a hue change alone. aria-current is the
+   only thing that said "you are here", and a state carried by colour
+   alone is not a state to everyone. */
+.app-header-link-on {
+  color: var(--text);
+  box-shadow: inset 0 -2px 0 var(--accent);
+  cursor: default;
+}
+```
+
+- [ ] **Step 2: Group the desktop bar**
+
+Replace `.app-header-tail`'s rule (lines 168-171) with:
+
+```css
+/* Wider than the lead's gap on purpose: this cluster is three groups —
+   the session, the nav, the icon buttons — and at the lead's spacing they
+   read as one undifferentiated row of eight controls. */
+.app-header-tail {
+  gap: var(--space-4);
+  flex-shrink: 0;
+}
+```
+
+- [ ] **Step 3: Replace both breakpoints with one**
+
+Replace the block at lines 273-287 with:
+
+```css
+/* One breakpoint for the whole header, and it must stay in step with
+   HEADER_COMPACT_QUERY in lib/useMediaQuery.ts — that is what decides
+   which controls are in the DOM, and this only dresses what is left.
+   Under it the crumb goes first: the mark still says where you are, and
+   the nav has moved into the menu rather than being dropped.
+
+   This replaced two unrelated rules — a 560px block here and a 40rem
+   block for .session-chip-user at the bottom of the file — that between
+   them hid four things and let the other eight overflow. */
+@media (max-width: 48rem) {
+  .app-header {
+    /* Logical, so the notch inset lands on the physical side it belongs
+       to under an RTL locale as well. */
+    padding-inline: max(var(--space-3), env(safe-area-inset-inline-start))
+      max(var(--space-3), env(safe-area-inset-inline-end));
+    gap: var(--space-2);
+  }
+
+  .app-header-crumb,
+  .app-header-rule,
+  .app-header-detail,
+  .app-header-wordmark-tail {
+    display: none;
+  }
+
+  .app-header-tail {
+    gap: var(--space-1);
+  }
+}
+```
+
+- [ ] **Step 4: Delete the stray rule**
+
+Delete the final block of `ui/src/theme.css` (lines 6433-6437):
+
+```css
+@media (max-width: 40rem) {
+  .session-chip-user {
+    display: none;
+  }
+}
+```
+
+It is now dead: `AppHeader` passes no login to the compact chip at all.
+
+- [ ] **Step 5: Verify**
+
+Run: `cd ui && npx tsc --noEmit && npm run lint && npm test`
+Expected: PASS, including `src/styles/layout.test.ts` and
+`src/styles/contrast.test.ts`.
+
+Then confirm by eye that the header's height rule is untouched:
+
+Run: `cd ui && grep -A 3 "^\.app-header {" src/theme.css`
+Expected: the output still contains `height: 56px` and, below it,
+`flex-shrink: 0`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui/src/theme.css
+git commit -m "style(ui): one breakpoint for the header, and a bar with groups
+
+Two unrelated media queries hid four of twelve controls and let the rest
+overflow. The nav links were a 24px target with no current state a
+colour-blind reader could see."
+```
+
+---
+
+## Task 12: The a11y sweep, and the whole suite green
+
+**Files:**
+- Modify: `ui/src/a11y.test.tsx`
+- Test: everything
+
+**Interfaces:**
+- Consumes: every export from Tasks 8-11.
+- Produces: nothing.
+
+- [ ] **Step 1: Add the open menu and the rebuild screen to the sweep**
+
+In `ui/src/a11y.test.tsx`, add `import { HeaderMenu } from "./components/HeaderMenu";`
+and append two cases in the style of the file's existing ones:
+
+```tsx
+test("the header menu, open", async () => {
+  const user = userEvent.setup();
+  const { container } = render(
+    <HeaderMenu label="Menu">
+      <button type="button">Exams</button>
+      <button type="button">Progress</button>
+    </HeaderMenu>,
+  );
+  await user.click(screen.getByRole("button", { name: "Menu" }));
+  expect(await axe(container, AXE_OPTS)).toHaveNoViolations();
+});
+
+test("the boot screen, rebuilding", async () => {
+  const { container } = render(
+    <HostedBooting
+      session={{
+        kind: "practical",
+        bank: "ckad-mock-01",
+        pod: "sim-session-practical-583231",
+        state: "starting",
+        op: "reset",
+        startedAt: "2026-08-05T09:00:00Z",
+        expiresAt: "2026-08-05T19:00:00Z",
+        lastSeen: "2026-08-05T09:00:00Z",
+      }}
+      onChanged={() => {}}
+    />,
+  );
+  expect(await axe(container, AXE_OPTS)).toHaveNoViolations();
+});
+```
+
+- [ ] **Step 2: Run the full UI gate**
+
+Run: `cd ui && npx tsc --noEmit && npm run lint && npm test`
+Expected: PASS, with no violations reported.
+
+- [ ] **Step 3: Run the full Go gate**
+
+Run: `cd hub && go test ./... && go vet ./...`
+Expected: PASS.
+
+- [ ] **Step 4: Run the other three Go modules, which this plan did not touch**
+
+Run: `for m in conductor facilitator proxy; do (cd $m && go test ./... && go vet ./...) || echo "FAILED: $m"; done`
+Expected: no `FAILED:` line.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/a11y.test.tsx
+git commit -m "test(ui): the open menu and the rebuild screen join the a11y sweep"
+```
+
+---
+
+## Verification
+
+Before opening a pull request, confirm each of these by running the command and
+reading its output — not by assuming a green suite covers it.
+
+- [ ] `cd hub && go test ./... && go vet ./...` — passes.
+- [ ] `for m in conductor facilitator proxy; do (cd $m && go test ./... && go vet ./...); done` — passes.
+- [ ] `cd ui && npx tsc --noEmit && npm run lint && npm test` — passes.
+- [ ] `cd ui && grep -c "throw new Error(await readError(res))" src/api.ts` — prints `0`.
+- [ ] `grep -n "max-width: 560px\|max-width: 40rem" ui/src/theme.css` — prints nothing.
+- [ ] `grep -n "48rem" ui/src/theme.css ui/src/lib/useMediaQuery.ts` — prints one hit in each.
+- [ ] `cd ui && npm run build` — succeeds.
+
+**Manual browser pass**, which the automated gate structurally cannot cover
+(jsdom has no layout engine, so no test in this repo can see an overflow):
+
+- [ ] At 375px wide, the header fits on one line with no horizontal scroll, and
+      the lease countdown is readable without opening the menu.
+- [ ] The menu opens, Tab cycles inside it, Escape closes it and returns focus to
+      the button.
+- [ ] End session from inside the menu raises the confirmation, and the
+      confirmation is still there after the menu has closed.
+- [ ] At 1440px the header is unchanged from `main` apart from the grouping,
+      the larger link targets and the underline on the current section.
+- [ ] Both light and dark themes.

--- a/docs/history/specs/2026-08-05-hosted-rebuild-and-responsive-header-design.md
+++ b/docs/history/specs/2026-08-05-hosted-rebuild-and-responsive-header-design.md
@@ -1,0 +1,229 @@
+# A rebuild the app owns, and a header that fits a phone
+
+Date: 2026-08-05
+
+Two unrelated defects, shipped together because both live in the same
+four files of the SPA's chrome.
+
+## Part one — "New attempt" reports itself as a failure
+
+### The symptom
+
+A candidate finishes an attempt on a hosted seat, presses **New
+attempt** on the score screen, and gets a warning toast:
+
+> Cannot reach facilitator: Error: your exam environment is still starting
+
+They are then dropped on the exam picker with no explanation, having
+asked for another go at the exam they were already sitting.
+
+Nothing is broken. Every part of that sentence is true and none of it is
+news, because the app itself asked for the thing it is complaining
+about.
+
+### What actually happens
+
+On a hosted seat, `New attempt` is `POST /api/control/reset`, and the
+hub answers it with `Recycle` (`hub/internal/session/session.go:567`):
+the candidate's session Pod is **deleted and recreated**. Reset and
+switch are Pod replacement in a hosted deployment, not the in-place
+rebuild they are under `./sim up` — `hub/internal/api/api.go:143` says
+so, and it is the right design. It is simply invisible to the browser.
+
+While the Pod is gone, `runRecycle` clears the session's address
+(`session.go:632`), so the proxy has nowhere to send traffic and answers
+every `/api/*` request with a 503 (`hub/internal/api/proxy.go:104`):
+
+```json
+{"error": "your exam environment is still starting", "state": "pending"}
+```
+
+Four separate things then go wrong, and each one is a different bug:
+
+1. **The toast.** `SimApp`'s 10s session poller hits that 503,
+   `getSession` throws a plain `Error` carrying the prose, and
+   `handlePollError` (`ui/src/App.tsx:278`) pushes a warning toast. The
+   toast is correct code doing its job — it exists because the app's
+   most central fetch used to fail in silence — but it cannot tell an
+   expected wait from an outage, because nothing in the response says
+   which this is.
+
+2. **The overlay dies.** `applyControlResult` optimistically renders
+   `ControlProgress`, which is exactly the right screen for a rebuild.
+   Within ~2s `/api/me` reports `session.state: "pending"`, and
+   `App()` (`ui/src/App.tsx:119`) gates on `me.session?.state ===
+   "ready"` — so `SimApp` unmounts wholesale and takes the overlay with
+   it. The toast, pushed into a module-level store, outlives it.
+
+3. **The wrong story.** `HostedHome` renders `HostedBooting`, which is
+   written for a first boot: "we are building the cluster your chosen
+   exam asked for", with a *give up* button. The candidate has a seat
+   and did not ask to give it up.
+
+4. **The landing.** The recycled Pod is stamped with `BANK` at creation
+   (`images/k8s-env/start.sh:131`), so it boots straight into building
+   the seat's exam and comes up with a live cluster. But `SimApp`
+   remounts on a bare fragment, so `modeBankId` is null, `session.state`
+   is `idle`, and the switch falls through to the exam picker — one
+   card, the exam they were already sitting.
+
+### The fix
+
+**1. The hub says what kind of wait this is, in a field.**
+
+`proxy.go`'s 503 body gains `"code": "environment_starting"`; the
+`ErrorHandler`'s 502 gains `"code": "environment_unreachable"`. No
+behaviour change. It exists so a client can tell an expected wait from
+an outage without reading prose — prose that is a UI string in a Go file
+and will be reworded one day by someone who has no idea a client is
+parsing it.
+
+**2. `/api/me` reports the in-flight op.**
+
+The hub already knows: `Recycle` labels its job `reset` or `switch` in
+the session's own job store before returning. Surfacing that on the
+session object in `/api/me` costs one field and buys the boot screen the
+ability to tell a first boot from a rebuild.
+
+Deliberately *not* a second poller against `/api/control/status`:
+`useHosted` already polls `/api/me` every 2s while a session is not
+ready, and this is a fact about the session. It is also server truth, so
+it survives a reload mid-rebuild — which a remembered click would not.
+
+**3. The toast learns the difference.**
+
+`ui/src/api.ts` grows an `ApiError extends Error` carrying `status` and
+`code`. Twenty call sites throw through one `readError` helper today, so
+this is a single edit at the source, and `String(err)` on the result is
+unchanged — every existing call site and every string it feeds keeps
+working.
+
+`handlePollError` then skips the toast when either:
+
+- the error is an `ApiError` with `code === "environment_starting"`, or
+- a control job is in flight (`control.busy`).
+
+Both, not either alone. The first is the durable signal and covers a
+reload landing mid-rebuild. The second covers the window between the
+202 and `/api/me` flipping — and it covers the **local** product, where
+a reset restarts the facilitator in place and the poll fails for the
+same non-reason. `App.tsx:372` already carries a comment noting exactly
+that about the control poller; the session poller never got the same
+treatment.
+
+`pollError` state is still set either way, so the pre-first-session
+loading screen keeps its message.
+
+**4. `HostedBooting` gains a rebuild mode.**
+
+With `op` present it renders rebuild copy — "Rebuilding your
+environment", naming the certification — instead of first-boot copy. It
+keeps the elapsed counter and `PendingBar`, which are the parts that
+work: they tick identically whether or not the candidate accepts motion.
+"Give up" is reworded to say what it does, which is end the session and
+release the seat. It stays: a candidate whose rebuild has wedged needs a
+way out, and it is the only one on the screen.
+
+**5. The landing is chosen, not fallen into.**
+
+When a hosted session goes ready and carries a bank, `App()` navigates
+to `#/exams/<bank>/mode` rather than letting `SimApp` mount on a bare
+route.
+
+This applies to **first boots as well as rebuilds**. A hosted seat is
+bank-scoped — the Pod is stamped and sized for one exam, and the picker
+inside the session offers no other — so a picker with one card on it is
+a step that asks the candidate to re-confirm a decision they made in the
+lobby. Going straight to the mode screen is right in both cases.
+
+The safety net already exists: `Mode.tsx:372` bounces to `/exams` when
+the facilitator's active exam is not the bank in the route. So the worst
+case of a wrong guess here is exactly today's behaviour.
+
+### What this does not fix
+
+A hosted "new attempt" still costs a full Pod recycle plus a cluster
+build, because reset *is* Pod replacement in a hosted deployment. This
+spec makes those minutes legible; it does not make them shorter. Making
+the reset in-place would mean giving the session Pod's conductor a way
+to tear down and rebuild its own cluster, which is a different piece of
+work with its own security argument to make.
+
+## Part two — the header does not fit a phone
+
+### The symptom
+
+`AppHeader` + `SessionChip` is a single non-wrapping flex row carrying,
+at its fullest: brand mark and wordmark, a rule, a crumb, a detail line,
+the backgrounded-job chip, two nav links, the login name, the lease
+countdown, End session, Sign out, About, and the theme toggle.
+
+Its only responsive rule (`ui/src/theme.css:276`) hides the crumb, the
+rule and the detail under 560px. A second, unrelated rule at the very
+bottom of the file (`theme.css:6433`) hides the login name under 40rem.
+Everything else stays in the row and overflows.
+
+### The fix
+
+**Collapse into a menu below one breakpoint.**
+
+Driven by `useMediaQuery` (already in `lib/`), not by CSS `display:
+none`. The distinction matters: the controls have to *move* into the
+popover, and rendering both copies would give every button two
+accessible names — which breaks the a11y sweep and, more to the point,
+makes the header unusable with a screen reader.
+
+What collapses: the nav links, the login name, End session, Sign out,
+About, and the theme toggle.
+
+What stays in the bar: the brand mark, the lease countdown, the menu
+button, and `BackgroundJobChip` when a rebuild is running in the
+background. The countdown stays because a hosted session is taken back
+at its cap whatever the candidate is doing — that is the one number they
+cannot be left to guess, and it must never be a tap away. The job chip
+stays for the reason it was built: a 2-4 minute teardown behind an
+idle-looking page.
+
+**The menu** is a popover under its trigger with `aria-expanded` and
+`aria-controls`, Escape to close, focus returned to the trigger,
+click-outside to dismiss, and `useFocusTrap` while open — the pattern
+`InfoDrawer` already establishes. Three sections: navigation, account,
+then About and theme.
+
+One hazard to design around: `SessionChip` renders its own End-session
+confirmation `Dialog`. Inside a popover that unmounts on close, that
+dialog would be destroyed by the very click that opens it. The confirm
+state is lifted and the dialog rendered outside the popover.
+
+**The desktop pass**, since it is the same component either way. Today
+the bar is eight ungrouped controls in a flat row, and the nav links
+have `padding: var(--space-1) 0` — roughly a 24px target, well under the
+44px minimum. So: group them (nav | rule | session | icons), give the
+links a real target and a hover and active treatment, and make
+`aria-current` visible as something other than a colour shift, since a
+state that differs only by hue is not a state to everyone.
+
+**Constraints to hold.** The 56px fixed height and `flex-shrink: 0` stay
+exactly as they are: `styles/layout.test.ts` asserts both, and the
+comment at `theme.css:145` records what happens without the second one —
+a header whose height depends on how long the page below it is. The
+popover is absolutely positioned and changes neither.
+
+The two ad-hoc breakpoints are replaced by one system at 48rem, and the
+horizontal padding picks up `env(safe-area-inset-*)` for notched phones.
+
+### Tests
+
+- `AppHeader.test.tsx`: collapsed mode — the menu opens, closes on
+  Escape, returns focus, and every collapsed control is reachable
+  through it. `matchMediaMock` already exists in `test/setup`.
+- `a11y.test.tsx`: the open menu joins the sweep.
+- `SessionChip`: the End-session confirmation still works from inside
+  the menu.
+- `styles/layout.test.ts`: unchanged, and must stay passing.
+
+## Scope
+
+Not touched: the exam's own topbar (`Exam.tsx`), which is a different
+component with a different job — a clock and a submit button — and is
+deliberately not a variant of this header.

--- a/docs/history/specs/2026-08-05-hosted-rebuild-and-responsive-header-design.md
+++ b/docs/history/specs/2026-08-05-hosted-rebuild-and-responsive-header-design.md
@@ -206,8 +206,9 @@ do with this change.
 **The menu** is a popover under its trigger with `aria-expanded` and
 `aria-controls`, Escape to close, focus returned to the trigger,
 click-outside to dismiss, and `useFocusTrap` while open — the pattern
-`InfoDrawer` already establishes. Three sections: navigation, account,
-then About and theme.
+`InfoDrawer` already establishes. Two sections: navigation, then
+account. About and the theme toggle are not among them — they stay in
+the bar, for the reason above.
 
 One hazard to design around: `SessionChip` renders its own End-session
 confirmation `Dialog`. Inside a popover that unmounts on close, that

--- a/docs/history/specs/2026-08-05-hosted-rebuild-and-responsive-header-design.md
+++ b/docs/history/specs/2026-08-05-hosted-rebuild-and-responsive-header-design.md
@@ -124,7 +124,17 @@ work: they tick identically whether or not the candidate accepts motion.
 release the seat. It stays: a candidate whose rebuild has wedged needs a
 way out, and it is the only one on the screen.
 
-**5. The landing is chosen, not fallen into.**
+**5. The rebuild's clock starts when the rebuild does.**
+
+`runRecycle` restamps `StartedAt` in its `start` phase, which is after the
+old Pod has been deleted and drained. The boot screen's elapsed counter is
+`now - StartedAt`, so for the whole of the first phase a rebuild would count
+from the session's original start — "4:21:07 so far", thirty seconds in. The
+restamp moves to `Recycle`, where the job is accepted. `ExpiresAt` stays
+where it is: it is the lease, and moving it is a different decision from
+fixing a displayed counter.
+
+**6. The landing is chosen, not fallen into.**
 
 When a hosted session goes ready and carries a bank, `App()` navigates
 to `#/exams/<bank>/mode` rather than letting `SimApp` mount on a bare
@@ -173,16 +183,25 @@ popover, and rendering both copies would give every button two
 accessible names — which breaks the a11y sweep and, more to the point,
 makes the header unusable with a screen reader.
 
-What collapses: the nav links, the login name, End session, Sign out,
-About, and the theme toggle.
+What collapses: the nav links, the login name, End session, Sign out.
 
-What stays in the bar: the brand mark, the lease countdown, the menu
-button, and `BackgroundJobChip` when a rebuild is running in the
-background. The countdown stays because a hosted session is taken back
-at its cap whatever the candidate is doing — that is the one number they
-cannot be left to guess, and it must never be a tap away. The job chip
-stays for the reason it was built: a 2-4 minute teardown behind an
-idle-looking page.
+What stays in the bar: the brand mark, the lease countdown, About, the
+theme toggle, the menu button, and `BackgroundJobChip` when a rebuild is
+running in the background. The countdown stays because a hosted session
+is taken back at its cap whatever the candidate is doing — that is the
+one number they cannot be left to guess, and it must never be a tap
+away. The job chip stays for the reason it was built: a 2-4 minute
+teardown behind an idle-looking page.
+
+About and the theme toggle stay for a reason found while planning rather
+than while writing this. `InfoButton` renders `InfoDrawer` itself, so
+inside a popover that unmounts on close the drawer would be destroyed by
+the click that opened it — precisely the hazard called out below for the
+End-session dialog. Moving them in would mean hoisting the drawer's state
+into the header as well, for two icon buttons that cost about 88px in a
+bar that has room for them. They stay, and the menu holds what the
+`AppHeader` can own without restructuring a component that has nothing to
+do with this change.
 
 **The menu** is a popover under its trigger with `aria-expanded` and
 `aria-controls`, Escape to close, focus returned to the trigger,

--- a/hub/internal/api/api.go
+++ b/hub/internal/api/api.go
@@ -401,3 +401,19 @@ func writeJSON(w http.ResponseWriter, status int, body any) {
 func writeError(w http.ResponseWriter, status int, msg string) {
 	writeJSON(w, status, map[string]string{"error": msg})
 }
+
+// Error codes on the proxy's own answers.
+//
+// The `error` field is a sentence for a person and stays that way. These
+// are for the SPA, which has to tell an expected wait from a fault and
+// must not do it by matching prose — the copy is a UI string living in a
+// Go file, and it will be reworded by someone with no idea a client is
+// parsing it.
+const (
+	codeEnvironmentStarting    = "environment_starting"
+	codeEnvironmentUnreachable = "environment_unreachable"
+)
+
+func writeErrorCode(w http.ResponseWriter, status int, code, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg, "code": code})
+}

--- a/hub/internal/api/proxy.go
+++ b/hub/internal/api/proxy.go
@@ -40,7 +40,8 @@ func (s *Server) newProxy() *httputil.ReverseProxy {
 		FlushInterval: -1,
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			s.logf("hub: proxy %s: %v", r.URL.Path, err)
-			writeError(w, http.StatusBadGateway, "your exam environment is not reachable right now")
+			writeErrorCode(w, http.StatusBadGateway, codeEnvironmentUnreachable,
+				"your exam environment is not reachable right now")
 		},
 		Transport: &http.Transport{
 			// No idle timeout on the desktop stream, but a bound on how
@@ -102,6 +103,7 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Retry-After", "5")
 		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
 			"error": "your exam environment is still starting",
+			"code":  codeEnvironmentStarting,
 			"state": live.State,
 		})
 		return

--- a/hub/internal/api/session_test.go
+++ b/hub/internal/api/session_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"io"
 	"net"
@@ -9,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -385,5 +387,104 @@ func TestEndingASessionFreesTheSeat(t *testing.T) {
 	}
 	if _, err := m.Get("583231"); err == nil {
 		t.Error("the session outlived the request to end it")
+	}
+}
+
+// stalledPods creates Pods that never become ready. That is exactly the
+// state the proxy's 503 branch exists for — a session admitted, holding a
+// seat, with nowhere to send traffic yet — and it is the state a hosted
+// "New attempt" spends its first minutes in, because a reset here is Pod
+// replacement.
+type stalledPods struct {
+	mu   sync.Mutex
+	live map[string]bool
+}
+
+func (p *stalledPods) Create(_ context.Context, spec []byte) error {
+	var pod struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(spec, &pod); err != nil {
+		return err
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.live == nil {
+		p.live = map[string]bool{}
+	}
+	if p.live[pod.Metadata.Name] {
+		return session.ErrPodExists
+	}
+	p.live[pod.Metadata.Name] = true
+	return nil
+}
+
+func (p *stalledPods) Get(_ context.Context, name string) (session.Pod, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.live[name] {
+		return session.Pod{}, session.ErrPodGone
+	}
+	return session.Pod{Name: name, IP: "10.42.0.9", Phase: "Running", Ready: false}, nil
+}
+
+func (p *stalledPods) Delete(_ context.Context, name string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.live[name] {
+		return session.ErrPodGone
+	}
+	delete(p.live, name)
+	return nil
+}
+
+func (p *stalledPods) List(context.Context, string) ([]session.Pod, error) {
+	return nil, nil
+}
+
+// The SPA has to tell an expected wait from an outage, and the sentence
+// in the body is copy — the next person to reword it would silently
+// break whatever was matching on it.
+func TestProxySaysWhetherAWaitIsAWaitOrAFault(t *testing.T) {
+	s, _ := newServer(t, auth.ModeGitHub)
+	s.Sessions = session.New(&stalledPods{}, session.Config{
+		Flavours: map[session.Kind]session.Flavour{
+			session.Practical: {Seats: 1, Template: session.Template(podTemplate)},
+		},
+		Logf: func(string, ...any) {},
+	})
+	s.DefaultKind = session.Practical
+
+	c := login(t, s, "583231", "octocat")
+	start := httptest.NewRequest(http.MethodPost, "/api/session/start", strings.NewReader("{}"))
+	start.AddCookie(c)
+	if w := do(s, start); w.Code != http.StatusAccepted {
+		t.Fatalf("start = %d, want 202", w.Code)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/api/session", nil)
+	r.AddCookie(c)
+	w := do(s, r)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", w.Code)
+	}
+	var body struct {
+		Error string `json:"error"`
+		Code  string `json:"code"`
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Code != "environment_starting" {
+		t.Errorf("code = %q, want environment_starting; body was %q", body.Code, body.Error)
+	}
+	if body.Error == "" {
+		t.Error("the sentence for a person went away — both are wanted, not one or the other")
+	}
+	if body.State == "" {
+		t.Error("state went away; the boot screen reads it")
 	}
 }

--- a/hub/internal/session/job.go
+++ b/hub/internal/session/job.go
@@ -183,6 +183,22 @@ func (s *jobStore) snapshot() Snapshot {
 	return Snapshot{Busy: s.current != nil, Job: s.current.copy(), Last: s.last.copy()}
 }
 
+// op reports the operation of the job in flight, or "" when there is
+// none. A narrower read than snapshot(): snapshot deep-copies both
+// current and last, phases slice and all, to hand a caller a Job it can
+// keep past the lock — which Status needs and Manager.Get does not.
+// handleProxy calls Get on every proxied request, so before this existed
+// every asset and every poll paid for two Job copies and two []Phase
+// allocations to learn one string.
+func (s *jobStore) op() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.current == nil {
+		return ""
+	}
+	return s.current.Op
+}
+
 func (s *jobStore) logLines() (string, []string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/hub/internal/session/session.go
+++ b/hub/internal/session/session.go
@@ -78,6 +78,17 @@ type Session struct {
 	LastSeen  time.Time `json:"lastSeen"`
 	Error     string    `json:"error,omitempty"`
 
+	// Op is the control operation running against this session right now
+	// — "reset" or "switch" — and empty when there is none.
+	//
+	// On the session rather than left to GET /api/control/status because
+	// of who asks and when. The SPA polls /api/me every 2s while a session
+	// is not ready, and this is the field that lets the screen shown
+	// during that wait tell a first boot from a rebuild the candidate
+	// asked for. It is server truth, so it survives a reload mid-rebuild,
+	// which a remembered click would not.
+	Op string `json:"op,omitempty"`
+
 	// addr is where the proxy sends traffic. Unexported: it is the
 	// candidate's own Pod, but publishing an in-cluster address in a JSON
 	// response is telling every user something about the infrastructure
@@ -493,12 +504,22 @@ func (m *Manager) setState(e *entry, st State, errText string) {
 // Get returns a user's session.
 func (m *Manager) Get(user string) (Session, error) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	e, ok := m.sessions[user]
 	if !ok {
+		m.mu.Unlock()
 		return Session{}, ErrNoSession
 	}
-	return e.Session, nil
+	out := e.Session
+	m.mu.Unlock()
+	// Deliberately read outside m.mu. The job store has a lock of its own
+	// and nothing that holds it ever reaches for m.mu, so nesting the two
+	// here would make this the first place in the package that could
+	// deadlock — for no gain, since `out` is already a copy.
+	if snap := e.jobs.snapshot(); snap.Busy && snap.Job != nil {
+		out.Op = snap.Job.Op
+		out.addr = ""
+	}
+	return out, nil
 }
 
 // Touch records that a user is still there. Called on every proxied

--- a/hub/internal/session/session.go
+++ b/hub/internal/session/session.go
@@ -611,6 +611,16 @@ func (m *Manager) Recycle(user, bank string) (Job, error) {
 		return Job{}, ErrBusy
 	}
 
+	// The clock the boot screen counts from. It used to be restamped in
+	// the start phase, i.e. after the old Pod had been deleted and
+	// drained, so the first stretch of every rebuild counted from the
+	// session's original start. ExpiresAt stays where it is: it is the
+	// lease, and extending it a few seconds earlier is a different
+	// decision from fixing a displayed counter.
+	m.mu.Lock()
+	e.StartedAt = m.now()
+	m.mu.Unlock()
+
 	go m.runRecycle(e, fl, bank)
 	return j, nil
 }
@@ -647,8 +657,11 @@ func (m *Manager) runRecycle(e *entry, fl Flavour, bank string) {
 		if bank != "" {
 			e.Bank = bank
 		}
+		// StartedAt is not touched here: Recycle stamped it when the job
+		// was accepted, which is when the wait the candidate is watching
+		// actually began.
 		now := m.now()
-		e.StartedAt, e.LastSeen = now, now
+		e.LastSeen = now
 		e.ExpiresAt = now.Add(m.cfg.MaxAge)
 		e.addr, e.State, e.Error = "", Pending, ""
 		m.mu.Unlock()

--- a/hub/internal/session/session.go
+++ b/hub/internal/session/session.go
@@ -515,8 +515,12 @@ func (m *Manager) Get(user string) (Session, error) {
 	// and nothing that holds it ever reaches for m.mu, so nesting the two
 	// here would make this the first place in the package that could
 	// deadlock — for no gain, since `out` is already a copy.
-	if snap := e.jobs.snapshot(); snap.Busy && snap.Job != nil {
-		out.Op = snap.Job.Op
+	//
+	// op(), not snapshot(): this runs on every proxied request by way of
+	// handleProxy, and snapshot deep-copies two Jobs and their []Phase
+	// slices to answer a question that only needs one string.
+	if op := e.jobs.op(); op != "" {
+		out.Op = op
 		out.addr = ""
 	}
 	return out, nil
@@ -606,6 +610,13 @@ func (m *Manager) Recycle(user, bank string) (Job, error) {
 		op = "switch"
 		phases[1].Label = "Start a session on the new exam"
 	}
+	// Beginning a job here is what makes Get stop reporting an address
+	// for this session until the job ends — Get clears it the moment
+	// jobs.op() reports one in flight, on the theory that a Pod being
+	// replaced has nowhere for the proxy to send traffic. That rule
+	// lives in Get, not here, so whoever adds a third job type to
+	// jobStore and reads this line rather than Get's needs to know that
+	// starting a job here has that side effect there.
 	j, ok := e.jobs.begin(op, bank, phases)
 	if !ok {
 		return Job{}, ErrBusy

--- a/hub/internal/session/session_test.go
+++ b/hub/internal/session/session_test.go
@@ -539,3 +539,44 @@ func TestUnknownKindIsRefused(t *testing.T) {
 		t.Errorf("err = %v, want ErrNoSuchKind for a flavour this deployment does not offer", err)
 	}
 }
+
+// A rebuild is a Pod replacement, and the screen shown while it runs has
+// to be able to say so. Without this the only signal is "not ready",
+// which is also exactly what a first boot looks like — so the candidate
+// who pressed "New attempt" got a screen welcoming them to a new
+// environment and offering to give their seat up.
+func TestGetReportsTheControlOpWhileARebuildRuns(t *testing.T) {
+	m, pods := newManager(t, 1, nil)
+	if _, err := m.Start(context.Background(), "583231", Practical, ""); err != nil {
+		t.Fatal(err)
+	}
+	waitReady(t, m, "583231")
+
+	if s, _ := m.Get("583231"); s.Op != "" {
+		t.Errorf("op = %q on a settled session, want empty", s.Op)
+	}
+
+	// Hold the replacement un-ready so the recycle stays in flight for the
+	// length of this test rather than racing it.
+	name := pods.created[0]
+	pods.mu.Lock()
+	pods.notReady[name] = true
+	pods.mu.Unlock()
+
+	if _, err := m.Recycle("583231", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		s, err := m.Get("583231")
+		if err == nil && s.Op == "reset" {
+			if s.Addr() != "" {
+				t.Errorf("addr = %q mid-rebuild, want empty", s.Addr())
+			}
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("Get never reported the reset in flight")
+}

--- a/hub/internal/session/session_test.go
+++ b/hub/internal/session/session_test.go
@@ -582,23 +582,25 @@ func TestGetReportsTheControlOpWhileARebuildRuns(t *testing.T) {
 }
 
 // The boot screen's elapsed counter is (now - StartedAt), and a rebuild
-// shows that screen. Restamping only once the old Pod has drained meant
+// shows that screen. Restamping only once the old Pod had drained meant
 // the first phase of every rebuild counted from the session's original
 // start — hours, on a long seat.
+//
+// No polling and no Pod fixture, deliberately: the property under test is
+// that the restamp happens before Recycle returns. Left in the goroutine
+// it would be a race against the caller, which is the bug itself, so a
+// test that waited for the goroutine would pass either way.
 func TestRecycleRestampsTheClockWhenItBeginsNotWhenThePodIsRecreated(t *testing.T) {
-	m, pods := newManager(t, 1, nil)
+	m, _ := newManager(t, 1, nil)
 	if _, err := m.Start(context.Background(), "583231", Practical, ""); err != nil {
 		t.Fatal(err)
 	}
 	waitReady(t, m, "583231")
 
-	before, _ := m.Get("583231")
-
-	// Never ready, so the recycle cannot reach its start phase and any
-	// restamping observed below is the one Recycle itself did.
-	pods.mu.Lock()
-	pods.notReady[pods.created[0]] = true
-	pods.mu.Unlock()
+	before, err := m.Get("583231")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if _, err := m.Recycle("583231", ""); err != nil {
 		t.Fatal(err)

--- a/hub/internal/session/session_test.go
+++ b/hub/internal/session/session_test.go
@@ -580,3 +580,35 @@ func TestGetReportsTheControlOpWhileARebuildRuns(t *testing.T) {
 	}
 	t.Fatal("Get never reported the reset in flight")
 }
+
+// The boot screen's elapsed counter is (now - StartedAt), and a rebuild
+// shows that screen. Restamping only once the old Pod has drained meant
+// the first phase of every rebuild counted from the session's original
+// start — hours, on a long seat.
+func TestRecycleRestampsTheClockWhenItBeginsNotWhenThePodIsRecreated(t *testing.T) {
+	m, pods := newManager(t, 1, nil)
+	if _, err := m.Start(context.Background(), "583231", Practical, ""); err != nil {
+		t.Fatal(err)
+	}
+	waitReady(t, m, "583231")
+
+	before, _ := m.Get("583231")
+
+	// Never ready, so the recycle cannot reach its start phase and any
+	// restamping observed below is the one Recycle itself did.
+	pods.mu.Lock()
+	pods.notReady[pods.created[0]] = true
+	pods.mu.Unlock()
+
+	if _, err := m.Recycle("583231", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	after, err := m.Get("583231")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !after.StartedAt.After(before.StartedAt) {
+		t.Errorf("startedAt = %v, want later than the original %v", after.StartedAt, before.StartedAt)
+	}
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -34,7 +34,6 @@ import { HostedBooting } from "./screens/HostedBooting";
 import { HostedSignIn } from "./screens/HostedSignIn";
 import { HostedStart } from "./screens/HostedStart";
 import { Review } from "./screens/Review";
-import { SessionChip } from "./components/SessionChip";
 import { useHosted } from "./lib/useHosted";
 import type { Me } from "./api";
 import { useRoute } from "./lib/useHashRoute";
@@ -173,13 +172,10 @@ function HostedHome({ hosted, route }: { hosted: Hosted; route: ReturnType<typeo
   return (
     <>
       <TopProgress />
-      <AppHeader {...headerProps}>
-        <SessionChip
-          login={me.user?.login ?? ""}
-          session={me.session}
-          onChanged={refresh}
-        />
-      </AppHeader>
+      <AppHeader
+        {...headerProps}
+        session={{ login: me.user?.login ?? "", session: me.session, onChanged: refresh }}
+      />
       <main>
         <ScreenTransition screenKey={reviewId ? `review:${reviewId}` : onProgress ? "progress" : "lobby"}>
           {screen}
@@ -674,24 +670,27 @@ function SimApp({ hosted }: { hosted?: Hosted } = {}) {
           button — and neither is the boot screen, which is a takeover with
           nothing to navigate to yet. */}
       {session && !booting && session.state !== "running" && (
-        <AppHeader {...headerProps}>
-          {/* Hosted only. It carries the lease countdown, which is the one
-              thing about a hosted session a candidate cannot be left to
-              guess: the seat is taken back at the cap whatever they are
-              doing. Deliberately NOT rendered over a running exam — that
-              screen has its own topbar with its own clock, and a second
-              countdown beside it would be read as the exam's. One good
-              consequence and one recorded cost: there is no way to
-              destroy an environment mid-attempt by misclick, and a lease
-              that expires mid-attempt gives no warning. See
-              docs/follow-ups.md. */}
-          {hosted && (
-            <SessionChip
-              login={hosted.me.user?.login ?? ""}
-              session={hosted.me.session}
-              onChanged={hosted.refresh}
-            />
-          )}
+        <AppHeader
+          {...headerProps}
+          // Hosted only. It carries the lease countdown, which is the one
+          // thing about a hosted session a candidate cannot be left to
+          // guess: the seat is taken back at the cap whatever they are
+          // doing. Deliberately NOT rendered over a running exam — that
+          // screen has its own topbar with its own clock, and a second
+          // countdown beside it would be read as the exam's. One good
+          // consequence and one recorded cost: there is no way to destroy
+          // an environment mid-attempt by misclick, and a lease that
+          // expires mid-attempt gives no warning. See docs/follow-ups.md.
+          session={
+            hosted
+              ? {
+                  login: hosted.me.user?.login ?? "",
+                  session: hosted.me.session,
+                  onChanged: hosted.refresh,
+                }
+              : undefined
+          }
+        >
           {/* A backgrounded rebuild used to run for 2-4 minutes with no
               indicator anywhere: the lobby behind it looked idle while the
               cluster it describes was being torn down. */}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -4,6 +4,7 @@ import {
   getControlStatus,
   getExam,
   getSession,
+  isEnvironmentStarting,
   pollSession,
   startControlReset,
   startControlSwitch,
@@ -278,6 +279,23 @@ function SimApp({ hosted }: { hosted?: Hosted } = {}) {
   const handlePollError = useCallback((err: unknown) => {
     setPollError(String(err));
     if (!seenSession.current) return;
+    // Two ways to know this is not a fault, and both are wanted.
+    //
+    // The hub answers every proxied request with 503 environment_starting
+    // while it replaces a session Pod, and a hosted "New attempt" IS a Pod
+    // replacement. That is the durable signal: it survives a reload
+    // landing mid-rebuild, where nothing in this tab remembers a click.
+    //
+    // A control job in flight covers the rest — the window between the
+    // 202 and /api/me reporting it, and the LOCAL product, where a reset
+    // restarts the facilitator in place and the poll fails for exactly
+    // the same non-reason. The overlay is already narrating it; a warning
+    // toast over the top says the thing the candidate asked for has gone
+    // wrong.
+    //
+    // pollError is set above either way, so the pre-first-session loading
+    // screen keeps its message.
+    if (isEnvironmentStarting(err) || wasBusy.current) return;
     pollToastId.current = toastStore.push({
       kind: "warning",
       message: strings.app.cannotReach(String(err)),

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -38,6 +38,7 @@ import { SessionChip } from "./components/SessionChip";
 import { useHosted } from "./lib/useHosted";
 import type { Me } from "./api";
 import { useRoute } from "./lib/useHashRoute";
+import { useSeatLanding } from "./lib/useSeatLanding";
 import { strings } from "./strings";
 
 // Control-status poll cadence: fast while a job is running (the overlay
@@ -94,6 +95,11 @@ export interface Hosted {
 export default function App() {
   const { state, refresh } = useHosted();
   const route = useRoute();
+
+  // Before the gate below, not inside a branch: hooks may not be
+  // conditional, and this one has to keep watching across every state the
+  // gate switches between.
+  useSeatLanding(state);
 
   if (state.status === "unknown") {
     return (

--- a/ui/src/a11y.test.tsx
+++ b/ui/src/a11y.test.tsx
@@ -632,35 +632,44 @@ describe("axe: no WCAG violations", () => {
   // empty or closed panel and pass for the wrong reason.
   test("app header, compact, with the menu open", async () => {
     matchMediaMock([HEADER_COMPACT_QUERY]);
-    const user = userEvent.setup();
-    const { container } = render(
-      <AppHeader
-        nav={[
-          { label: "Exams", to: "/exams" },
-          { label: "Progress", to: "/progress", current: true },
-        ]}
-        session={{
-          login: "octocat",
-          session: {
-            kind: "practical",
-            pod: "sim-session-practical-1",
-            state: "ready",
-            startedAt: "2026-08-05T09:00:00Z",
-            expiresAt: "2026-08-05T19:00:00Z",
-            lastSeen: "2026-08-05T09:00:00Z",
-          },
-          onChanged: () => {},
-        }}
-      />,
-    );
-    await user.click(screen.getByRole("button", { name: strings.header.menuLabel }));
-    expect(screen.getByRole("button", { name: "Exams" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: strings.hosted.endSession })).toBeInTheDocument();
-    expect(await axe(container, AXE_OPTS)).toHaveNoViolations();
-    // Reset so compact mode does not leak into every scan that follows
-    // this one in the file — matchMediaMock replaces window.matchMedia
-    // wholesale rather than scoping to this render.
-    matchMediaMock([]);
+    // `finally`, not a trailing statement: matchMediaMock replaces
+    // window.matchMedia wholesale rather than scoping to this render, so
+    // a leaked mock does not fail HERE — it fails somewhere else, in
+    // whichever later test happens to render something that reads
+    // matchMedia next, which looks like an unrelated regression with no
+    // clue pointing back at this test. `finally` is what makes the reset
+    // survive a thrown assertion (a failed toBeInTheDocument, or axe
+    // itself finding a violation), rather than only the case where every
+    // assertion above it happened to pass.
+    try {
+      const user = userEvent.setup();
+      const { container } = render(
+        <AppHeader
+          nav={[
+            { label: "Exams", to: "/exams" },
+            { label: "Progress", to: "/progress", current: true },
+          ]}
+          session={{
+            login: "octocat",
+            session: {
+              kind: "practical",
+              pod: "sim-session-practical-1",
+              state: "ready",
+              startedAt: "2026-08-05T09:00:00Z",
+              expiresAt: "2026-08-05T19:00:00Z",
+              lastSeen: "2026-08-05T09:00:00Z",
+            },
+            onChanged: () => {},
+          }}
+        />,
+      );
+      await user.click(screen.getByRole("button", { name: strings.header.menuLabel }));
+      expect(screen.getByRole("button", { name: "Exams" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: strings.hosted.endSession })).toBeInTheDocument();
+      expect(await axe(container, AXE_OPTS)).toHaveNoViolations();
+    } finally {
+      matchMediaMock([]);
+    }
   });
 
   test("modal dialog", async () => {

--- a/ui/src/a11y.test.tsx
+++ b/ui/src/a11y.test.tsx
@@ -27,11 +27,13 @@ import { McqAnswerReview } from "./components/McqAnswerReview";
 import { HostedBooting } from "./screens/HostedBooting";
 import { HostedSignIn } from "./screens/HostedSignIn";
 import { HostedStart } from "./screens/HostedStart";
-import { SessionChip } from "./components/SessionChip";
-import { SPLIT_QUERY } from "./lib/useMediaQuery";
+import { EndSessionDialog, SessionActions, SessionChip } from "./components/SessionChip";
+import { HeaderMenu } from "./components/HeaderMenu";
+import { HEADER_COMPACT_QUERY, SPLIT_QUERY } from "./lib/useMediaQuery";
 import { matchMediaMock } from "./test/setup";
 import { marksStore } from "./components/marksStore";
 import { toastStore } from "./components/toastStore";
+import { strings } from "./strings";
 import type { ControlJob, ExamQuestionInfo, SessionSnapshot } from "./api";
 
 // Component-level scans run outside App's <main>, so the page-level
@@ -608,6 +610,59 @@ describe("axe: no WCAG violations", () => {
     expect(await axe(container, AXE_OPTS)).toHaveNoViolations();
   });
 
+  test("the header menu, open", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <HeaderMenu label="Menu">
+        <button type="button">Exams</button>
+        <button type="button">Progress</button>
+      </HeaderMenu>,
+    );
+    await user.click(screen.getByRole("button", { name: "Menu" }));
+    expect(await axe(container, AXE_OPTS)).toHaveNoViolations();
+  });
+
+  // HeaderMenu on its own above is a stand-in — two placeholder buttons,
+  // no real controls. The surface a phone actually renders is AppHeader
+  // in its compact state: the nav links, the login and both ways out of
+  // a session all move into this panel there, and that composition was
+  // never scanned open. Assert the nav and session controls are actually
+  // on screen before sweeping — a mis-set matchMediaMock, or a menu that
+  // silently failed to open, would otherwise leave this scanning an
+  // empty or closed panel and pass for the wrong reason.
+  test("app header, compact, with the menu open", async () => {
+    matchMediaMock([HEADER_COMPACT_QUERY]);
+    const user = userEvent.setup();
+    const { container } = render(
+      <AppHeader
+        nav={[
+          { label: "Exams", to: "/exams" },
+          { label: "Progress", to: "/progress", current: true },
+        ]}
+        session={{
+          login: "octocat",
+          session: {
+            kind: "practical",
+            pod: "sim-session-practical-1",
+            state: "ready",
+            startedAt: "2026-08-05T09:00:00Z",
+            expiresAt: "2026-08-05T19:00:00Z",
+            lastSeen: "2026-08-05T09:00:00Z",
+          },
+          onChanged: () => {},
+        }}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: strings.header.menuLabel }));
+    expect(screen.getByRole("button", { name: "Exams" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: strings.hosted.endSession })).toBeInTheDocument();
+    expect(await axe(container, AXE_OPTS)).toHaveNoViolations();
+    // Reset so compact mode does not leak into every scan that follows
+    // this one in the file — matchMediaMock replaces window.matchMedia
+    // wholesale rather than scoping to this render.
+    matchMediaMock([]);
+  });
+
   test("modal dialog", async () => {
     const { container } = render(
       <Dialog title="End the exam?" onClose={() => {}}>
@@ -834,6 +889,30 @@ describe("axe: no WCAG violations", () => {
     expect(await axe(container, AXE_OPTS)).toHaveNoViolations();
   });
 
+  // The rebuild variant of the same screen: `op: "reset"` is what a
+  // hosted candidate sees for the 2-4 minutes their environment is torn
+  // down and rebuilt in place, and it renders different copy from a
+  // first boot (see the hub-side comments on why a rebuild must not read
+  // as an outage). Never scanned before this suite existed either.
+  test("the boot screen, rebuilding", async () => {
+    const { container } = render(
+      <HostedBooting
+        session={{
+          kind: "practical",
+          bank: "ckad-mock-01",
+          pod: "sim-session-practical-583231",
+          state: "starting",
+          op: "reset",
+          startedAt: "2026-08-05T09:00:00Z",
+          expiresAt: "2026-08-05T19:00:00Z",
+          lastSeen: "2026-08-05T09:00:00Z",
+        }}
+        onChanged={() => {}}
+      />,
+    );
+    expect(await axe(container, AXE_OPTS)).toHaveNoViolations();
+  });
+
   // The one hosted surface that lives inside the header, beside the
   // theme toggle and a backgrounded-job chip.
   test("session chip with a lease running out", async () => {
@@ -850,6 +929,43 @@ describe("axe: no WCAG violations", () => {
         }}
       />,
     );
+    expect(await axe(container, AXE_OPTS)).toHaveNoViolations();
+  });
+
+  // SessionChip above is presentational only (see its own file comment);
+  // the two ways out of a session live in SessionActions, and the
+  // confirmation they raise lives in EndSessionDialog. An earlier task
+  // split those out of what used to be one component, and this suite
+  // kept scanning only the chip — the controls and the dialog never had
+  // an axe pass of their own.
+  test("session actions with an active session", async () => {
+    // A session is set so both controls render: the always-present
+    // sign-out and the end-session button that exists only when there is
+    // an environment to end. The bare-session case would leave the
+    // second button unswept.
+    const { container } = render(
+      <SessionActions
+        session={{
+          kind: "practical",
+          pod: "sim-session-practical-1",
+          state: "ready",
+          startedAt: "2026-08-04T11:00:00Z",
+          expiresAt: "2026-08-04T21:00:00Z",
+          lastSeen: "2026-08-04T12:00:00Z",
+        }}
+        onEnd={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: strings.hosted.endSession })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: strings.hosted.signOut })).toBeInTheDocument();
+    expect(await axe(container, AXE_OPTS)).toHaveNoViolations();
+  });
+
+  test("end-session confirmation dialog", async () => {
+    const { container } = render(<EndSessionDialog onClose={() => {}} onChanged={() => {}} />);
+    // Confirms the dialog actually rendered its body rather than an
+    // empty modal shell, which axe would sweep and pass trivially.
+    expect(screen.getByRole("dialog")).toHaveTextContent(strings.hosted.endConfirmTitle);
     expect(await axe(container, AXE_OPTS)).toHaveNoViolations();
   });
 });

--- a/ui/src/a11y.test.tsx
+++ b/ui/src/a11y.test.tsx
@@ -287,6 +287,15 @@ describe("axe: no WCAG violations", () => {
     // navigates by fragment, and a fragment left behind would put every
     // Score render after it on the deep dive instead of the results body.
     window.location.hash = "";
+    // matchMediaMock replaces window.matchMedia wholesale rather than
+    // scoping to one render, so any test in this describe that calls it
+    // — the panel resizer's SPLIT_QUERY, the compact header's
+    // HEADER_COMPACT_QUERY — otherwise leaves every later test seeing
+    // whatever query list it set rather than the default "everything
+    // answers false". One reset here ends the class of problem outright:
+    // no test has to remember its own cleanup, and reordering the file
+    // cannot make one test's mock leak into another's.
+    matchMediaMock([]);
   });
 
   // The exam screen was the one surface this suite never scanned, which is
@@ -630,46 +639,38 @@ describe("axe: no WCAG violations", () => {
   // on screen before sweeping — a mis-set matchMediaMock, or a menu that
   // silently failed to open, would otherwise leave this scanning an
   // empty or closed panel and pass for the wrong reason.
+  //
+  // No try/finally around the matchMediaMock call here: the describe's
+  // own afterEach resets it unconditionally now, pass or fail, so a
+  // second reset here would only restate what that one already
+  // guarantees for every test in the file.
   test("app header, compact, with the menu open", async () => {
     matchMediaMock([HEADER_COMPACT_QUERY]);
-    // `finally`, not a trailing statement: matchMediaMock replaces
-    // window.matchMedia wholesale rather than scoping to this render, so
-    // a leaked mock does not fail HERE — it fails somewhere else, in
-    // whichever later test happens to render something that reads
-    // matchMedia next, which looks like an unrelated regression with no
-    // clue pointing back at this test. `finally` is what makes the reset
-    // survive a thrown assertion (a failed toBeInTheDocument, or axe
-    // itself finding a violation), rather than only the case where every
-    // assertion above it happened to pass.
-    try {
-      const user = userEvent.setup();
-      const { container } = render(
-        <AppHeader
-          nav={[
-            { label: "Exams", to: "/exams" },
-            { label: "Progress", to: "/progress", current: true },
-          ]}
-          session={{
-            login: "octocat",
-            session: {
-              kind: "practical",
-              pod: "sim-session-practical-1",
-              state: "ready",
-              startedAt: "2026-08-05T09:00:00Z",
-              expiresAt: "2026-08-05T19:00:00Z",
-              lastSeen: "2026-08-05T09:00:00Z",
-            },
-            onChanged: () => {},
-          }}
-        />,
-      );
-      await user.click(screen.getByRole("button", { name: strings.header.menuLabel }));
-      expect(screen.getByRole("button", { name: "Exams" })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: strings.hosted.endSession })).toBeInTheDocument();
-      expect(await axe(container, AXE_OPTS)).toHaveNoViolations();
-    } finally {
-      matchMediaMock([]);
-    }
+    const user = userEvent.setup();
+    const { container } = render(
+      <AppHeader
+        nav={[
+          { label: "Exams", to: "/exams" },
+          { label: "Progress", to: "/progress", current: true },
+        ]}
+        session={{
+          login: "octocat",
+          session: {
+            kind: "practical",
+            pod: "sim-session-practical-1",
+            state: "ready",
+            startedAt: "2026-08-05T09:00:00Z",
+            expiresAt: "2026-08-05T19:00:00Z",
+            lastSeen: "2026-08-05T09:00:00Z",
+          },
+          onChanged: () => {},
+        }}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: strings.header.menuLabel }));
+    expect(screen.getByRole("button", { name: "Exams" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: strings.hosted.endSession })).toBeInTheDocument();
+    expect(await axe(container, AXE_OPTS)).toHaveNoViolations();
   });
 
   test("modal dialog", async () => {

--- a/ui/src/a11y.test.tsx
+++ b/ui/src/a11y.test.tsx
@@ -848,7 +848,6 @@ describe("axe: no WCAG violations", () => {
           expiresAt: new Date(Date.now() + 5 * 60_000).toISOString(),
           lastSeen: "2026-08-04T12:00:00Z",
         }}
-        onChanged={() => {}}
       />,
     );
     expect(await axe(container, AXE_OPTS)).toHaveNoViolations();

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+import { ApiError, isEnvironmentStarting } from "./api";
+
+describe("ApiError", () => {
+  // Everything that renders one of these renders `${err}`, and the
+  // toast copy is asserted elsewhere by its full text. Setting `name`
+  // would silently reword every one of them.
+  test("stringifies exactly as a plain Error does", () => {
+    const err = new ApiError(503, "your exam environment is still starting", "environment_starting");
+    expect(String(err)).toBe("Error: your exam environment is still starting");
+  });
+
+  test("keeps the parts a caller branches on", () => {
+    const err = new ApiError(503, "still starting", "environment_starting");
+    expect(err.status).toBe(503);
+    expect(err.code).toBe("environment_starting");
+    expect(err instanceof Error).toBe(true);
+  });
+
+  test("recognises the hub's Pod-replacement wait and nothing else", () => {
+    expect(isEnvironmentStarting(new ApiError(503, "x", "environment_starting"))).toBe(true);
+    expect(isEnvironmentStarting(new ApiError(502, "x", "environment_unreachable"))).toBe(false);
+    expect(isEnvironmentStarting(new ApiError(500, "x"))).toBe(false);
+    expect(isEnvironmentStarting(new Error("your exam environment is still starting"))).toBe(false);
+  });
+});

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -400,6 +400,50 @@ export interface Results {
 
 interface ApiErrorBody {
   error: string;
+  code?: string;
+}
+
+/**
+ * An HTTP error from the API, with the machine-readable parts kept.
+ *
+ * `name` is deliberately left as "Error", so `String(err)` is unchanged
+ * and every call site that renders one reads exactly as it did. What is
+ * added is `code`: the hub answers a proxied request with 503
+ * `environment_starting` for the minutes it spends replacing a session
+ * Pod, and that is an expected wait rather than a fault — a distinction
+ * no amount of reading the sentence can make safely.
+ */
+export class ApiError extends Error {
+  readonly status: number;
+  readonly code?: string;
+
+  constructor(status: number, message: string, code?: string) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+/** The hub's answer while a session Pod is being replaced. */
+export const ENVIRONMENT_STARTING = "environment_starting";
+
+export function isEnvironmentStarting(err: unknown): boolean {
+  return err instanceof ApiError && err.code === ENVIRONMENT_STARTING;
+}
+
+/**
+ * The error a failed response should throw.
+ *
+ * readError stays beside it and is still used: the `{ ok: false, error }`
+ * call sites want the sentence and nothing else.
+ */
+async function apiError(res: Response): Promise<ApiError> {
+  try {
+    const body = (await res.json()) as ApiErrorBody;
+    return new ApiError(res.status, body.error || `HTTP ${res.status}`, body.code);
+  } catch {
+    return new ApiError(res.status, `HTTP ${res.status}`);
+  }
 }
 
 async function readError(res: Response): Promise<string> {
@@ -453,7 +497,7 @@ async function request(path: string, opts: RequestOptions = {}): Promise<Respons
 export async function getSession(signal?: AbortSignal): Promise<SessionSnapshot> {
   const res = await request("/api/session", { signal });
   if (!res.ok) {
-    throw new Error(await readError(res));
+    throw await apiError(res);
   }
   return (await res.json()) as SessionSnapshot;
 }
@@ -493,7 +537,7 @@ export interface BootStatus {
 export async function getBoot(signal?: AbortSignal): Promise<BootStatus> {
   const res = await request("/api/boot", { signal });
   if (!res.ok) {
-    throw new Error(await readError(res));
+    throw await apiError(res);
   }
   return (await res.json()) as BootStatus;
 }
@@ -501,7 +545,7 @@ export async function getBoot(signal?: AbortSignal): Promise<BootStatus> {
 export async function getExam(signal?: AbortSignal): Promise<ExamInfo> {
   const res = await request("/api/exam", { signal });
   if (!res.ok) {
-    throw new Error(await readError(res));
+    throw await apiError(res);
   }
   return (await res.json()) as ExamInfo;
 }
@@ -517,7 +561,7 @@ export async function getExam(signal?: AbortSignal): Promise<ExamInfo> {
 export async function getExamTips(signal?: AbortSignal): Promise<string> {
   const res = await request("/api/exam/tips", { signal });
   if (!res.ok) {
-    throw new Error(await readError(res));
+    throw await apiError(res);
   }
   return ((await res.json()) as { markdown: string }).markdown;
 }
@@ -525,7 +569,7 @@ export async function getExamTips(signal?: AbortSignal): Promise<string> {
 export async function getQuestion(id: string, signal?: AbortSignal): Promise<QuestionDetail> {
   const res = await request(`/api/questions/${encodeURIComponent(id)}`, { signal });
   if (!res.ok) {
-    throw new Error(await readError(res));
+    throw await apiError(res);
   }
   return (await res.json()) as QuestionDetail;
 }
@@ -544,7 +588,7 @@ export async function getSolution(id: string, signal?: AbortSignal): Promise<Sol
     return { ok: false, error: await readError(res) };
   }
   if (!res.ok) {
-    throw new Error(await readError(res));
+    throw await apiError(res);
   }
   return { ok: true, solution: (await res.json()) as SolutionDetail };
 }
@@ -610,7 +654,7 @@ export async function startSession(
     return { ok: false, error: await readError(res) };
   }
   if (!res.ok) {
-    throw new Error(await readError(res));
+    throw await apiError(res);
   }
   // Branched on the STATUS, not on the body's shape. 202 also passes
   // `res.ok`, and its body is a preparation rather than a session — read
@@ -675,7 +719,7 @@ export async function putFocus(
     return { ok: false, error: await readError(res) };
   }
   if (!res.ok) {
-    throw new Error(await readError(res));
+    throw await apiError(res);
   }
   return { ok: true };
 }
@@ -688,7 +732,7 @@ export async function endSession(signal?: AbortSignal): Promise<SessionActionRes
     return { ok: false, error: await readError(res) };
   }
   if (!res.ok) {
-    throw new Error(await readError(res));
+    throw await apiError(res);
   }
   return { ok: true, session: (await res.json()) as SessionSnapshot };
 }
@@ -713,7 +757,7 @@ export async function getResults(signal?: AbortSignal): Promise<ResultsResponse>
     return { status: "error", message: await readError(res) };
   }
   if (!res.ok) {
-    throw new Error(await readError(res));
+    throw await apiError(res);
   }
   return { status: "ready", results: (await res.json()) as Results };
 }
@@ -783,7 +827,7 @@ export async function putAnswer(
     return { ok: false, error: await readError(res) };
   }
   if (!res.ok) {
-    throw new Error(await readError(res));
+    throw await apiError(res);
   }
   const body = (await res.json()) as { id: string; selected: number[] };
   return { ok: true, ...body };
@@ -797,7 +841,7 @@ export async function putAnswer(
 export async function getAnswers(signal?: AbortSignal): Promise<Record<string, number[]>> {
   const res = await request("/api/answers", { signal });
   if (!res.ok) {
-    throw new Error(await readError(res));
+    throw await apiError(res);
   }
   const body = (await res.json()) as { answers: Record<string, number[]> };
   return body.answers ?? {};
@@ -852,7 +896,7 @@ export interface ControlStatus {
 export async function getControlStatus(signal?: AbortSignal): Promise<ControlStatus> {
   const res = await request("/api/control/status", { signal });
   if (!res.ok) {
-    throw new Error(await readError(res));
+    throw await apiError(res);
   }
   return (await res.json()) as ControlStatus;
 }
@@ -867,7 +911,7 @@ export interface ControlLog {
 export async function getControlLog(signal?: AbortSignal): Promise<ControlLog> {
   const res = await request("/api/control/log", { signal });
   if (!res.ok) {
-    throw new Error(await readError(res));
+    throw await apiError(res);
   }
   const body = (await res.json()) as Partial<ControlLog>;
   // `lines ?? []`, the same guard getAnswers uses: a 200 whose body is
@@ -989,7 +1033,7 @@ export async function getHint(
     return { ok: false, error: await readError(res) };
   }
   if (!res.ok) {
-    throw new Error(await readError(res));
+    throw await apiError(res);
   }
   return { ok: true, hint: (await res.json()) as HintDetail };
 }
@@ -1159,7 +1203,7 @@ export interface CatalogResponse {
 export async function getCatalog(signal?: AbortSignal): Promise<CatalogResponse> {
   const res = await request("/api/catalog", { signal });
   if (!res.ok) {
-    throw new Error(await readError(res));
+    throw await apiError(res);
   }
   return (await res.json()) as CatalogResponse;
 }
@@ -1173,7 +1217,7 @@ export interface HistoryResponse {
 export async function getHistory(signal?: AbortSignal): Promise<HistoryResponse> {
   const res = await request("/api/history", { signal });
   if (!res.ok) {
-    throw new Error(await readError(res));
+    throw await apiError(res);
   }
   return (await res.json()) as HistoryResponse;
 }
@@ -1258,6 +1302,13 @@ export interface HostedSession {
   expiresAt: string;
   lastSeen: string;
   error?: string;
+  /**
+   * The control operation running against this session right now. Set by
+   * the hub while it replaces the Pod, which is what a hosted reset or
+   * exam switch is. Absent means nothing is running — including on a
+   * first boot, which is the distinction this exists to draw.
+   */
+  op?: "reset" | "switch";
 }
 
 /** How many of one flavour's seats are taken. */
@@ -1305,7 +1356,7 @@ export async function getMe(signal?: AbortSignal): Promise<Me | null> {
   const res = await request("/api/me", { signal });
   if (res.status === 404) return null;
   if (!res.ok) {
-    throw new Error(await readError(res));
+    throw await apiError(res);
   }
   const body = (await res.json()) as Partial<Me>;
   if (typeof body.authMode !== "string") return null;
@@ -1341,7 +1392,7 @@ export interface HostedExam extends BankEntry {
 
 export async function getHostedExams(signal?: AbortSignal): Promise<HostedExam[]> {
   const res = await request("/hub/exams", { signal });
-  if (!res.ok) throw new Error(await readError(res));
+  if (!res.ok) throw await apiError(res);
   const body = (await res.json()) as { exams?: HostedExam[] };
   return body.exams ?? [];
 }
@@ -1453,7 +1504,7 @@ export async function getAttemptResults(
 ): Promise<Results> {
   const res = await request(`/api/history/${encodeURIComponent(attempt)}`, { signal });
   if (!res.ok) {
-    throw new Error(await readError(res));
+    throw await apiError(res);
   }
   return (await res.json()) as Results;
 }

--- a/ui/src/components/AppHeader.test.tsx
+++ b/ui/src/components/AppHeader.test.tsx
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { AppHeader } from "./AppHeader";
+import { HEADER_COMPACT_QUERY } from "../lib/useMediaQuery";
+import { matchMediaMock } from "../test/setup";
 import { strings } from "../strings";
 
 const renderHeader = render;
@@ -141,6 +143,84 @@ describe("AppHeader", () => {
       renderHeader(<AppHeader session={{ login: "octocat", onChanged: () => {} }} />);
       expect(screen.getByRole("button", { name: strings.hosted.signOut })).toBeInTheDocument();
       expect(screen.queryByRole("button", { name: strings.hosted.endSession })).toBeNull();
+    });
+  });
+
+  describe("compact", () => {
+    const liveSession = {
+      kind: "practical" as const,
+      bank: "ckad-mock-01",
+      pod: "sim-session-practical-583231",
+      state: "ready" as const,
+      startedAt: "2026-08-05T09:00:00Z",
+      expiresAt: "2026-08-05T19:00:00Z",
+      lastSeen: "2026-08-05T09:00:00Z",
+    };
+
+    beforeEach(() => matchMediaMock([HEADER_COMPACT_QUERY]));
+    afterEach(() => matchMediaMock([]));
+
+    test("puts the nav and the session controls behind one button", async () => {
+      const user = userEvent.setup();
+      renderHeader(
+        <AppHeader
+          nav={[{ label: "Exams", to: "/exams" }, { label: "Progress", to: "/progress" }]}
+          session={{ login: "octocat", session: liveSession, onChanged: () => {} }}
+        />,
+      );
+
+      expect(screen.queryByRole("button", { name: "Exams" })).toBeNull();
+      expect(screen.queryByRole("button", { name: strings.hosted.signOut })).toBeNull();
+
+      await user.click(screen.getByRole("button", { name: strings.header.menuLabel }));
+      expect(screen.getByRole("button", { name: "Exams" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Progress" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: strings.hosted.endSession })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: strings.hosted.signOut })).toBeInTheDocument();
+      expect(screen.getByText("octocat")).toBeInTheDocument();
+    });
+
+    // Every control has exactly one accessible name at any width. Rendering
+    // both copies and hiding one in CSS would give a screen reader two of
+    // each, which is worse than the overflow it would be fixing.
+    test("does not render a second copy of anything", async () => {
+      const user = userEvent.setup();
+      renderHeader(
+        <AppHeader
+          nav={[{ label: "Exams", to: "/exams" }]}
+          session={{ login: "octocat", session: liveSession, onChanged: () => {} }}
+        />,
+      );
+      await user.click(screen.getByRole("button", { name: strings.header.menuLabel }));
+      expect(screen.getAllByRole("button", { name: "Exams" })).toHaveLength(1);
+      expect(screen.getAllByRole("button", { name: strings.hosted.signOut })).toHaveLength(1);
+    });
+
+    // The lease is taken back at its cap whatever the candidate is doing.
+    // It must never be a tap away.
+    test("keeps the countdown, About and the theme control in the bar", () => {
+      renderHeader(
+        <AppHeader session={{ login: "octocat", session: liveSession, onChanged: () => {} }} />,
+      );
+      const bar = screen.getByRole("banner");
+      expect(bar).toHaveTextContent(/left|Ends in|Session over/);
+      expect(screen.getByRole("button", { name: strings.info.open })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /theme/i })).toBeInTheDocument();
+    });
+
+    // The dialog is raised from inside the popover and must outlive it.
+    test("the end-session confirmation survives the menu closing", async () => {
+      const user = userEvent.setup();
+      renderHeader(
+        <AppHeader session={{ login: "octocat", session: liveSession, onChanged: () => {} }} />,
+      );
+      await user.click(screen.getByRole("button", { name: strings.header.menuLabel }));
+      await user.click(screen.getByRole("button", { name: strings.hosted.endSession }));
+
+      const dialog = await screen.findByRole("dialog");
+      expect(dialog).toHaveTextContent(strings.hosted.endConfirmTitle);
+      // The menu itself is gone.
+      expect(screen.queryByRole("group", { name: strings.header.menuLabel })).toBeNull();
     });
   });
 });

--- a/ui/src/components/AppHeader.test.tsx
+++ b/ui/src/components/AppHeader.test.tsx
@@ -100,4 +100,47 @@ describe("AppHeader", () => {
     );
     expect(screen.getByText("rebuilding")).toBeInTheDocument();
   });
+
+  describe("session", () => {
+    const liveSession = {
+      kind: "practical" as const,
+      bank: "ckad-mock-01",
+      pod: "sim-session-practical-583231",
+      state: "ready" as const,
+      startedAt: "2026-08-05T09:00:00Z",
+      expiresAt: "2026-08-05T19:00:00Z",
+      lastSeen: "2026-08-05T09:00:00Z",
+    };
+
+    test("carries the login, the countdown and both ways out", () => {
+      renderHeader(
+        <AppHeader session={{ login: "octocat", session: liveSession, onChanged: () => {} }} />,
+      );
+      expect(screen.getByText("octocat")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: strings.hosted.endSession }),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: strings.hosted.signOut })).toBeInTheDocument();
+    });
+
+    // The dialog has to be a sibling of the controls that raise it, not a
+    // child. Task 10 puts those controls inside a popover that unmounts on
+    // close, and a dialog underneath them would go with it.
+    test("raises the confirmation from the header, not from the button", async () => {
+      const user = userEvent.setup();
+      renderHeader(
+        <AppHeader session={{ login: "octocat", session: liveSession, onChanged: () => {} }} />,
+      );
+      await user.click(screen.getByRole("button", { name: strings.hosted.endSession }));
+      const dialog = await screen.findByRole("dialog");
+      expect(dialog).toHaveTextContent(strings.hosted.endConfirmTitle);
+      expect(screen.getByRole("banner").contains(dialog)).toBe(false);
+    });
+
+    test("shows only sign-out when there is no environment", () => {
+      renderHeader(<AppHeader session={{ login: "octocat", onChanged: () => {} }} />);
+      expect(screen.getByRole("button", { name: strings.hosted.signOut })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: strings.hosted.endSession })).toBeNull();
+    });
+  });
 });

--- a/ui/src/components/AppHeader.test.tsx
+++ b/ui/src/components/AppHeader.test.tsx
@@ -103,6 +103,24 @@ describe("AppHeader", () => {
     expect(screen.getByText("rebuilding")).toBeInTheDocument();
   });
 
+  // .app-header-tail has no `order` property, so DOM order is what a
+  // candidate sees and tabs through. A backgrounded rebuild's chip has to
+  // stay beside the session controls, not slide past the nav links: a
+  // silent reorder here shipped once already because nothing pinned it.
+  test("keeps the caller's children ahead of the nav links", () => {
+    const { container } = renderHeader(
+      <AppHeader nav={[{ label: "Exams", to: "/exams" }]}>
+        <span>rebuilding</span>
+      </AppHeader>,
+    );
+    const tail = container.querySelector(".app-header-tail")!;
+    const kids = Array.from(tail.children);
+    const chipIndex = kids.findIndex((el) => el.textContent === "rebuilding");
+    const navIndex = kids.findIndex((el) => el.tagName === "NAV");
+    expect(chipIndex).toBeGreaterThanOrEqual(0);
+    expect(navIndex).toBeGreaterThan(chipIndex);
+  });
+
   describe("session", () => {
     const liveSession = {
       kind: "practical" as const,
@@ -194,6 +212,7 @@ describe("AppHeader", () => {
       await user.click(screen.getByRole("button", { name: strings.header.menuLabel }));
       expect(screen.getAllByRole("button", { name: "Exams" })).toHaveLength(1);
       expect(screen.getAllByRole("button", { name: strings.hosted.signOut })).toHaveLength(1);
+      expect(screen.getAllByRole("button", { name: strings.hosted.endSession })).toHaveLength(1);
     });
 
     // The lease is taken back at its cap whatever the candidate is doing.

--- a/ui/src/components/AppHeader.test.tsx
+++ b/ui/src/components/AppHeader.test.tsx
@@ -227,6 +227,27 @@ describe("AppHeader", () => {
       expect(screen.getByRole("button", { name: /theme/i })).toBeInTheDocument();
     });
 
+    // `./sim up` never passes a `session` prop at all — it is `undefined`,
+    // not an object whose own `.session` happens to be undefined — and
+    // that is the one shape none of the tests above exercise: every one
+    // of them passes a session. It matters here specifically because it
+    // is what drives the `(nav?.length || session) &&` gate deciding
+    // whether the menu renders at all.
+    test("the local product's shape still gets a menu, holding only the nav", async () => {
+      const user = userEvent.setup();
+      renderHeader(
+        <AppHeader
+          nav={[{ label: "Exams", to: "/exams" }, { label: "Progress", to: "/progress" }]}
+        />,
+      );
+      await user.click(screen.getByRole("button", { name: strings.header.menuLabel }));
+      expect(screen.getByRole("button", { name: "Exams" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Progress" })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: strings.hosted.signOut })).toBeNull();
+      expect(screen.queryByRole("button", { name: strings.hosted.endSession })).toBeNull();
+      expect(screen.queryByText(strings.header.menuAccount)).toBeNull();
+    });
+
     // The dialog is raised from inside the popover and must outlive it.
     test("the end-session confirmation survives the menu closing", async () => {
       const user = userEvent.setup();

--- a/ui/src/components/AppHeader.tsx
+++ b/ui/src/components/AppHeader.tsx
@@ -1,5 +1,8 @@
+import { useState } from "react";
 import type { ReactNode } from "react";
+import type { HostedSession } from "../api";
 import { BrandMark } from "./BrandMark";
+import { EndSessionDialog, SessionActions, SessionChip } from "./SessionChip";
 import { Icon } from "./Icon";
 import { InfoButton } from "./InfoButton";
 import { ThemeToggle } from "./ThemeToggle";
@@ -36,10 +39,19 @@ export interface AppHeaderProps {
   detail?: string;
   nav?: NavItem[];
   /**
-   * Anything that has to sit left of the theme toggle — today the
-   * backgrounded-rebuild chip, which must be visible on every screen it
-   * can reach or a 2-4 minute teardown happens behind an idle-looking
-   * page.
+   * Hosted only: the lease clock and the two ways out.
+   *
+   * A typed prop rather than more `children` because the header has to
+   * know which of the things it carries collapse into the menu on a
+   * narrow viewport and which stay in the bar — and because the
+   * confirmation the End control raises has to be rendered here, outside
+   * that menu, to survive it closing.
+   */
+  session?: { login: string; session?: HostedSession; onChanged: () => void };
+  /**
+   * Ambient status that never collapses — today the backgrounded-rebuild
+   * chip, which must be visible on every screen it can reach or a 2-4
+   * minute teardown happens behind an idle-looking page.
    */
   children?: ReactNode;
 }
@@ -60,67 +72,85 @@ export function AppHeader({
   crumb,
   detail,
   nav,
+  session,
   children,
 }: AppHeaderProps) {
+  // Owned here, not by the control that raises it. See SessionChip.
+  const [confirming, setConfirming] = useState(false);
+
   return (
-    <header className={`app-header app-header-${variant}`}>
-      <div className="app-header-lead">
-        {variant === "back" && back ? (
-          <button
-            type="button"
-            className="app-header-back"
-            onClick={() => navigate(back.to)}
-          >
-            {/* Icon, not a "←" literal: @fontsource declares a
-                unicode-range per face and U+2190 is outside both of this
-                app's, so the character would never reach the woff2 —
-                exactly the trap Icon.tsx exists to close. */}
-            <Icon name="chevron-left" /> {back.label}
-          </button>
-        ) : (
-          <a className="app-header-home" href="#/">
-            <BrandMark />
-            <span className="app-header-wordmark">
-              {strings.header.wordmark}
-              <span className="app-header-wordmark-tail">{strings.header.wordmarkTail}</span>
-            </span>
-          </a>
-        )}
+    <>
+      <header className={`app-header app-header-${variant}`}>
+        <div className="app-header-lead">
+          {variant === "back" && back ? (
+            <button
+              type="button"
+              className="app-header-back"
+              onClick={() => navigate(back.to)}
+            >
+              {/* Icon, not a "←" literal: @fontsource declares a
+                  unicode-range per face and U+2190 is outside both of this
+                  app's, so the character would never reach the woff2 —
+                  exactly the trap Icon.tsx exists to close. */}
+              <Icon name="chevron-left" /> {back.label}
+            </button>
+          ) : (
+            <a className="app-header-home" href="#/">
+              <BrandMark />
+              <span className="app-header-wordmark">
+                {strings.header.wordmark}
+                <span className="app-header-wordmark-tail">{strings.header.wordmarkTail}</span>
+              </span>
+            </a>
+          )}
 
-        {crumb && (
-          <>
-            <span className="app-header-rule" aria-hidden="true" />
-            <span className="app-header-crumb">{crumb}</span>
-          </>
-        )}
-        {detail && <span className="app-header-detail">{detail}</span>}
-      </div>
+          {crumb && (
+            <>
+              <span className="app-header-rule" aria-hidden="true" />
+              <span className="app-header-crumb">{crumb}</span>
+            </>
+          )}
+          {detail && <span className="app-header-detail">{detail}</span>}
+        </div>
 
-      <div className="app-header-tail">
-        {children}
-        {nav && nav.length > 0 && (
-          <nav className="app-header-nav" aria-label={strings.header.navLabel}>
-            {nav.map((item) =>
-              item.current ? (
-                <span key={item.to} className="app-header-link app-header-link-on" aria-current="page">
-                  {item.label}
-                </span>
-              ) : (
-                <button
-                  key={item.to}
-                  type="button"
-                  className="app-header-link"
-                  onClick={() => navigate(item.to)}
-                >
-                  {item.label}
-                </button>
-              ),
-            )}
-          </nav>
-        )}
-        <InfoButton />
-        <ThemeToggle />
-      </div>
-    </header>
+        <div className="app-header-tail">
+          {session && (
+            <>
+              <SessionChip login={session.login} session={session.session} />
+              <SessionActions session={session.session} onEnd={() => setConfirming(true)} />
+            </>
+          )}
+          {children}
+          {nav && nav.length > 0 && (
+            <nav className="app-header-nav" aria-label={strings.header.navLabel}>
+              {nav.map((item) =>
+                item.current ? (
+                  <span key={item.to} className="app-header-link app-header-link-on" aria-current="page">
+                    {item.label}
+                  </span>
+                ) : (
+                  <button
+                    key={item.to}
+                    type="button"
+                    className="app-header-link"
+                    onClick={() => navigate(item.to)}
+                  >
+                    {item.label}
+                  </button>
+                ),
+              )}
+            </nav>
+          )}
+          <InfoButton />
+          <ThemeToggle />
+        </div>
+      </header>
+      {confirming && session && (
+        <EndSessionDialog
+          onClose={() => setConfirming(false)}
+          onChanged={session.onChanged}
+        />
+      )}
+    </>
   );
 }

--- a/ui/src/components/AppHeader.tsx
+++ b/ui/src/components/AppHeader.tsx
@@ -166,7 +166,15 @@ export function AppHeader({
           <ThemeToggle />
           {compact && (nav?.length || session) && (
             <HeaderMenu label={strings.header.menuLabel}>
-              {nav && nav.length > 0 && <NavLinks nav={nav} />}
+              {/* Same landmark as the desktop nav, wrapped around the
+                  same links, for the same reason: without it a
+                  screen-reader user loses the navigation landmark on
+                  exactly the viewport where it is hardest to find. */}
+              {nav && nav.length > 0 && (
+                <nav className="header-menu-nav" aria-label={strings.header.navLabel}>
+                  <NavLinks nav={nav} />
+                </nav>
+              )}
               {session && (
                 <>
                   <div className="header-menu-rule" />

--- a/ui/src/components/AppHeader.tsx
+++ b/ui/src/components/AppHeader.tsx
@@ -150,6 +150,7 @@ export function AppHeader({
               <SessionActions session={session.session} onEnd={() => setConfirming(true)} />
             </div>
           )}
+          {children}
           {!compact && nav && nav.length > 0 && (
             <nav className="app-header-nav" aria-label={strings.header.navLabel}>
               <NavLinks nav={nav} />
@@ -161,7 +162,6 @@ export function AppHeader({
           {compact && session?.session && (
             <SessionChip login="" session={session.session} />
           )}
-          {children}
           <InfoButton />
           <ThemeToggle />
           {compact && (nav?.length || session) && (

--- a/ui/src/components/AppHeader.tsx
+++ b/ui/src/components/AppHeader.tsx
@@ -115,10 +115,10 @@ export function AppHeader({
 
         <div className="app-header-tail">
           {session && (
-            <>
+            <div className="session-cluster">
               <SessionChip login={session.login} session={session.session} />
               <SessionActions session={session.session} onEnd={() => setConfirming(true)} />
-            </>
+            </div>
           )}
           {children}
           {nav && nav.length > 0 && (

--- a/ui/src/components/AppHeader.tsx
+++ b/ui/src/components/AppHeader.tsx
@@ -3,10 +3,12 @@ import type { ReactNode } from "react";
 import type { HostedSession } from "../api";
 import { BrandMark } from "./BrandMark";
 import { EndSessionDialog, SessionActions, SessionChip } from "./SessionChip";
+import { HeaderMenu } from "./HeaderMenu";
 import { Icon } from "./Icon";
 import { InfoButton } from "./InfoButton";
 import { ThemeToggle } from "./ThemeToggle";
 import { navigate } from "../lib/useHashRoute";
+import { HEADER_COMPACT_QUERY, useMediaQuery } from "../lib/useMediaQuery";
 import { strings } from "../strings";
 
 /** One entry in the header's right-hand navigation. */
@@ -56,6 +58,29 @@ export interface AppHeaderProps {
   children?: ReactNode;
 }
 
+function NavLinks({ nav }: { nav: NavItem[] }) {
+  return (
+    <>
+      {nav.map((item) =>
+        item.current ? (
+          <span key={item.to} className="app-header-link app-header-link-on" aria-current="page">
+            {item.label}
+          </span>
+        ) : (
+          <button
+            key={item.to}
+            type="button"
+            className="app-header-link"
+            onClick={() => navigate(item.to)}
+          >
+            {item.label}
+          </button>
+        ),
+      )}
+    </>
+  );
+}
+
 /**
  * The chrome above every screen that is not the exam itself.
  *
@@ -77,6 +102,11 @@ export function AppHeader({
 }: AppHeaderProps) {
   // Owned here, not by the control that raises it. See SessionChip.
   const [confirming, setConfirming] = useState(false);
+  // Branched in JS rather than hidden in CSS, and that is the whole
+  // point: the controls MOVE. Rendering both copies and hiding one would
+  // give every button two accessible names, which is a worse bug than the
+  // overflow it fixes.
+  const compact = useMediaQuery(HEADER_COMPACT_QUERY);
 
   return (
     <>
@@ -114,35 +144,42 @@ export function AppHeader({
         </div>
 
         <div className="app-header-tail">
-          {session && (
+          {!compact && session && (
             <div className="session-cluster">
               <SessionChip login={session.login} session={session.session} />
               <SessionActions session={session.session} onEnd={() => setConfirming(true)} />
             </div>
           )}
-          {children}
-          {nav && nav.length > 0 && (
+          {!compact && nav && nav.length > 0 && (
             <nav className="app-header-nav" aria-label={strings.header.navLabel}>
-              {nav.map((item) =>
-                item.current ? (
-                  <span key={item.to} className="app-header-link app-header-link-on" aria-current="page">
-                    {item.label}
-                  </span>
-                ) : (
-                  <button
-                    key={item.to}
-                    type="button"
-                    className="app-header-link"
-                    onClick={() => navigate(item.to)}
-                  >
-                    {item.label}
-                  </button>
-                ),
-              )}
+              <NavLinks nav={nav} />
             </nav>
           )}
+          {/* The countdown never collapses: a hosted seat is taken back at
+              its cap whatever the candidate is doing, so the number they
+              cannot guess must not be behind a tap. */}
+          {compact && session?.session && (
+            <SessionChip login="" session={session.session} />
+          )}
+          {children}
           <InfoButton />
           <ThemeToggle />
+          {compact && (nav?.length || session) && (
+            <HeaderMenu label={strings.header.menuLabel}>
+              {nav && nav.length > 0 && <NavLinks nav={nav} />}
+              {session && (
+                <>
+                  <div className="header-menu-rule" />
+                  <span className="header-menu-label">{strings.header.menuAccount}</span>
+                  <span className="header-menu-item">{session.login}</span>
+                  <SessionActions
+                    session={session.session}
+                    onEnd={() => setConfirming(true)}
+                  />
+                </>
+              )}
+            </HeaderMenu>
+          )}
         </div>
       </header>
       {confirming && session && (

--- a/ui/src/components/HeaderMenu.test.tsx
+++ b/ui/src/components/HeaderMenu.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HeaderMenu } from "./HeaderMenu";
+
+describe("HeaderMenu", () => {
+  test("starts closed and says so", () => {
+    render(
+      <HeaderMenu label="Menu">
+        <button type="button">Exams</button>
+      </HeaderMenu>,
+    );
+    const trigger = screen.getByRole("button", { name: "Menu" });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("button", { name: "Exams" })).toBeNull();
+  });
+
+  test("opens, and the trigger points at what it opened", async () => {
+    const user = userEvent.setup();
+    render(
+      <HeaderMenu label="Menu">
+        <button type="button">Exams</button>
+      </HeaderMenu>,
+    );
+    const trigger = screen.getByRole("button", { name: "Menu" });
+    await user.click(trigger);
+
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    const panel = screen.getByRole("group");
+    expect(trigger).toHaveAttribute("aria-controls", panel.id);
+    expect(screen.getByRole("button", { name: "Exams" })).toBeInTheDocument();
+  });
+
+  test("Escape closes it and hands focus back", async () => {
+    const user = userEvent.setup();
+    render(
+      <HeaderMenu label="Menu">
+        <button type="button">Exams</button>
+      </HeaderMenu>,
+    );
+    const trigger = screen.getByRole("button", { name: "Menu" });
+    await user.click(trigger);
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("button", { name: "Exams" })).toBeNull();
+    expect(trigger).toHaveFocus();
+  });
+
+  // A menu left open behind the screen its own link just changed is the
+  // classic mobile-nav bug.
+  test("choosing something closes it", async () => {
+    const user = userEvent.setup();
+    render(
+      <HeaderMenu label="Menu">
+        <button type="button">Exams</button>
+      </HeaderMenu>,
+    );
+    await user.click(screen.getByRole("button", { name: "Menu" }));
+    await user.click(screen.getByRole("button", { name: "Exams" }));
+    expect(screen.queryByRole("button", { name: "Exams" })).toBeNull();
+  });
+});

--- a/ui/src/components/HeaderMenu.tsx
+++ b/ui/src/components/HeaderMenu.tsx
@@ -1,0 +1,82 @@
+import { useCallback, useId, useRef, useState, type ReactNode } from "react";
+import { Icon } from "./Icon";
+import { useFocusTrap } from "../lib/useFocusTrap";
+
+/**
+ * The narrow-viewport home for everything in the header that is not
+ * time-critical: the nav links and the session controls.
+ *
+ * A popover rather than a full-screen sheet because of what is behind it.
+ * The bar keeps the lease countdown, and a takeover would hide the one
+ * number a hosted candidate cannot be left to guess while they are
+ * reading a menu.
+ *
+ * `role="group"` on the panel, not `role="menu"`. The ARIA menu pattern
+ * comes with a keyboard contract — arrow keys move between items, Tab
+ * leaves — that this does not implement and does not want: the contents
+ * are ordinary links and buttons, and Tab through them is the behaviour
+ * everyone already has.
+ */
+export function HeaderMenu({ label, children }: { label: string; children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const panelId = useId();
+  // Stable across renders: useFocusTrap holds it in a dependency array,
+  // and a fresh closure each render would re-run the effect — tearing
+  // down and re-adding the key handler, and re-stealing focus, on every
+  // parent render while the menu is open.
+  const close = useCallback(() => setOpen(false), []);
+
+  return (
+    <div className="header-menu">
+      <button
+        type="button"
+        className="header-menu-button"
+        aria-label={label}
+        aria-expanded={open}
+        aria-controls={open ? panelId : undefined}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <Icon name="menu" />
+      </button>
+      {open && (
+        <>
+          {/* Catches the click that dismisses. Not focusable and not in
+              the a11y tree: Escape is the keyboard way out, and this is
+              only for a pointer. */}
+          <div className="header-menu-scrim" aria-hidden="true" onClick={close} />
+          <div
+            ref={panelRef}
+            id={panelId}
+            role="group"
+            aria-label={label}
+            className="header-menu-panel"
+            // Any activation inside closes. The contents are links and
+            // one-shot actions, so there is nothing here a candidate
+            // presses twice — and a menu still open over the screen its
+            // own link just changed is the failure this avoids.
+            onClick={close}
+          >
+            <FocusTrap containerRef={panelRef} onClose={close} />
+            {children}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// useFocusTrap must run against a mounted container, and the panel only
+// exists while open. A child component keeps the hook unconditional — a
+// hook called inside `{open && …}` in the parent would be a conditional
+// hook — while still mounting and unmounting with the panel.
+function FocusTrap({
+  containerRef,
+  onClose,
+}: {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  onClose: () => void;
+}) {
+  useFocusTrap(containerRef, onClose);
+  return null;
+}

--- a/ui/src/components/Icon.test.tsx
+++ b/ui/src/components/Icon.test.tsx
@@ -57,6 +57,7 @@ describe("Icon", () => {
       "theme-light",
       "theme-dark",
       "help",
+      "menu",
     ];
     expect(new Set(ICON_NAMES)).toEqual(new Set(declared));
   });

--- a/ui/src/components/Icon.tsx
+++ b/ui/src/components/Icon.tsx
@@ -47,7 +47,8 @@ export type IconName =
   | "theme-auto"
   | "theme-light"
   | "theme-dark"
-  | "help";
+  | "help"
+  | "menu";
 
 const SUN_RAYS = [
   "M12 2.4v2.2",
@@ -128,6 +129,13 @@ const PATHS: Record<IconName, ReactNode> = {
     <>
       <path d="M9.3 9.2a2.8 2.8 0 1 1 3.6 2.7c-.9.3-1.4 1-1.4 1.9v.5" />
       <path d="M11.5 17.6h.01" />
+    </>
+  ),
+  menu: (
+    <>
+      <path d="M4 7h16" />
+      <path d="M4 12h16" />
+      <path d="M4 17h16" />
     </>
   ),
 };

--- a/ui/src/components/SessionChip.tsx
+++ b/ui/src/components/SessionChip.tsx
@@ -38,7 +38,7 @@ export function SessionChip({
 
   return (
     <div className="session-chip">
-      <span className="session-chip-user">{login}</span>
+      {login && <span className="session-chip-user">{login}</span>}
       {live && (
         <span
           className="session-chip-clock"

--- a/ui/src/components/SessionChip.tsx
+++ b/ui/src/components/SessionChip.tsx
@@ -5,35 +5,105 @@ import { formatClock } from "../lib/format";
 import { useTick } from "../lib/useTick";
 import { strings } from "../strings";
 
-interface SessionChipProps {
-  login: string;
-  /** Absent while the candidate has no environment: only sign-out shows. */
-  session?: HostedSession;
-  onChanged: () => void;
-}
-
 /** Under this much lease left, the countdown starts insisting. */
 const SOON_SECONDS = 15 * 60;
 
 /**
- * Who you are, how long you have, and the two ways out.
+ * Who you are and how long you have.
  *
  * The countdown is the part that earns its place: a hosted session has a
  * hard cap and is taken back at it whatever the candidate is doing, so
  * the one thing they cannot be left to guess is how long that is. It is
  * recomputed from the server's `expiresAt` on every tick rather than
  * decremented, so a throttled background tab resyncs instead of drifting.
+ *
+ * Presentational, and deliberately so. The controls that used to sit
+ * beside it are SessionActions below, and the confirmation they raise is
+ * owned by the header — because on a narrow viewport those controls live
+ * inside a popover that unmounts when it closes, and a dialog rendered
+ * underneath them would be destroyed by the click that opened it.
  */
-export function SessionChip({ login, session, onChanged }: SessionChipProps) {
-  const [confirming, setConfirming] = useState(false);
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
+export function SessionChip({
+  login,
+  session,
+}: {
+  login: string;
+  session?: HostedSession;
+}) {
   const expires = session ? Date.parse(session.expiresAt) : NaN;
   const live = session !== undefined && !Number.isNaN(expires);
   const now = useTick(live);
   const secondsLeft = live ? Math.max(0, Math.round((expires - now) / 1000)) : 0;
   const soon = live && secondsLeft <= SOON_SECONDS;
+
+  return (
+    <div className="session-chip">
+      <span className="session-chip-user">{login}</span>
+      {live && (
+        <span
+          className="session-chip-clock"
+          data-soon={soon || undefined}
+          // Announced only when it starts mattering. A clock in a live
+          // region that re-reads every second is unusable with a screen
+          // reader on, and for most of a ten-hour lease it is not news.
+          role={soon ? "status" : undefined}
+        >
+          {secondsLeft === 0
+            ? strings.hosted.chipExpired
+            : soon
+              ? strings.hosted.chipEndingSoon(formatClock(secondsLeft))
+              : strings.hosted.chipTimeLeft(formatClock(secondsLeft))}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// A full reload rather than a state update. Signing out invalidates a
+// cookie that every open fetch and the desktop's WebSocket are carrying,
+// and there is no partial version of that.
+async function signOut() {
+  await logout().catch(() => undefined);
+  window.location.assign("/");
+}
+
+/**
+ * The two ways out.
+ *
+ * `onEnd` raises the confirmation rather than performing anything: see
+ * SessionChip above for why the dialog cannot live here.
+ */
+export function SessionActions({
+  session,
+  onEnd,
+}: {
+  session?: HostedSession;
+  onEnd: () => void;
+}) {
+  return (
+    <>
+      {session && (
+        <button type="button" className="btn btn-quiet" onClick={onEnd}>
+          {strings.hosted.endSession}
+        </button>
+      )}
+      <button type="button" className="btn btn-quiet" onClick={() => void signOut()}>
+        {strings.hosted.signOut}
+      </button>
+    </>
+  );
+}
+
+/** The confirmation, and the call it makes if confirmed. */
+export function EndSessionDialog({
+  onClose,
+  onChanged,
+}: {
+  onClose: () => void;
+  onChanged: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const end = async () => {
     setBusy(true);
@@ -44,72 +114,27 @@ export function SessionChip({ login, session, onChanged }: SessionChipProps) {
       setError(result.error);
       return;
     }
-    setConfirming(false);
+    onClose();
     onChanged();
   };
 
-  const signOut = async () => {
-    await logout().catch(() => undefined);
-    // A full reload rather than a state update. Signing out invalidates a
-    // cookie that every open fetch and the desktop's WebSocket are
-    // carrying, and there is no partial version of that.
-    window.location.assign("/");
-  };
-
   return (
-    <>
-      <div className="session-chip">
-        <span className="session-chip-user">{login}</span>
-        {live && (
-          <span
-            className="session-chip-clock"
-            data-soon={soon || undefined}
-            // Announced only when it starts mattering. A clock in a live
-            // region that re-reads every second is unusable with a screen
-            // reader on, and for most of a ten-hour lease it is not news.
-            role={soon ? "status" : undefined}
-          >
-            {secondsLeft === 0
-              ? strings.hosted.chipExpired
-              : soon
-                ? strings.hosted.chipEndingSoon(formatClock(secondsLeft))
-                : strings.hosted.chipTimeLeft(formatClock(secondsLeft))}
-          </span>
-        )}
-        {session && (
-          <button type="button" className="btn btn-quiet" onClick={() => setConfirming(true)}>
-            {strings.hosted.endSession}
-          </button>
-        )}
-        <button type="button" className="btn btn-quiet" onClick={() => void signOut()}>
-          {strings.hosted.signOut}
+    <Dialog title={strings.hosted.endConfirmTitle} onClose={onClose}>
+      <p>{strings.hosted.endConfirmBody}</p>
+      {error && <p className="error-text">{strings.hosted.endFailed(error)}</p>}
+      <div className="confirm-actions">
+        <button type="button" className="btn" onClick={onClose} disabled={busy}>
+          {strings.hosted.endCancel}
+        </button>
+        <button
+          type="button"
+          className="btn btn-danger"
+          onClick={() => void end()}
+          disabled={busy}
+        >
+          {strings.hosted.endConfirm}
         </button>
       </div>
-
-      {confirming && (
-        <Dialog title={strings.hosted.endConfirmTitle} onClose={() => setConfirming(false)}>
-          <p>{strings.hosted.endConfirmBody}</p>
-          {error && <p className="error-text">{strings.hosted.endFailed(error)}</p>}
-          <div className="confirm-actions">
-            <button
-              type="button"
-              className="btn"
-              onClick={() => setConfirming(false)}
-              disabled={busy}
-            >
-              {strings.hosted.endCancel}
-            </button>
-            <button
-              type="button"
-              className="btn btn-danger"
-              onClick={() => void end()}
-              disabled={busy}
-            >
-              {strings.hosted.endConfirm}
-            </button>
-          </div>
-        </Dialog>
-      )}
-    </>
+    </Dialog>
   );
 }

--- a/ui/src/lib/useHosted.ts
+++ b/ui/src/lib/useHosted.ts
@@ -33,6 +33,13 @@ const POLL_RETRY_MS = 3_000;
 function cadenceFor(me: Me): number {
   if (me.queue) return POLL_ACTIVE_MS;
   if (me.session && me.session.state !== "ready") return POLL_ACTIVE_MS;
+  // A session with a job in flight is exactly a session about to change
+  // state, whatever it currently reports: during a recycle's stop phase
+  // the hub answers "ready" WITH op set, because the address is cleared
+  // before the state catches up. Without this check that combination
+  // fell through to the idle cadence, and the SPA could take up to 20s
+  // to notice a rebuild had begun.
+  if (me.session?.op) return POLL_ACTIVE_MS;
   return POLL_IDLE_MS;
 }
 

--- a/ui/src/lib/useMediaQuery.ts
+++ b/ui/src/lib/useMediaQuery.ts
@@ -50,3 +50,13 @@ export const TOUCH_ONLY_QUERY = "(any-pointer: coarse) and (not (any-pointer: fi
  * fractional-DPI displays, where neither rule would apply.
  */
 export const SPLIT_QUERY = "not (max-width: 900px)";
+
+/**
+ * Too narrow for the header's full row.
+ *
+ * At its fullest that row is a wordmark, a rule, a crumb, a detail line,
+ * two nav links, a login, a lease countdown and four buttons. It starts
+ * colliding well above the 560px the old rule used, which only ever hid
+ * the crumb and let the rest overflow.
+ */
+export const HEADER_COMPACT_QUERY = "(max-width: 48rem)";

--- a/ui/src/lib/useMediaQuery.ts
+++ b/ui/src/lib/useMediaQuery.ts
@@ -58,5 +58,8 @@ export const SPLIT_QUERY = "not (max-width: 900px)";
  * two nav links, a login, a lease countdown and four buttons. It starts
  * colliding well above the 560px the old rule used, which only ever hid
  * the crumb and let the rest overflow.
+ *
+ * Mirrored in theme.css's compact-header media query on .app-header —
+ * the two breakpoints must agree.
  */
 export const HEADER_COMPACT_QUERY = "(max-width: 48rem)";

--- a/ui/src/lib/useSeatLanding.ts
+++ b/ui/src/lib/useSeatLanding.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from "react";
+import { navigate } from "./useHashRoute";
+import type { HostedState } from "./useHosted";
+
+/**
+ * Where a hosted candidate lands when their environment comes up.
+ *
+ * A hosted seat is scoped to one exam: the Pod is stamped and sized for
+ * it, and the selector inside the session offers no other. So the exam
+ * picker at the end of a boot is a screen with a single card on it,
+ * asking the candidate to re-confirm the choice they made in the lobby —
+ * and at the end of a rebuild it reads as having been thrown out of the
+ * attempt they asked to repeat.
+ *
+ * Two guards, and both matter:
+ *
+ *   - It fires only on a transition into ready that this tab WATCHED. A
+ *     page load that finds a session already ready is not mid-anything,
+ *     and moving it would take a candidate off whatever they had open.
+ *   - It yields to a route they are deliberately on. Progress and a past
+ *     attempt are about their record rather than their environment, and a
+ *     rebuild finishing behind them must not close what they are reading.
+ *
+ * Mode.tsx bounces to /exams when the facilitator's active exam is not
+ * the bank in the route, so a wrong guess here costs exactly the screen
+ * this replaces and nothing more.
+ */
+export function useSeatLanding(state: HostedState): void {
+  const seen = useRef(false);
+  const wasReady = useRef(false);
+
+  useEffect(() => {
+    // `unknown` is the placeholder useHosted() renders for exactly one
+    // tick before its first /api/me answers — never real session data.
+    // Treating it as the baseline observation would make every page load
+    // read as a watched transition the instant real data arrived, which
+    // is the "page load into an already-ready seat" case the first guard
+    // exists to exclude.
+    if (state.status === "unknown") return;
+
+    const session = state.status === "hosted" ? state.me.session : undefined;
+    const ready = session?.state === "ready";
+    const bank = session?.bank;
+
+    // The first observation establishes a baseline and never navigates.
+    if (!seen.current) {
+      seen.current = true;
+      wasReady.current = ready;
+      return;
+    }
+    const arrived = ready && !wasReady.current;
+    wasReady.current = ready;
+    if (!arrived || !bank) return;
+
+    const here = window.location.hash.replace(/^#\/?/, "").split("/")[0];
+    if (here === "progress" || here === "history" || here === "exams") return;
+    navigate(`/exams/${bank}/mode`, { replace: true });
+  }, [state]);
+}

--- a/ui/src/screens/Hosted.test.tsx
+++ b/ui/src/screens/Hosted.test.tsx
@@ -24,18 +24,21 @@ function me(overrides: Partial<Me> = {}): Me {
   };
 }
 
+/** A settled idle session, as the facilitator reports one. */
+const readySessionStub = {
+  state: "idle",
+  bank: "ckad-mock-01",
+  startedAt: "",
+  durationSeconds: 7200,
+  remainingSeconds: 0,
+  endReason: "",
+  mode: "exam",
+  untimed: false,
+};
+
 /** A ready local environment, so the ordinary app can mount over a hub. */
 const localStubs: Record<string, unknown> = {
-  "/api/session": {
-    state: "idle",
-    bank: "ckad-mock-01",
-    startedAt: "",
-    durationSeconds: 7200,
-    remainingSeconds: 0,
-    endReason: "",
-    mode: "exam",
-    untimed: false,
-  },
+  "/api/session": readySessionStub,
   "/api/boot": {
     state: "ready",
     phase: "ready",
@@ -162,6 +165,25 @@ function stubFetch() {
         });
       }
       if (url.includes("/api/history/")) return json(attemptResults);
+      // Two failure fixtures for the session poll, opted into by writing
+      // a sentinel into localStubs. `null` is the hub's answer while it
+      // replaces a Pod — an expected wait. "boom" is a facilitator that
+      // has actually fallen over, which must still be reported.
+      if (url.endsWith("/api/session")) {
+        if (localStubs["/api/session"] === null) {
+          return json(
+            {
+              error: "your exam environment is still starting",
+              code: "environment_starting",
+              state: "pending",
+            },
+            503,
+          );
+        }
+        if (localStubs["/api/session"] === "boom") {
+          return json({ error: "the facilitator is not answering" }, 500);
+        }
+      }
       for (const [path, body] of Object.entries(localStubs)) {
         if (url.endsWith(path)) return json(body);
       }
@@ -173,6 +195,7 @@ function stubFetch() {
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true, now });
   identity = me();
+  localStubs["/api/session"] = readySessionStub;
   startAnswer = { status: 202, body: { starting: true, state: "pending" } };
   hubExams = [];
   stubFetch();
@@ -520,4 +543,54 @@ test("the hosted dashboard exports but does not import", async () => {
 
   expect(await screen.findByRole("link", { name: /export/i })).toBeTruthy();
   expect(screen.queryByRole("button", { name: /^import$/i })).toBeNull();
+});
+
+/** A ready hosted seat, so SimApp mounts and its session poller runs. */
+function readySeat() {
+  return {
+    kind: "practical" as const,
+    bank: "ckad-mock-01",
+    pod: "sim-session-practical-583231",
+    state: "ready" as const,
+    startedAt: new Date(now - 600_000).toISOString(),
+    expiresAt: new Date(now + 2 * 3600_000).toISOString(),
+    lastSeen: new Date(now).toISOString(),
+  };
+}
+
+// The reported bug, in the window it actually happens in.
+//
+// SimApp has to be MOUNTED and its session poller running, because that
+// poller is what raises the toast. /api/me flips to "pending" about two
+// seconds after the POST and unmounts SimApp — but a toast pushed before
+// then lives in a module singleton and outlives it. So the fixture holds
+// /api/me at "ready" while the proxy has already started answering 503,
+// which is exactly the race.
+test("a Pod replacement raises no outage toast", async () => {
+  identity = me({ session: readySeat() });
+  render(<App />);
+  await screen.findByRole("heading", { name: /path to kubestronaut/i });
+
+  // The hub begins replacing the Pod. Every proxied request is a 503 from
+  // here on; /api/me has not caught up.
+  localStubs["/api/session"] = null;
+  window.dispatchEvent(new Event("focus")); // pollSession re-fetches on focus
+  await vi.advanceTimersByTimeAsync(0); // let the mocked 503 round-trip settle
+
+  await waitFor(() => {
+    expect(screen.queryByText(/cannot reach facilitator/i)).toBeNull();
+  });
+});
+
+// The other half, and the reason the guard is a code and not a blanket
+// mute: a facilitator that has genuinely fallen over must still say so.
+test("a real failure still raises the toast", async () => {
+  identity = me({ session: readySeat() });
+  render(<App />);
+  await screen.findByRole("heading", { name: /path to kubestronaut/i });
+
+  localStubs["/api/session"] = "boom"; // forces the 500 branch in stubFetch
+  window.dispatchEvent(new Event("focus"));
+
+  expect(await screen.findByText(/cannot reach facilitator/i)).toBeInTheDocument();
 });

--- a/ui/src/screens/Hosted.test.tsx
+++ b/ui/src/screens/Hosted.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import App from "../App";
 import type { Me } from "../api";
+import { strings } from "../strings";
 
 // The hosted tier, from the outside: what a browser sees when the SPA is
 // served by the hub instead of by a facilitator.
@@ -593,4 +594,54 @@ test("a real failure still raises the toast", async () => {
   window.dispatchEvent(new Event("focus"));
 
   expect(await screen.findByText(/cannot reach facilitator/i)).toBeInTheDocument();
+});
+
+// The rebuild screen names the exam and offers the honest way out. A
+// first boot must be untouched by all of this.
+test("a rebuild says so, and a first boot still reads as a first boot", async () => {
+  hubExams = [
+    {
+      id: "ckad-mock-01",
+      title: "CKAD Mock Exam 01",
+      certification: "CKAD",
+      examType: "hands-on",
+      kind: "practical",
+      available: true,
+      nodes: 2,
+      questionCount: 22,
+    },
+  ];
+  const booting = {
+    kind: "practical" as const,
+    bank: "ckad-mock-01",
+    pod: "sim-session-practical-583231",
+    state: "starting" as const,
+    startedAt: new Date(now).toISOString(),
+    expiresAt: new Date(now + 3_600_000).toISOString(),
+    lastSeen: new Date(now).toISOString(),
+  };
+
+  identity = me({ session: { ...booting, op: "reset" } });
+  const rebuild = render(<App />);
+  await screen.findByRole("heading", { name: strings.hosted.rebuildTitle });
+  // The heading needs no exam data and renders on the first pass; the
+  // body names the exam only once GET /hub/exams has round-tripped. That
+  // is an independent, unbounded number of microtask hops behind the
+  // heading, so a positive `waitFor` — which keeps retrying on every DOM
+  // mutation rather than checking once — is what actually waits for it,
+  // where a single timer flush proved to still race it.
+  await waitFor(() => {
+    expect(screen.getByText(/clean CKAD environment/i)).toBeInTheDocument();
+  });
+  expect(
+    screen.getByRole("button", { name: strings.hosted.rebuildGiveUp }),
+  ).toBeInTheDocument();
+  rebuild.unmount();
+
+  identity = me({ session: booting });
+  render(<App />);
+  await screen.findByRole("heading", { name: strings.hosted.bootStartingTitle });
+  expect(
+    screen.getByRole("button", { name: strings.hosted.bootGiveUp }),
+  ).toBeInTheDocument();
 });

--- a/ui/src/screens/Hosted.test.tsx
+++ b/ui/src/screens/Hosted.test.tsx
@@ -636,6 +636,13 @@ test("a rebuild says so, and a first boot still reads as a first boot", async ()
   expect(
     screen.getByRole("button", { name: strings.hosted.rebuildGiveUp }),
   ).toBeInTheDocument();
+  // The reassure line, not just the title: this is the sentence that used
+  // to say "a first build on a cold node pulls several gigabytes" about a
+  // node that already had every image, and past minute ten told a
+  // candidate trying to KEEP their seat to give it up.
+  expect(
+    screen.getByText("Tearing down the old cluster and starting a clean one."),
+  ).toBeInTheDocument();
   rebuild.unmount();
 
   identity = me({ session: booting });
@@ -644,6 +651,50 @@ test("a rebuild says so, and a first boot still reads as a first boot", async ()
   expect(
     screen.getByRole("button", { name: strings.hosted.bootGiveUp }),
   ).toBeInTheDocument();
+  expect(screen.getByText("Pulling images and starting the cluster.")).toBeInTheDocument();
+});
+
+// op clears the moment a recycle's job finishes, which session.go does
+// just before flipping state to "failed" — so by the time this screen
+// can render the failure, the hub's own answer no longer says it was a
+// rebuild. The screen has to remember what it watched happen across the
+// polls in between, or a failed rebuild reads as "your environment did
+// not start", which is false: a moment ago this seat had one running.
+test("a rebuild that fails still reads as a rebuild, not a first boot", async () => {
+  const rebuilding = {
+    kind: "practical" as const,
+    bank: "ckad-mock-01",
+    pod: "sim-session-practical-583231",
+    state: "starting" as const,
+    op: "reset" as const,
+    startedAt: new Date(now).toISOString(),
+    expiresAt: new Date(now + 3_600_000).toISOString(),
+    lastSeen: new Date(now).toISOString(),
+  };
+  identity = me({ session: rebuilding });
+  render(<App />);
+  await screen.findByRole("heading", { name: strings.hosted.rebuildTitle });
+
+  // The hub's own answer once the recycle has actually failed: op is
+  // gone (the job finished), state is "failed", same as any other boot
+  // that died.
+  identity = me({
+    session: {
+      ...rebuilding,
+      state: "failed",
+      op: undefined,
+      error: "waiting for sim-session-practical-583231 to go away: context deadline exceeded",
+    },
+  });
+  await vi.advanceTimersByTimeAsync(2_000);
+
+  expect(
+    await screen.findByRole("heading", { name: strings.hosted.rebuildFailedTitle }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: strings.hosted.rebuildGiveUp }),
+  ).toBeInTheDocument();
+  expect(screen.queryByRole("heading", { name: strings.hosted.bootFailedTitle })).toBeNull();
 });
 
 // A hosted seat is scoped to one exam — the Pod is stamped and sized for

--- a/ui/src/screens/Hosted.test.tsx
+++ b/ui/src/screens/Hosted.test.tsx
@@ -678,6 +678,11 @@ test("an environment that comes up lands on its exam, not on the picker", async 
     },
   });
 
+  // useHosted only re-polls /api/me every POLL_ACTIVE_MS (useHosted.ts) —
+  // 2s — while a session is not yet ready, so the ready state above sits
+  // unseen until that timer fires. Advance past it explicitly rather than
+  // trusting shouldAdvanceTime's real-time pace to outrun waitFor's
+  // shorter default timeout.
   await vi.advanceTimersByTimeAsync(2_000);
   await waitFor(() => {
     expect(window.location.hash).toBe("#/exams/ckad-mock-01/mode");
@@ -709,5 +714,56 @@ test("a page load into a ready seat is left where it is", async () => {
   // the hash is checked. See Score.test.tsx and the Pod-replacement test
   // above for the same pattern.
   await vi.advanceTimersByTimeAsync(0);
+  await waitFor(() => expect(window.location.hash).toBe("#/progress"));
+});
+
+// The other guard the docstring calls "both matter" — and neither test
+// above reaches it. The first arrives on the default route, so the
+// yield list is passed through without being evaluated; the second's
+// session is already ready at mount, so it only exercises the baseline
+// guard, and being on /progress there is incidental. A rebuild finishing
+// behind a candidate who is deliberately reading their progress page
+// must not close it under them. `history` and `exams` are the same
+// branch of the same condition as `progress`, so proving this one yields
+// is enough — three near-copies would not cover anything more.
+test("a rebuild finishing behind a deliberate route does not close it", async () => {
+  window.location.hash = "#/progress";
+  identity = me({
+    session: {
+      kind: "practical",
+      bank: "ckad-mock-01",
+      pod: "sim-session-practical-583231",
+      state: "starting",
+      op: "reset",
+      startedAt: new Date(now).toISOString(),
+      expiresAt: new Date(now + 3_600_000).toISOString(),
+      lastSeen: new Date(now).toISOString(),
+    },
+  });
+  render(<App />);
+  // /progress answers from the hub's own store regardless of session
+  // state — HostedHome renders it ahead of the booting screen for
+  // exactly that reason — so the export link, not a rebuild heading, is
+  // the settled signal to wait for here.
+  await screen.findByRole("link", { name: /export/i });
+
+  identity = me({
+    session: {
+      kind: "practical",
+      bank: "ckad-mock-01",
+      pod: "sim-session-practical-583231",
+      state: "ready",
+      startedAt: new Date(now).toISOString(),
+      expiresAt: new Date(now + 3_600_000).toISOString(),
+      lastSeen: new Date(now).toISOString(),
+    },
+  });
+
+  // Same poll-cadence wait as the sibling starting->ready test above:
+  // advance past useHosted's POLL_ACTIVE_MS before checking, so the
+  // guard has actually run (in either direction) before the assertion
+  // does, rather than a bare waitFor resolving on its already-true first
+  // check.
+  await vi.advanceTimersByTimeAsync(2_000);
   await waitFor(() => expect(window.location.hash).toBe("#/progress"));
 });

--- a/ui/src/screens/Hosted.test.tsx
+++ b/ui/src/screens/Hosted.test.tsx
@@ -645,3 +645,69 @@ test("a rebuild says so, and a first boot still reads as a first boot", async ()
     screen.getByRole("button", { name: strings.hosted.bootGiveUp }),
   ).toBeInTheDocument();
 });
+
+// A hosted seat is scoped to one exam — the Pod is stamped and sized for
+// it — so the picker at the end of a boot has one card on it and asks the
+// candidate to re-confirm what they chose in the lobby. After a rebuild
+// it reads as having been thrown out of the attempt they asked to repeat.
+test("an environment that comes up lands on its exam, not on the picker", async () => {
+  identity = me({
+    session: {
+      kind: "practical",
+      bank: "ckad-mock-01",
+      pod: "sim-session-practical-583231",
+      state: "starting",
+      op: "reset",
+      startedAt: new Date(now).toISOString(),
+      expiresAt: new Date(now + 3_600_000).toISOString(),
+      lastSeen: new Date(now).toISOString(),
+    },
+  });
+  render(<App />);
+  await screen.findByRole("heading", { name: strings.hosted.rebuildTitle });
+
+  identity = me({
+    session: {
+      kind: "practical",
+      bank: "ckad-mock-01",
+      pod: "sim-session-practical-583231",
+      state: "ready",
+      startedAt: new Date(now).toISOString(),
+      expiresAt: new Date(now + 3_600_000).toISOString(),
+      lastSeen: new Date(now).toISOString(),
+    },
+  });
+
+  await vi.advanceTimersByTimeAsync(2_000);
+  await waitFor(() => {
+    expect(window.location.hash).toBe("#/exams/ckad-mock-01/mode");
+  });
+});
+
+// A tab that was already on a ready session is not mid-anything, and
+// yanking it to the mode screen would lose whatever the candidate was
+// reading.
+test("a page load into a ready seat is left where it is", async () => {
+  window.location.hash = "#/progress";
+  identity = me({
+    session: {
+      kind: "practical",
+      bank: "ckad-mock-01",
+      pod: "sim-session-practical-583231",
+      state: "ready",
+      startedAt: new Date(now).toISOString(),
+      expiresAt: new Date(now + 3_600_000).toISOString(),
+      lastSeen: new Date(now).toISOString(),
+    },
+  });
+  render(<App />);
+  // A bare waitFor on an assertion that is already true on its first
+  // synchronous check resolves instantly, before the mocked /api/me
+  // round-trip (and the effect it would drive) ever runs — passing
+  // whether or not the hook is wired correctly. Flush that round-trip
+  // first so a wrongly-navigating hook has actually had its turn before
+  // the hash is checked. See Score.test.tsx and the Pod-replacement test
+  // above for the same pattern.
+  await vi.advanceTimersByTimeAsync(0);
+  await waitFor(() => expect(window.location.hash).toBe("#/progress"));
+});

--- a/ui/src/screens/HostedBooting.tsx
+++ b/ui/src/screens/HostedBooting.tsx
@@ -41,6 +41,12 @@ export function HostedBooting({ session, onChanged }: HostedBootingProps) {
   const examsState = useAsync((signal) => getHostedExams(signal), []);
   const exam = examsState.data?.find((e) => e.id === session.bank);
 
+  // The hub says what it is doing to this Pod. Without it "not ready" is
+  // the only signal, and a first boot and a rebuild are indistinguishable
+  // — which is how the candidate who pressed "New attempt" ended up on a
+  // screen written to greet them.
+  const rebuilding = session.op === "reset" || session.op === "switch";
+
   const retry = async () => {
     setBusy(true);
     // End first, then ask again: a failed session still holds its seat so
@@ -86,15 +92,25 @@ export function HostedBooting({ session, onChanged }: HostedBootingProps) {
   }
 
   const pending = session.state === "pending";
-  const title = pending ? strings.hosted.bootPendingTitle : strings.hosted.bootStartingTitle;
+  const title = rebuilding
+    ? strings.hosted.rebuildTitle
+    : pending
+      ? strings.hosted.bootPendingTitle
+      : strings.hosted.bootStartingTitle;
   // The queue reads the same whatever is being queued for; the build does
   // not. A multiple-choice seat has no cluster to build and is up in
   // seconds, so the hands-on copy would be describing someone else's wait.
-  const body = pending
-    ? strings.hosted.bootPendingBody
-    : session.kind === "mcq"
-      ? strings.hosted.bootStartingBodyMcq
-      : strings.hosted.bootStartingBody(exam?.nodes, exam?.questionCount);
+  //
+  // A rebuild outranks both: it is the same work as a first build, but
+  // the sentence a candidate needs is what is happening to the attempt
+  // they just finished, not what a new environment contains.
+  const body = rebuilding
+    ? strings.hosted.rebuildBody(exam?.certification || exam?.title)
+    : pending
+      ? strings.hosted.bootPendingBody
+      : session.kind === "mcq"
+        ? strings.hosted.bootStartingBodyMcq
+        : strings.hosted.bootStartingBody(exam?.nodes, exam?.questionCount);
 
   return (
     <div className="page hosted-screen hosted-booting">
@@ -120,7 +136,7 @@ export function HostedBooting({ session, onChanged }: HostedBootingProps) {
         </p>
       </div>
       <button type="button" className="btn" onClick={() => void giveUp()} disabled={busy}>
-        {strings.hosted.bootGiveUp}
+        {rebuilding ? strings.hosted.rebuildGiveUp : strings.hosted.bootGiveUp}
       </button>
     </div>
   );

--- a/ui/src/screens/HostedBooting.tsx
+++ b/ui/src/screens/HostedBooting.tsx
@@ -47,6 +47,22 @@ export function HostedBooting({ session, onChanged }: HostedBootingProps) {
   // screen written to greet them.
   const rebuilding = session.op === "reset" || session.op === "switch";
 
+  // op clears the instant the job finishes, which happens just before a
+  // failed recycle's state flips to "failed" (session.go's runRecycle
+  // sets State before calling jobs.finish) — so by the time this screen
+  // can render the failure, the hub has already forgotten it was a
+  // rebuild. This component stays mounted for the whole of one boot
+  // (HostedHome keys its screen transition on "lobby", not on session
+  // state), so remembering the last true read across renders survives to
+  // explain the failure that follows it — "adjusting state during
+  // rendering", which is what React itself calls this pattern, rather
+  // than a ref: a ref may not be read or written during render. A page
+  // reload mid-failure loses the memory and falls back to the first-boot
+  // copy, the same gap every other in-memory read in this app has.
+  const [wasRebuilding, setWasRebuilding] = useState(false);
+  if (rebuilding && !wasRebuilding) setWasRebuilding(true);
+  const failedRebuild = failed && wasRebuilding;
+
   const retry = async () => {
     setBusy(true);
     // End first, then ask again: a failed session still holds its seat so
@@ -72,7 +88,7 @@ export function HostedBooting({ session, onChanged }: HostedBootingProps) {
   if (failed) {
     return (
       <div className="page hosted-screen">
-        <h1>{strings.hosted.bootFailedTitle}</h1>
+        <h1>{failedRebuild ? strings.hosted.rebuildFailedTitle : strings.hosted.bootFailedTitle}</h1>
         {session.error && <p className="error-text">{session.error}</p>}
         <div className="score-actions">
           <button
@@ -84,7 +100,7 @@ export function HostedBooting({ session, onChanged }: HostedBootingProps) {
             {strings.hosted.bootRetry}
           </button>
           <button type="button" className="btn" onClick={() => void giveUp()} disabled={busy}>
-            {strings.hosted.bootGiveUp}
+            {failedRebuild ? strings.hosted.rebuildGiveUp : strings.hosted.bootGiveUp}
           </button>
         </div>
       </div>
@@ -124,7 +140,7 @@ export function HostedBooting({ session, onChanged }: HostedBootingProps) {
           narrate it. */}
       {!pending && session.kind !== "mcq" && (
         <p className="hosted-boot-reassure" role="status">
-          {strings.hosted.bootReassure(elapsed)}
+          {rebuilding ? strings.hosted.rebuildReassure(elapsed) : strings.hosted.bootReassure(elapsed)}
         </p>
       )}
       <div className="score-loading-progress">

--- a/ui/src/strings.ts
+++ b/ui/src/strings.ts
@@ -1568,6 +1568,28 @@ export const strings = {
     // "cancel the rebuild", which is not what the button does — it ends
     // the session and hands the seat back to the pool.
     rebuildGiveUp: "End session and free the seat",
+    // bootReassure's own copy, said about a rebuild instead of a first
+    // boot. It shares that copy's thresholds because the wait is the
+    // same wait — but "a first build on a cold node pulls several
+    // gigabytes" is false here, the images are already on this node from
+    // the attempt being replaced, and the long-wait line no longer tells
+    // someone trying to KEEP their seat to give it up; rebuildGiveUp
+    // exists precisely to stop saying that.
+    rebuildReassure: (elapsedMs: number) => {
+      if (elapsedMs < 90_000) return "Tearing down the old cluster and starting a clean one.";
+      if (elapsedMs < 240_000)
+        return "Still going — the new cluster is coming up and its questions are being set up.";
+      if (elapsedMs < 600_000)
+        return "Taking longer than usual, but the images are already on this node — this is not a first build. Still working.";
+      return "This is well past the usual wait, and something may be wrong. Ending the session frees the seat so you can start again.";
+    },
+    // "Your environment did not start" is a first-boot sentence, and it
+    // is wrong here: a moment ago this seat had a running environment,
+    // and what failed was replacing it. Retrying does not resume that
+    // rebuild — it ends the session and starts over, same as any other
+    // failed boot — so this stops short of promising the attempt that
+    // was being rebuilt back.
+    rebuildFailedTitle: "Your environment could not be rebuilt",
 
     // The header chip.
     chipLabel: "Session",

--- a/ui/src/strings.ts
+++ b/ui/src/strings.ts
@@ -1549,6 +1549,22 @@ export const strings = {
     bootRetry: "Try again",
     bootGiveUp: "Give up this seat",
 
+    // A rebuild, not a first boot. The same wait, a different fact: this
+    // candidate already has a seat and asked for another attempt, so copy
+    // that welcomes them to a new environment and offers to give the seat
+    // up is describing somebody else's situation entirely.
+    rebuildTitle: "Rebuilding your environment",
+    // Named when the exam is known, because a candidate mid-rebuild wants
+    // to be sure it is being rebuilt as the exam they were sitting.
+    rebuildBody: (exam?: string) =>
+      exam
+        ? `Your last attempt is being cleared and a clean ${exam} environment built in its place. This takes a few minutes, and nothing is lost if you close this tab.`
+        : "Your last attempt is being cleared and a clean environment built in its place. This takes a few minutes, and nothing is lost if you close this tab.",
+    // Says what it does. "Give up this seat" during a rebuild reads as
+    // "cancel the rebuild", which is not what the button does — it ends
+    // the session and hands the seat back to the pool.
+    rebuildGiveUp: "End session and free the seat",
+
     // The header chip.
     chipLabel: "Session",
     chipTimeLeft: (left: string) => `${left} left`,

--- a/ui/src/strings.ts
+++ b/ui/src/strings.ts
@@ -31,6 +31,10 @@ export const strings = {
     // from nowhere.
     navExams: "Exams",
     navProgress: "Progress",
+    // The narrow-viewport menu. The button is icon-only, so this is the
+    // whole of its accessible name.
+    menuLabel: "Menu",
+    menuAccount: "Account",
   },
 
   // 1b, the exam selector. The screen a candidate lands on.

--- a/ui/src/styles/layout.test.ts
+++ b/ui/src/styles/layout.test.ts
@@ -67,6 +67,25 @@ describe("full-height chain", () => {
   });
 });
 
+// `.app-header` is a sibling of `main` inside #root's column flex, so
+// `height: 56px` here is only a flex BASE size — with the default shrink
+// factor the score screen's 1500px of results squashed it to its
+// min-content height (29px, the label text) while the lobby, whose
+// content fits, kept the full 56. A header that is a different height
+// depending on how long the page below it is. Neither half is visible to
+// a render test: jsdom has no layout engine to shrink it in the first
+// place.
+describe("the app header does not shrink with the page below it", () => {
+  test("keeps its 56px base and refuses to give it up", async () => {
+    const css = await readThemeCss();
+    const header = ruleBody(css, ".app-header");
+
+    expect(header, "the header's own rule was renamed or removed").not.toBeNull();
+    expect(header).toContain("height: 56px");
+    expect(header).toContain("flex-shrink: 0");
+  });
+});
+
 describe("desktop viewport", () => {
   test("the noVNC mount is out of flow, so it can never size itself from its canvas", async () => {
     // noVNC observes this element and asks the server for a framebuffer of

--- a/ui/src/theme.css
+++ b/ui/src/theme.css
@@ -165,9 +165,11 @@
   gap: var(--space-3);
 }
 
-/* Wider than the lead's gap on purpose: this cluster is three groups —
-   the session, the nav, the icon buttons — and at the lead's spacing they
-   read as one undifferentiated row of eight controls. */
+/* Wider than the lead's gap on purpose: this cluster is four groups —
+   the session, {children} (the backgrounded-job chip, between the
+   session and the nav — see AppHeader.tsx), the nav, the icon buttons —
+   and at the lead's spacing they read as one undifferentiated row of
+   controls. */
 .app-header-tail {
   gap: var(--space-4);
   flex-shrink: 0;

--- a/ui/src/theme.css
+++ b/ui/src/theme.css
@@ -314,8 +314,48 @@
     display: none;
   }
 
+  /* .app-header-home has to give up its flex item's default min-width
+     (its own content size) before the wordmark inside it can shrink at
+     all, and at the 320px reflow width the full word "kubestronaut-sim"
+     no longer fits. */
+  .app-header-home {
+    min-width: 0;
+  }
+
+  /* Ellipsises rather than running into the tail at 320px, the WCAG
+     reflow width. .app-header-detail already does this; the wordmark
+     never needed it until the row itself could get this narrow. */
+  .app-header-wordmark {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+  }
+
+  /* .job-chip-label already truncates with its own min-width: 0 and
+     text-overflow: ellipsis — the chip's 11rem floor was the only thing
+     still stopping the whole chip from shrinking, and with
+     .app-header-tail's flex-shrink: 0 that floor was reachable in both
+     products (locally, a `./sim reset` from a terminal while the lobby
+     is backgrounded; hosted, during a recycle's stop phase with SimApp
+     still mounted). A comfortable resting width is not worth a
+     scrollbar on a phone. */
+  .app-header .job-chip {
+    min-width: 0;
+  }
+
   .app-header-tail {
     gap: var(--space-1);
+  }
+
+  /* The compact bar's only two survivors: About and the theme toggle
+     stay here rather than move into the menu (see the design spec), so
+     they are the controls a thumb actually has to hit directly. Scoped
+     to the header — .info-button is shared with the exam topbar, which
+     this branch has no business resizing. */
+  .app-header .info-button,
+  .app-header .theme-toggle {
+    min-width: 44px;
+    min-height: 44px;
   }
 }
 

--- a/ui/src/theme.css
+++ b/ui/src/theme.css
@@ -6568,10 +6568,22 @@
   box-shadow: var(--shadow-2);
 }
 
+/* The nav landmark inside the panel wraps the links in an actual <nav>,
+   which is one level deeper than the buttons and the label the panel's
+   other children render at. Its own flex column and gap match the
+   panel's exactly, so that extra level does not change the rhythm
+   between the nav links or between the nav block and what follows it. */
+.header-menu-nav {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
 /* Every child is a full-width row with a real target, whatever element
-   it happens to be — the panel takes nav links, session buttons and a
-   plain label. */
+   it happens to be — the panel takes nav links (through the landmark
+   wrapper above), session buttons and a plain label. */
 .header-menu-panel > button,
+.header-menu-panel > .header-menu-nav > button,
 .header-menu-panel > .header-menu-item {
   display: flex;
   align-items: center;
@@ -6585,10 +6597,18 @@
   font: inherit;
   font-size: var(--text-s);
   text-align: left;
+}
+
+/* Only the buttons: the sole .header-menu-item is the login name, a
+   static <span>, and a pointer cursor over something that does not
+   respond to a click is a false affordance. */
+.header-menu-panel > button,
+.header-menu-panel > .header-menu-nav > button {
   cursor: pointer;
 }
 
-.header-menu-panel > button:hover {
+.header-menu-panel > button:hover,
+.header-menu-panel > .header-menu-nav > button:hover {
   background: var(--surface-hover);
 }
 

--- a/ui/src/theme.css
+++ b/ui/src/theme.css
@@ -6441,6 +6441,100 @@
   font-size: var(--text-s);
 }
 
+/* ---- header menu ----
+   Everything in the header that is not time-critical, on a viewport too
+   narrow to hold it. See HeaderMenu.tsx for why this is a popover and not
+   a sheet. */
+
+.header-menu {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.header-menu-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  background: none;
+  border: 0;
+  border-radius: var(--radius-s);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.header-menu-button:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+/* Sits under the panel and over everything else, so a pointer anywhere
+   outside dismisses. */
+.header-menu-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-panel);
+}
+
+.header-menu-panel {
+  position: absolute;
+  top: calc(100% + var(--space-2));
+  right: 0;
+  z-index: var(--z-dialog);
+  min-width: 13rem;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-2);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-m);
+  box-shadow: var(--shadow-2);
+}
+
+/* Every child is a full-width row with a real target, whatever element
+   it happens to be — the panel takes nav links, session buttons and a
+   plain label. */
+.header-menu-panel > button,
+.header-menu-panel > .header-menu-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 44px;
+  padding: 0 var(--space-3);
+  background: none;
+  border: 0;
+  border-radius: var(--radius-s);
+  color: var(--text);
+  font: inherit;
+  font-size: var(--text-s);
+  text-align: left;
+  cursor: pointer;
+}
+
+.header-menu-panel > button:hover {
+  background: var(--surface-hover);
+}
+
+.header-menu-label {
+  padding: var(--space-2) var(--space-3) var(--space-1);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+}
+
+.header-menu-rule {
+  height: 1px;
+  margin: var(--space-1) 0;
+  background: var(--border);
+}
+
 @media (max-width: 40rem) {
   .session-chip-user {
     display: none;

--- a/ui/src/theme.css
+++ b/ui/src/theme.css
@@ -165,8 +165,11 @@
   gap: var(--space-3);
 }
 
+/* Wider than the lead's gap on purpose: this cluster is three groups —
+   the session, the nav, the icon buttons — and at the lead's spacing they
+   read as one undifferentiated row of eight controls. */
 .app-header-tail {
-  gap: var(--space-3);
+  gap: var(--space-4);
   flex-shrink: 0;
 }
 
@@ -233,9 +236,13 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
+  /* 44px, which is the floor for a pointer target. This was
+     `var(--space-1) 0` — about 24px tall and no wider than its word. */
+  min-height: 44px;
+  padding: 0 var(--space-3);
   background: none;
   border: 0;
-  padding: var(--space-1) 0;
+  border-radius: var(--radius-s);
   font: inherit;
   font-size: var(--text-s);
   font-weight: 500;
@@ -249,12 +256,15 @@
 
 .app-header-back:hover {
   color: var(--accent-strong);
+  background: var(--surface-hover);
 }
 
+/* Tight, because the links are now padded: the gap used to be doing the
+   separating that the targets do. */
 .app-header-nav {
   display: flex;
   align-items: center;
-  gap: var(--space-4);
+  gap: var(--space-1);
 }
 
 .app-header-link {
@@ -263,26 +273,47 @@
 
 .app-header-link:hover {
   color: var(--text);
+  background: var(--surface-hover);
 }
 
+/* A rule under the word, not a hue change alone. aria-current is the
+   only thing that said "you are here", and a state carried by colour
+   alone is not a state to everyone. */
 .app-header-link-on {
   color: var(--text);
+  box-shadow: inset 0 -2px 0 var(--accent);
   cursor: default;
 }
 
-/* Under ~560px the crumb is the first thing to go: the mark still says
-   where you are, and the nav is the only part that cannot be reached any
-   other way. */
-@media (max-width: 560px) {
+/* One breakpoint for the whole header, and it must stay in step with
+   HEADER_COMPACT_QUERY in lib/useMediaQuery.ts — that is what decides
+   which controls are in the DOM, and this only dresses what is left.
+   Under it the crumb goes first: the mark still says where you are, and
+   the nav has moved into the menu rather than being dropped.
+
+   This replaced two unrelated rules — a 560px block here and a 40rem
+   block for .session-chip-user at the bottom of the file — that between
+   them hid four things and let the other eight overflow. */
+@media (max-width: 48rem) {
   .app-header {
-    padding: 0 var(--space-3);
+    /* Physical, not logical: the inset describes a hardware cutout,
+       which sits on a physical edge of the device and does not move
+       with writing direction. max() keeps the ordinary padding on
+       every device that reports no inset. */
+    padding-left: max(var(--space-3), env(safe-area-inset-left));
+    padding-right: max(var(--space-3), env(safe-area-inset-right));
     gap: var(--space-2);
   }
 
   .app-header-crumb,
   .app-header-rule,
-  .app-header-detail {
+  .app-header-detail,
+  .app-header-wordmark-tail {
     display: none;
+  }
+
+  .app-header-tail {
+    gap: var(--space-1);
   }
 }
 
@@ -6533,10 +6564,4 @@
   height: 1px;
   margin: var(--space-1) 0;
   background: var(--border);
-}
-
-@media (max-width: 40rem) {
-  .session-chip-user {
-    display: none;
-  }
 }

--- a/ui/src/theme.css
+++ b/ui/src/theme.css
@@ -6359,7 +6359,18 @@
   color: var(--text-muted);
 }
 
-/* The header chip: identity, the lease, and the two ways out. */
+/* Identity, the lease, and the two ways out, as one group. The chip and
+   the actions are separate components — the actions have to survive
+   being raised from inside a popover that unmounts them on Task 10's
+   narrow viewport — but without this wrapper they fall back to being
+   plain siblings in .app-header-tail and inherit its wider gap. */
+.session-cluster {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+/* The header chip: identity and the lease. */
 .session-chip {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Two unrelated defects, shipped together because both live in the same four files of the SPA's chrome.

## What changes

**A hosted "New attempt" stops reporting itself as a failure.** Pressing it is `POST /api/control/reset`, which the hub answers by deleting and recreating the candidate's Pod. For the minutes that takes, every proxied request gets a 503 — and four separate things went wrong behind that one symptom. The session poller raised `Cannot reach facilitator` about the rebuild the app itself had just requested. `/api/me` flipping to `pending` unmounted `SimApp` and took the overlay narrating the job with it, while the toast, living in a module store, outlived both. `HostedBooting` then told a first-boot story — with a *give up this seat* button — to someone who already had a seat. And the remount landed on an exam picker holding exactly one card.

The fix is two machine-readable facts and four screens that use them. The proxy's own error bodies carry a `code`, so a client can tell an expected wait from an outage without parsing prose that is a UI string living in a Go file. `/api/me` reports the in-flight `op`, which is what lets a waiting screen tell a first boot from a rebuild — server truth, so it survives a reload mid-rebuild where a remembered click would not.

**The header fits a phone.** It was one non-wrapping row of up to twelve controls whose only responsive rule hid four and let the rest overflow. Below 48rem the nav links and session controls now *move* into a popover — move, not hide, because rendering both copies and hiding one gives every control two accessible names, which is worse than the overflow it fixes. The lease countdown never collapses: a hosted seat is taken back at its cap whatever the candidate is doing, and that is the one number they cannot be left to guess.

Two ad-hoc breakpoints (560px and a stray 40rem at the bottom of the file) become one at 48rem, matched to the constant that decides what is in the DOM. Nav links get a real 44px target instead of ~24px, and `aria-current` gets a rule under the word rather than a hue change alone.

## Defects this surfaced

- **The rebuild's clock started after the wait it measures.** `StartedAt` was restamped in `runRecycle`'s `start` phase, a phase in — so the screen that counts from it spent the first stretch of every rebuild reporting the age of the session being replaced.
- **The compact bar's own controls had no touch target.** The nav links got the 44px pass, but they move into the menu on a phone. The two controls actually left in the bar — About and the theme toggle — were 28px and ~21px, the latter below even the 24px WCAG 2.5.8 floor. The half a thumb can reach was the half that had not been measured.
- **The backgrounded-job chip overflowed that bar**, because `min-width: 11rem` inside a `flex-shrink: 0` container cannot yield. Reachable in both products.
- **`bootReassure` was still first-boot copy on the rebuild screen.** From minute four it said *"A first build on a cold node pulls several gigabytes"* — false, the images are already there — and past minute ten, *"give up this seat and start again"*, the exact framing `rebuildGiveUp` was written to replace, eleven lines above it in the same file.
- **`useHosted` polled at the 20-second idle cadence during a rebuild's first phase**, because the hub still reports `ready` there. Up to twenty seconds to notice.
- **`Manager.Get` deep-copied two `Job`s and two `[]Phase` on every proxied request** to read one string, once the narrower `op()` was what it needed.
- **`docs/api.md` documented a contract that had changed**: no `code`, no `op`, and a 503 row whose stated premise the new invariant had falsified.

## One known gap

`HostedBooting` remembers "this was a rebuild" in component state, because the hub clears the job on failure and `op` is therefore absent on the failed screen. Two consequences, both narrow and both copy-only: a reload mid-failed-rebuild falls back to first-boot copy, and a retry that fails again still claims the rebuild framing. Keeping `Op` set until the session is retried or ended would answer this server-side, which is where every other signal of this kind on this branch lives. Worth a follow-up rather than a wider change here.

## Verification

Offline: 4 Go modules (`go test ./...` and `go vet ./...`), 737 UI tests across 46 files, `tsc --noEmit`, `lint` at zero warnings.

The UI suite grew from 707 to 737. Several of those are guards for things nothing was watching: `.app-header`'s `height: 56px` and `flex-shrink: 0` (believed asserted, actually not — the file mentioned the selector only in a comment); the header tail's element order, after a silent reorder shipped green; and the route-yield guard in the landing hook, which both of its original tests reached by a path that never evaluated it.

**A browser pass is still owed** and is the reason this is worth reviewing with the app running. jsdom has no layout engine, so nothing in the suite can see a computed style — and two invisible visual regressions did ship mid-branch, caught by reading rather than by tests. The checks that matter: the header at 375px, the menu's focus behaviour and Escape, the end-session confirmation surviving the menu closing, 1440px parity with `main`, and both themes.

`tests/smoke.sh` was not run. It checks that a fresh environment scores 0 and the reference solutions score 100%; this branch touches the hub's session lifecycle and the SPA's chrome, and neither grading nor the exam environment is in the diff.

## Reviewing the commits

Twenty-eight commits, ordered as the plan's twelve tasks plus their review fixes, so each is small and thematic and the tree is green at every one. `docs/history/specs/2026-08-05-hosted-rebuild-and-responsive-header-design.md` carries the reasoning and `docs/history/plans/2026-08-05-hosted-rebuild-and-responsive-header.md` the task breakdown; both are the first two commits, so reading them first makes the rest read as intended.
