### PR TITLE
bank: deepen the CKAD pool to 44 and mix each sitting by level

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ If you touched `site/`, also run `bash site/build.sh --check`.
 
 | Gate | Proves |
 |---|---|
-| `bank-weights.sh` | Each question's `weight:` equals the sum of its `# points:` headers, `exam.yaml` and the `q*/` directories agree, and the domain balance matches the curriculum |
+| `bank-weights.sh` | Each question's `weight:` equals the sum of its `# points:` headers, `exam.yaml` and the `q*/` directories agree, and the domain balance matches the curriculum. For a bank declaring `spec.difficultyMix`, also that every question's level matches its `targetSeconds` band, that the pool is deep enough per domain and level to hold the mix, and that a drawn sitting fits the clock |
 | `check-lint.sh` | No validator grades spelling instead of behaviour, and every check carries an exact `# points: N` header |
 | `check-lib.sh` | The `banks/_lib/checks.sh` helpers still treat `0.1` and `100m`, or `1Gi` and `1024Mi`, as the same answer |
 | `bank-hints.sh` | Every hinted question has both tiers, and no hint shares 120 consecutive characters with its solution |

--- a/README.md
+++ b/README.md
@@ -44,10 +44,13 @@ what creates its cluster, and the page shows each phase as it completes.
 
 | Bank | Engine | Questions | Per attempt | Time | Pass |
 |---|---|---|---|---|---|
-| CKAD Mock Exam 01 | Hands-on | 26 | 22 drawn | 120 min | 66% |
+| CKAD Mock Exam | Hands-on | 26 | 17 drawn | 120 min | 66% |
 | KCNA Mock Exam | Multiple choice | 97 | 65 drawn | 90 min | 75% |
 
 - Every draw is stratified to the published curriculum weights.
+- CKAD also mixes the draw across three levels — quick, core and deep, set
+  by how long a task should take — so a sitting is not a wall of long
+  multi-step tasks.
 - CKAD runs against a two-node Kubernetes 1.35 cluster.
 - KCNA ships a full explanation for every question.
 - CKA, KCSA and CKS appear in the catalog as coming soon.
@@ -155,8 +158,7 @@ Calibration choices, not gaps.
 | Divergence | Reason |
 |---|---|
 | Harder than the real exam | Pass here, be comfortable there. |
-| 22 questions vs a real CKAD's 15–20 | More coverage per sitting. Point budgets still track curriculum weights within 2 points. |
-| Two-node cluster | Enough for scheduling, affinity and DaemonSet questions, and it fits in 9GB. |
+| Two-node cluster | Headroom for scheduling, affinity and DaemonSet questions, and it fits in 9GB. No question needs the second node today — CKAD has no node-management competency. |
 | Ingress and NodePorts published to your host | Convenience for debugging. No grading check depends on it. |
 | Documentation allowlist has no deny-override | Allowing `kubernetes.io` also allows `discuss.kubernetes.io`. |
 | Solutions readable in Training | That is the point of the mode. Exam and Mastery keep the gate. |

--- a/banks/ckad-mock-01/exam.yaml
+++ b/banks/ckad-mock-01/exam.yaml
@@ -2,7 +2,7 @@ apiVersion: sim.kubestronaut.dev/v1alpha2
 kind: Exam
 metadata:
   name: ckad-mock-01
-  title: CKAD Mock Exam 01
+  title: CKAD Mock Exam
   certification: CKAD
   description: >-
     Developer-track exercises across the full CKAD curriculum: workloads
@@ -14,13 +14,17 @@ spec:
   duration: 120m
   passingScore: 66
   kubernetesVersion: "1.35"
-  examLength: 22
+  examLength: 17
   domainWeights:
     Application Design and Build: 20
     Application Deployment: 20
     Application Environment, Configuration and Security: 25
     Application Observability and Maintenance: 15
     Services and Networking: 20
+  difficultyMix:
+    quick: 30
+    core: 45
+    deep: 25
   environment:
     provider: kind
     nodes: 2
@@ -34,6 +38,8 @@ spec:
       instance: instance-1
       domain: Application Environment, Configuration and Security
       weight: 9
+      targetSeconds: 300
+      difficulty: core
       docs:
         - label: Namespaces
           url: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
@@ -44,6 +50,8 @@ spec:
       instance: instance-1
       domain: Application Deployment
       weight: 9
+      targetSeconds: 560
+      difficulty: deep
       docs:
         - label: Deployments
           url: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
@@ -52,6 +60,8 @@ spec:
       instance: instance-2
       domain: Services and Networking
       weight: 11
+      targetSeconds: 600
+      difficulty: deep
       docs:
         - label: Network policies
           url: https://kubernetes.io/docs/concepts/services-networking/network-policies/
@@ -60,6 +70,8 @@ spec:
       instance: instance-2
       domain: Application Design and Build
       weight: 6
+      targetSeconds: 660
+      difficulty: deep
       docs:
         - label: CronJob
           url: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
@@ -70,6 +82,8 @@ spec:
       instance: instance-1
       domain: Application Design and Build
       weight: 6
+      targetSeconds: 660
+      difficulty: deep
       docs:
         - label: Init containers
           url: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
@@ -80,6 +94,8 @@ spec:
       instance: instance-2
       domain: Application Environment, Configuration and Security
       weight: 9
+      targetSeconds: 570
+      difficulty: deep
       docs:
         - label: ConfigMaps
           url: https://kubernetes.io/docs/concepts/configuration/configmap/
@@ -90,6 +106,8 @@ spec:
       instance: instance-1
       domain: Application Environment, Configuration and Security
       weight: 9
+      targetSeconds: 400
+      difficulty: core
       docs:
         - label: Security contexts
           url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -98,6 +116,8 @@ spec:
       instance: instance-2
       domain: Services and Networking
       weight: 11
+      targetSeconds: 330
+      difficulty: core
       docs:
         - label: Ingress
           url: https://kubernetes.io/docs/concepts/services-networking/ingress/
@@ -106,6 +126,8 @@ spec:
       instance: instance-1
       domain: Application Design and Build
       weight: 6
+      targetSeconds: 480
+      difficulty: core
       docs:
         - label: Container images
           url: https://kubernetes.io/docs/concepts/containers/images/
@@ -114,6 +136,8 @@ spec:
       instance: instance-2
       domain: Application Design and Build
       weight: 6
+      targetSeconds: 570
+      difficulty: deep
       docs:
         - label: Persistent volumes
           url: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
@@ -124,11 +148,15 @@ spec:
       instance: instance-1
       domain: Application Deployment
       weight: 9
+      targetSeconds: 450
+      difficulty: core
     - id: q12
       title: Roll out, then roll back
       instance: instance-2
       domain: Application Deployment
       weight: 9
+      targetSeconds: 570
+      difficulty: deep
       docs:
         - label: Deployment rollouts and rollbacks
           url: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
@@ -137,6 +165,8 @@ spec:
       instance: instance-1
       domain: Application Deployment
       weight: 9
+      targetSeconds: 450
+      difficulty: core
       docs:
         - label: Kustomize
           url: https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/
@@ -145,6 +175,8 @@ spec:
       instance: instance-2
       domain: Application Environment, Configuration and Security
       weight: 9
+      targetSeconds: 640
+      difficulty: deep
       docs:
         - label: Secrets
           url: https://kubernetes.io/docs/concepts/configuration/secret/
@@ -153,6 +185,8 @@ spec:
       instance: instance-1
       domain: Application Environment, Configuration and Security
       weight: 9
+      targetSeconds: 600
+      difficulty: deep
       docs:
         - label: ServiceAccounts for Pods
           url: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
@@ -161,6 +195,8 @@ spec:
       instance: instance-2
       domain: Application Observability and Maintenance
       weight: 8
+      targetSeconds: 300
+      difficulty: core
       docs:
         - label: Liveness, readiness and startup probes
           url: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
@@ -169,11 +205,15 @@ spec:
       instance: instance-1
       domain: Application Observability and Maintenance
       weight: 8
+      targetSeconds: 600
+      difficulty: deep
     - id: q18
       title: Bring a manifest up to date
       instance: instance-2
       domain: Application Observability and Maintenance
       weight: 8
+      targetSeconds: 450
+      difficulty: core
       docs:
         - label: Deprecated API migration guide
           url: https://kubernetes.io/docs/reference/using-api/deprecation-guide/
@@ -182,6 +222,8 @@ spec:
       instance: instance-1
       domain: Services and Networking
       weight: 11
+      targetSeconds: 240
+      difficulty: quick
       docs:
         - label: Services
           url: https://kubernetes.io/docs/concepts/services-networking/service/
@@ -190,6 +232,8 @@ spec:
       instance: instance-2
       domain: Services and Networking
       weight: 11
+      targetSeconds: 240
+      difficulty: quick
       docs:
         - label: Service types
           url: https://kubernetes.io/docs/concepts/services-networking/service/
@@ -198,16 +242,22 @@ spec:
       instance: instance-1
       domain: Application Design and Build
       weight: 6
+      targetSeconds: 240
+      difficulty: quick
     - id: q22
       title: The ambassador pattern
       instance: instance-2
       domain: Application Design and Build
       weight: 6
+      targetSeconds: 240
+      difficulty: quick
     - id: q23
       title: Blue/green cutover
       instance: instance-1
       domain: Application Deployment
       weight: 9
+      targetSeconds: 150
+      difficulty: quick
       docs:
         - label: Services
           url: https://kubernetes.io/docs/concepts/services-networking/service/
@@ -218,6 +268,8 @@ spec:
       instance: instance-2
       domain: Application Environment, Configuration and Security
       weight: 9
+      targetSeconds: 450
+      difficulty: core
       docs:
         - label: Security contexts
           url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -228,6 +280,8 @@ spec:
       instance: instance-1
       domain: Application Observability and Maintenance
       weight: 8
+      targetSeconds: 420
+      difficulty: core
       docs:
         - label: Ephemeral containers
           url: https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/
@@ -238,6 +292,8 @@ spec:
       instance: instance-2
       domain: Application Design and Build
       weight: 6
+      targetSeconds: 210
+      difficulty: quick
       docs:
         - label: Images and pull policy
           url: https://kubernetes.io/docs/concepts/containers/images/

--- a/banks/ckad-mock-01/exam.yaml
+++ b/banks/ckad-mock-01/exam.yaml
@@ -49,7 +49,7 @@ spec:
       title: Fix a failing Deployment
       instance: instance-1
       domain: Application Deployment
-      weight: 9
+      weight: 7
       targetSeconds: 560
       difficulty: deep
       docs:
@@ -59,7 +59,7 @@ spec:
       title: NetworkPolicy lockdown
       instance: instance-2
       domain: Services and Networking
-      weight: 11
+      weight: 9
       targetSeconds: 600
       difficulty: deep
       docs:
@@ -69,7 +69,7 @@ spec:
       title: CronJob and Job
       instance: instance-2
       domain: Application Design and Build
-      weight: 6
+      weight: 9
       targetSeconds: 660
       difficulty: deep
       docs:
@@ -81,7 +81,7 @@ spec:
       title: Init container and native sidecar
       instance: instance-1
       domain: Application Design and Build
-      weight: 6
+      weight: 9
       targetSeconds: 660
       difficulty: deep
       docs:
@@ -115,7 +115,7 @@ spec:
       title: Route two Services with one Ingress
       instance: instance-2
       domain: Services and Networking
-      weight: 11
+      weight: 9
       targetSeconds: 330
       difficulty: core
       docs:
@@ -125,7 +125,7 @@ spec:
       title: Build, push and run a container image
       instance: instance-1
       domain: Application Design and Build
-      weight: 6
+      weight: 9
       targetSeconds: 480
       difficulty: core
       docs:
@@ -135,7 +135,7 @@ spec:
       title: Persistent and ephemeral storage
       instance: instance-2
       domain: Application Design and Build
-      weight: 6
+      weight: 9
       targetSeconds: 570
       difficulty: deep
       docs:
@@ -147,14 +147,14 @@ spec:
       title: Helm release management
       instance: instance-1
       domain: Application Deployment
-      weight: 9
+      weight: 7
       targetSeconds: 450
       difficulty: core
     - id: q12
       title: Roll out, then roll back
       instance: instance-2
       domain: Application Deployment
-      weight: 9
+      weight: 7
       targetSeconds: 570
       difficulty: deep
       docs:
@@ -164,7 +164,7 @@ spec:
       title: Kustomize overlay
       instance: instance-1
       domain: Application Deployment
-      weight: 9
+      weight: 7
       targetSeconds: 450
       difficulty: core
       docs:
@@ -194,7 +194,7 @@ spec:
       title: Health checks
       instance: instance-2
       domain: Application Observability and Maintenance
-      weight: 8
+      weight: 7
       targetSeconds: 300
       difficulty: core
       docs:
@@ -204,14 +204,14 @@ spec:
       title: Find out why two workloads are broken
       instance: instance-1
       domain: Application Observability and Maintenance
-      weight: 8
+      weight: 7
       targetSeconds: 600
       difficulty: deep
     - id: q18
       title: Bring a manifest up to date
       instance: instance-2
       domain: Application Observability and Maintenance
-      weight: 8
+      weight: 7
       targetSeconds: 450
       difficulty: core
       docs:
@@ -221,7 +221,7 @@ spec:
       title: A Service that reaches nothing
       instance: instance-1
       domain: Services and Networking
-      weight: 11
+      weight: 9
       targetSeconds: 240
       difficulty: quick
       docs:
@@ -231,7 +231,7 @@ spec:
       title: Expose a Deployment on a node port
       instance: instance-2
       domain: Services and Networking
-      weight: 11
+      weight: 9
       targetSeconds: 240
       difficulty: quick
       docs:
@@ -241,21 +241,21 @@ spec:
       title: The adapter pattern
       instance: instance-1
       domain: Application Design and Build
-      weight: 6
+      weight: 9
       targetSeconds: 240
       difficulty: quick
     - id: q22
       title: The ambassador pattern
       instance: instance-2
       domain: Application Design and Build
-      weight: 6
+      weight: 9
       targetSeconds: 240
       difficulty: quick
     - id: q23
       title: Blue/green cutover
       instance: instance-1
       domain: Application Deployment
-      weight: 9
+      weight: 7
       targetSeconds: 150
       difficulty: quick
       docs:
@@ -279,7 +279,7 @@ spec:
       title: Debug a Pod you cannot get into
       instance: instance-1
       domain: Application Observability and Maintenance
-      weight: 8
+      weight: 7
       targetSeconds: 420
       difficulty: core
       docs:
@@ -291,7 +291,7 @@ spec:
       title: Pull policy and shutdown budget
       instance: instance-2
       domain: Application Design and Build
-      weight: 6
+      weight: 9
       targetSeconds: 210
       difficulty: quick
       docs:
@@ -299,3 +299,183 @@ spec:
           url: https://kubernetes.io/docs/concepts/containers/images/
         - label: Pod lifecycle
           url: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
+    - id: q27
+      title: Defaults from a LimitRange
+      instance: instance-1
+      domain: Application Environment, Configuration and Security
+      weight: 9
+      targetSeconds: 240
+      difficulty: quick
+      docs:
+        - label: Limit ranges
+          url: https://kubernetes.io/docs/concepts/policy/limit-range/
+    - id: q28
+      title: Pull from a private registry
+      instance: instance-2
+      domain: Application Environment, Configuration and Security
+      weight: 9
+      targetSeconds: 240
+      difficulty: quick
+      docs:
+        - label: Pull an image from a private registry
+          url: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    - id: q29
+      title: Discover and use a custom resource
+      instance: instance-1
+      domain: Application Environment, Configuration and Security
+      weight: 9
+      targetSeconds: 420
+      difficulty: core
+      docs:
+        - label: Custom resources
+          url: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
+    - id: q30
+      title: Grant a ServiceAccount only what it needs
+      instance: instance-2
+      domain: Application Environment, Configuration and Security
+      weight: 9
+      targetSeconds: 480
+      difficulty: core
+      docs:
+        - label: RBAC authorization
+          url: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+    - id: q31
+      title: Pause a rollout, then resume it
+      instance: instance-1
+      domain: Application Deployment
+      weight: 7
+      targetSeconds: 240
+      difficulty: quick
+      docs:
+        - label: Deployments
+          url: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+    - id: q32
+      title: Restart a Deployment in place
+      instance: instance-2
+      domain: Application Deployment
+      weight: 7
+      targetSeconds: 210
+      difficulty: quick
+      docs:
+        - label: kubectl quick reference
+          url: https://kubernetes.io/docs/reference/kubectl/quick-reference/
+    - id: q33
+      title: A canary split by replica count
+      instance: instance-1
+      domain: Application Deployment
+      weight: 7
+      targetSeconds: 450
+      difficulty: core
+      docs:
+        - label: Deployments
+          url: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+    - id: q34
+      title: Install a Helm release from a values file
+      instance: instance-2
+      domain: Application Deployment
+      weight: 7
+      targetSeconds: 480
+      difficulty: core
+      docs:
+        - label: Values files
+          url: https://helm.sh/docs/chart_template_guide/values_files/
+    - id: q35
+      title: Patch a Kustomize base
+      instance: instance-1
+      domain: Application Deployment
+      weight: 7
+      targetSeconds: 450
+      difficulty: core
+      docs:
+        - label: Declarative management with Kustomize
+          url: https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/
+    - id: q36
+      title: Reach an outside name from inside the cluster
+      instance: instance-2
+      domain: Services and Networking
+      weight: 9
+      targetSeconds: 300
+      difficulty: core
+      docs:
+        - label: Service
+          url: https://kubernetes.io/docs/concepts/services-networking/service/
+    - id: q37
+      title: Terminate TLS at the Ingress
+      instance: instance-1
+      domain: Services and Networking
+      weight: 9
+      targetSeconds: 480
+      difficulty: core
+      docs:
+        - label: Ingress
+          url: https://kubernetes.io/docs/concepts/services-networking/ingress/
+    - id: q38
+      title: Deny everything, then allow one path
+      instance: instance-2
+      domain: Services and Networking
+      weight: 9
+      targetSeconds: 480
+      difficulty: core
+      docs:
+        - label: Network policies
+          url: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+    - id: q39
+      title: A headless Service and the names it publishes
+      instance: instance-1
+      domain: Services and Networking
+      weight: 9
+      targetSeconds: 570
+      difficulty: deep
+      docs:
+        - label: DNS for Services and Pods
+          url: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
+    - id: q40
+      title: A StatefulSet with storage that survives
+      instance: instance-2
+      domain: Application Design and Build
+      weight: 9
+      targetSeconds: 480
+      difficulty: core
+      docs:
+        - label: StatefulSets
+          url: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
+    - id: q41
+      title: Read the events behind a Pending Pod
+      instance: instance-1
+      domain: Application Observability and Maintenance
+      weight: 7
+      targetSeconds: 240
+      difficulty: quick
+      docs:
+        - label: Debug Pods
+          url: https://kubernetes.io/docs/tasks/debug/debug-application/debug-pods/
+    - id: q42
+      title: Report on workloads with custom columns
+      instance: instance-2
+      domain: Application Observability and Maintenance
+      weight: 7
+      targetSeconds: 210
+      difficulty: quick
+      docs:
+        - label: kubectl quick reference
+          url: https://kubernetes.io/docs/reference/kubectl/quick-reference/
+    - id: q43
+      title: A container that keeps failing its liveness probe
+      instance: instance-1
+      domain: Application Observability and Maintenance
+      weight: 7
+      targetSeconds: 450
+      difficulty: core
+      docs:
+        - label: Configure probes
+          url: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+    - id: q44
+      title: A Job that never finishes
+      instance: instance-2
+      domain: Application Observability and Maintenance
+      weight: 7
+      targetSeconds: 570
+      difficulty: deep
+      docs:
+        - label: Jobs
+          url: https://kubernetes.io/docs/concepts/workloads/controllers/job/

--- a/banks/ckad-mock-01/q02/validate.d/20_ready.sh
+++ b/banks/ckad-mock-01/q02/validate.d/20_ready.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 2
+# points: 1
 # desc: 3/3 replicas ready
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q02/validate.d/40_strategy.sh
+++ b/banks/ckad-mock-01/q02/validate.d/40_strategy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 2
+# points: 1
 # desc: rollingUpdate maxSurge=1 maxUnavailable=0
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q03/validate.d/20_ingress.sh
+++ b/banks/ckad-mock-01/q03/validate.d/20_ingress.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 3
+# points: 2
 # desc: single ingress rule: from role=frontend pods, TCP 80 only
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q03/validate.d/40_enforced.sh
+++ b/banks/ckad-mock-01/q03/validate.d/40_enforced.sh
@@ -8,8 +8,12 @@ evidence() {
   show_why "$1"
 }
 
-api=$(kubectl -n orbit get pod -l role=api \
-  -o jsonpath='{.items[?(@.status.phase=="Running")].status.podIP}' 2>/dev/null | awk '{print $1}')
+pod=$(kubectl -n orbit get pod -l role=api -o json 2>/dev/null \
+  | jq -r 'first(.items[]
+             | select(.status.phase == "Running" and (.status.podIP // "") != "")
+             | "\(.metadata.name) \(.status.podIP)")')
+api_pod=${pod%% *}
+api=${pod##* }
 [ -n "$api" ] || {
   echo "no running api Pod to test against"
   show_actual text "$(kubectl -n orbit get pod --show-labels 2>/dev/null)"
@@ -17,20 +21,77 @@ api=$(kubectl -n orbit get pod -l role=api \
   exit 1
 }
 
+np=$(kubectl -n orbit get netpol api-guard -o json 2>/dev/null)
+
+# A podSelector written the way kubectl takes a selector, so the Pods it really
+# picks can be listed rather than guessed at. An empty podSelector prints
+# nothing, which is also how it selects every Pod in the Namespace.
+selector_of() {
+  printf '%s' "$1" | jq -r '
+    (.spec.podSelector // {}) as $s
+    | (($s.matchLabels // {}) | to_entries | map("\(.key)=\(.value)"))
+      + (($s.matchExpressions // []) | map(
+          if .operator == "In" then "\(.key) in (\(.values | join(",")))"
+          elif .operator == "NotIn" then "\(.key) notin (\(.values | join(",")))"
+          elif .operator == "Exists" then .key
+          else "!\(.key)" end))
+    | join(",")' 2>/dev/null
+}
+
+selects_the_api_pod() {
+  local sel
+  sel=$(selector_of "$np")
+  [ -n "$sel" ] || {
+    has_name "$(kubectl -n orbit get pod -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)" "$api_pod"
+    return
+  }
+  has_name "$(kubectl -n orbit get pod -l "$sel" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)" "$api_pod"
+}
+
+# Every check runs on its own, so this re-reads what 10_np-exists.sh scores.
+# Until something governs ingress to THESE Pods and names who may connect, the
+# api Pods are unrestricted and every Pod in the cluster reaches them: a
+# successful request would then be evidence that no policy exists rather than
+# evidence that this one permits the traffic.
+guarded=false
+if [ -n "$np" ] \
+  && printf '%s' "$np" | jq -e '[.spec.policyTypes[]?] | index("Ingress")' >/dev/null 2>&1 \
+  && printf '%s' "$np" | jq -e '[.spec.ingress[]? | select(((.from // []) | length) == 0)] | length == 0' >/dev/null 2>&1 \
+  && selects_the_api_pod; then
+  guarded=true
+fi
+
 reaches() {
   kubectl -n orbit exec "deploy/$1" -- \
     wget -q -T 5 -O /dev/null "http://${api}:80" 2>/dev/null
 }
 
-crit 2 "frontend still reaches api on port 80" \
-  "frontend cannot reach api on port 80, but the policy should allow it" \
-  "The policy is denying traffic it was supposed to permit. An ingress rule allows a source only if BOTH halves match — the peer's labels and the destination port — so a rule naming the wrong label, or restricted to the wrong port, denies frontend just as completely as no rule at all would." \
-  -- reaches frontend
+allowed_by_the_policy() { [ "$guarded" = true ] && reaches frontend; }
+
+if [ "$guarded" = true ]; then
+  allowed_msg="frontend cannot reach api on port 80, but the policy should allow it"
+else
+  allowed_msg="nothing is governing ingress to the api Pods, so frontend reaching them counts for nothing yet — api-guard has to select those Pods, list Ingress, and say who may connect"
+fi
+
+# A request that never leaves is not a denial. exec into a Deployment with no
+# ready Pod fails exactly like a dropped packet, so deleting metrics would
+# otherwise score the denial it was seeded to demonstrate.
+live() {
+  n=$(kubectl -n orbit get deploy "$1" -o jsonpath='{.status.readyReplicas}' 2>/dev/null)
+  [ -n "$n" ] && [ "$n" -ge 1 ] 2>/dev/null
+}
+denied_from_a_live_source() { live metrics && negate reaches metrics; }
+
+crit 2 "api-guard is in force and frontend still reaches api on port 80" \
+  "$allowed_msg" \
+  "Reaching the api Pods only means the policy allows it once the policy applies to them, which is why the two are scored as one thing. With no policy selecting those Pods — or with one whose ingress rule names no peer at all — they are open to everything and frontend's request succeeds exactly as it did before the question was asked. Once the policy is in force, an ingress rule allows a source only if BOTH halves match — the peer's labels and the destination port — so a rule naming the wrong label, or restricted to the wrong port, denies frontend just as completely as no rule at all would." \
+  -- allowed_by_the_policy
 
 crit 3 "metrics is denied" \
-  "metrics reached api on port 80 — ingress is not restricted to role=frontend" \
+  "metrics reached api on port 80 — ingress is not restricted to role=frontend, or metrics has no ready Pod to send one from" \
   "Everything that is not explicitly allowed has to be denied, and metrics got through. Either spec.podSelector matches no Pod — a policy that protects nothing is not a policy that allows everything, it simply never applies — or the ingress rule's peer selector is wider than role=frontend." \
-  -- negate reaches metrics
+  -- denied_from_a_live_source
 
 crit_all_passed || evidence "$(crit_why)"
 report "policy enforced: frontend allowed, metrics denied"

--- a/banks/ckad-mock-01/q03/validate.d/40_enforced.sh
+++ b/banks/ckad-mock-01/q03/validate.d/40_enforced.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 5
+# points: 4
 # desc: the policy is actually enforced — frontend reaches api, metrics does not
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q04/validate.d/10_cronjob.sh
+++ b/banks/ckad-mock-01/q04/validate.d/10_cronjob.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 2
+# points: 3
 # desc: CronJob log-rotate runs every 5 minutes, forbids overlap, keeps 2/1 history
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q04/validate.d/30_job-spec.sh
+++ b/banks/ckad-mock-01/q04/validate.d/30_job-spec.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 2
+# points: 3
 # desc: Job backfill: 3 completions, parallelism 2, backoffLimit 2, container worker
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q04/validate.d/40_job-complete.sh
+++ b/banks/ckad-mock-01/q04/validate.d/40_job-complete.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 1
+# points: 2
 # desc: Job backfill completed, and its succeeded count is recorded on the instance
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q05/validate.d/10_sidecar.sh
+++ b/banks/ckad-mock-01/q05/validate.d/10_sidecar.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 2
+# points: 3
 # desc: shipper is a native sidecar (initContainers entry with restartPolicy Always)
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q05/validate.d/20_init.sh
+++ b/banks/ckad-mock-01/q05/validate.d/20_init.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 1
+# points: 2
 # desc: init container wait-for-source exists, is not a sidecar, and mounts nothing
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q05/validate.d/20_init.sh
+++ b/banks/ckad-mock-01/q05/validate.d/20_init.sh
@@ -9,24 +9,34 @@ evidence() {
 }
 
 sel='{.spec.template.spec.initContainers[?(@.name=="wait-for-source")]'
+names=$(kubectl -n lyra get deploy feed-writer \
+  -o jsonpath='{.spec.template.spec.initContainers[*].name}' 2>/dev/null)
 img=$(kubectl -n lyra get deploy feed-writer -o jsonpath="${sel}.image}" 2>/dev/null)
 policy=$(kubectl -n lyra get deploy feed-writer -o jsonpath="${sel}.restartPolicy}" 2>/dev/null)
 mounts=$(kubectl -n lyra get deploy feed-writer -o jsonpath="${sel}.volumeMounts[*].name}" 2>/dev/null)
+
+# Both of the criteria below grade an ABSENCE, and an absence only counts when
+# the thing it qualifies exists. Before feed-writer is written there is no
+# wait-for-source, so it has no restartPolicy and no volumeMounts either — which
+# scored a candidate who had done nothing two of these four weights.
+exists() { has_name "$names" wait-for-source; }
+plain_init_container() { exists && [ -z "$policy" ]; }
+mounts_nothing() { exists && [ -z "$mounts" ]; }
 
 crit 2 "an init container wait-for-source runs busybox:1.37" \
   "wait-for-source image is '$img'" \
   "There is no init container called wait-for-source carrying that image. Init containers are a list of their own beside containers, not a container with a flag set — an entry in the wrong list is a different thing entirely." \
   -- [ "$img" = "busybox:1.37" ]
 
-crit 1 "it is a plain init container, not a sidecar" \
-  "wait-for-source has restartPolicy '$policy'; it must be a plain init container" \
-  "restartPolicy: Always on an init container is what makes it a sidecar, and a sidecar never finishes. This container's job is to block until the Service answers and then exit, so with that field set the Pod would sit in Init forever and the main container would never start." \
-  -- [ -z "$policy" ]
+crit 1 "it exists and is a plain init container, not a sidecar" \
+  "wait-for-source has restartPolicy '$policy' (init containers: $(name_list "$names"))" \
+  "restartPolicy: Always on an init container is what makes it a sidecar, and a sidecar never finishes. This container's job is to block until the Service answers and then exit, so with that field set the Pod would sit in Init forever and the main container would never start. A container that was never written is not a sidecar either, which is why this asks that wait-for-source be in the initContainers list before reading the field." \
+  -- plain_init_container
 
-crit 1 "it mounts nothing" \
-  "wait-for-source should mount nothing, mounts: '$mounts'" \
-  "This container only waits for the Service to answer; it produces nothing for anyone to read. The shared emptyDir belongs to writer and shipper, and mounting it here would claim a relationship the question does not describe." \
-  -- [ -z "$mounts" ]
+crit 1 "it exists and mounts nothing" \
+  "wait-for-source should mount nothing, mounts: '$mounts' (init containers: $(name_list "$names"))" \
+  "This container only waits for the Service to answer; it produces nothing for anyone to read. The shared emptyDir belongs to writer and shipper, and mounting it here would claim a relationship the question does not describe. Mounting nothing is only an answer once there is a wait-for-source to mount nothing." \
+  -- mounts_nothing
 
 crit_all_passed || evidence "$(crit_why)"
 report "init container ok"

--- a/banks/ckad-mock-01/q05/validate.d/30_volume.sh
+++ b/banks/ckad-mock-01/q05/validate.d/30_volume.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 1
+# points: 2
 # desc: emptyDir feed-logs mounted at /var/log/feed in both writer and shipper
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q08/validate.d/10_ingress.sh
+++ b/banks/ckad-mock-01/q08/validate.d/10_ingress.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 5
+# points: 4
 # desc: Ingress helios-routes uses class nginx, host helios.sim.local, two Prefix paths
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q08/validate.d/20_routes.sh
+++ b/banks/ckad-mock-01/q08/validate.d/20_routes.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 6
+# points: 5
 # desc: the controller really routes / to storefront and /checkout to checkout
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q09/validate.d/20_image.sh
+++ b/banks/ckad-mock-01/q09/validate.d/20_image.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 2
+# points: 3
 # desc: image registry:5000/pulsar-agent:v1 was built, and carries the new value
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q09/validate.d/30_pushed.sh
+++ b/banks/ckad-mock-01/q09/validate.d/30_pushed.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 1
+# points: 2
 # desc: the image was pushed to registry:5000
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q09/validate.d/40_running.sh
+++ b/banks/ckad-mock-01/q09/validate.d/40_running.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 1
+# points: 2
 # desc: a container named pulsar-agent is running from that image
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q10/validate.d/10_pv.sh
+++ b/banks/ckad-mock-01/q10/validate.d/10_pv.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 2
+# points: 3
 # desc: PV archive-pv: 2Gi, RWO, hostPath /mnt/archive, class manual, Retain
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q10/validate.d/20_pvc.sh
+++ b/banks/ckad-mock-01/q10/validate.d/20_pvc.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 2
+# points: 3
 # desc: PVC archive-pvc requests 1Gi RWO on class manual and is Bound to archive-pv
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q10/validate.d/30_pod.sh
+++ b/banks/ckad-mock-01/q10/validate.d/30_pod.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 1
+# points: 2
 # desc: Pod archiver mounts the claim at /var/archive and an emptyDir at /var/scratch
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q11/validate.d/10_uninstalled.sh
+++ b/banks/ckad-mock-01/q11/validate.d/10_uninstalled.sh
@@ -31,4 +31,3 @@ crit 2 "the failed release report-legacy was found and uninstalled" \
 
 crit_all_passed || evidence "$(crit_why)"
 report "releases uninstalled"
-echo "uninstalls ok"

--- a/banks/ckad-mock-01/q11/validate.d/20_upgraded.sh
+++ b/banks/ckad-mock-01/q11/validate.d/20_upgraded.sh
@@ -26,15 +26,20 @@ newest=$(printf '1.0.0\n%s\n' "$version" | sort -V | tail -1)
 moved_on()  { [ "$version" != "1.0.0" ] && [ "$newest" = "$version" ]; }
 revised()   { [ "$revision" -ge 2 ] 2>/dev/null; }
 
+# 'deployed' is the state report-api-v2 was seeded in, so on its own it grades
+# nothing. It says something once an upgrade has been through the release: a
+# failed upgrade records a new revision and leaves the release marked failed.
+upgrade_deployed() { revised && [ "$status" = "deployed" ]; }
+
 crit 2 "on a chart newer than sim-web-1.0.0" \
   "chart is '$chart'; it must be newer than sim-web-1.0.0" \
   "An upgrade re-renders the release from a chart version, and the release is still on the one it was installed with. The repo's own index is the authority on which versions exist — guessing a number that is not published just fails, and asking for no version at all takes the newest." \
   -- moved_on
 
-crit 1 "the release is deployed, not failed" \
-  "release status is '$status', want deployed" \
-  "The release exists but is not in the deployed state. An upgrade that fails leaves the release marked failed with the previous revision's objects still running, so the cluster can look completely healthy while Helm considers the release broken." \
-  -- [ "$status" = "deployed" ]
+crit 1 "the upgrade left the release deployed, not failed" \
+  "release is at revision '$revision' with status '$status'; an upgrade that lands leaves it deployed at revision 2 or later" \
+  "No successful upgrade has been through this release. It was installed deployed and revision 1 means nothing has been applied since, so the status alone proves nothing here. An upgrade that fails records a new revision and marks the release failed with the previous revision's objects still running, so the cluster can look completely healthy while Helm considers the release broken." \
+  -- upgrade_deployed
 
 crit 1 "the upgrade went through Helm" \
   "revision is '$revision'; an upgrade should have produced at least 2" \

--- a/banks/ckad-mock-01/q11/validate.d/20_upgraded.sh
+++ b/banks/ckad-mock-01/q11/validate.d/20_upgraded.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 3
+# points: 2
 # desc: report-api-v2 was upgraded to a newer sim-web chart and is deployed
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q11/validate.d/30_installed.sh
+++ b/banks/ckad-mock-01/q11/validate.d/30_installed.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 3
+# points: 2
 # desc: report-cache installed from sim-cache with 2 replicas set via values
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q12/validate.d/10_rolled-back.sh
+++ b/banks/ckad-mock-01/q12/validate.d/10_rolled-back.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 3
+# points: 2
 # desc: payments-api is back on nginx:1.27-alpine with 4 ready replicas
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q12/validate.d/10_rolled-back.sh
+++ b/banks/ckad-mock-01/q12/validate.d/10_rolled-back.sh
@@ -12,11 +12,19 @@ img=$(kubectl -n draco get deploy payments-api \
   -o jsonpath='{.spec.template.spec.containers[?(@.name=="api")].image}' 2>/dev/null)
 spec=$(kubectl -n draco get deploy payments-api -o jsonpath='{.spec.replicas}' 2>/dev/null)
 ready=$(kubectl -n draco get deploy payments-api -o jsonpath='{.status.readyReplicas}' 2>/dev/null)
+rev=$(kubectl -n draco get deploy payments-api \
+  -o jsonpath='{.metadata.annotations.deployment\.kubernetes\.io/revision}' 2>/dev/null)
 
-crit 1 "back on nginx:1.27-alpine" \
-  "image is '$img', want nginx:1.27-alpine" \
-  "A rollback restores the POD TEMPLATE of an earlier revision — image, env, probes, everything the ReplicaSet was created from — and the image is the visible part of that. Reaching the old tag by editing the image back arrives at the same string without ever using the history, which is what the revision count beside this check exists to tell apart." \
-  -- [ "$img" = "nginx:1.27-alpine" ]
+# This is a round trip: the image it ends on is the image it started on, so the
+# tag alone is as true of a Deployment nobody touched as of a finished answer.
+# The revision counter is what separates the two — an upgrade and an undo leave
+# it at 3 or more, and nothing at all leaves it at 1.
+came_back() { [ "$img" = "nginx:1.27-alpine" ] && [ -n "$rev" ] && [ "$rev" -ge 3 ] 2>/dev/null; }
+
+crit 1 "back on nginx:1.27-alpine, having been off it" \
+  "image is '$img' at revision '$rev'; want nginx:1.27-alpine arrived at by an upgrade and a rollback (revision 3 or more)" \
+  "A rollback restores the POD TEMPLATE of an earlier revision — image, env, probes, everything the ReplicaSet was created from — and the image is the visible part of that. The tag on its own says nothing here, because it is the tag the Deployment started on: what is graded is that it went to 1.29 and came back. Editing the image back by hand arrives at the same string without ever using the history and leaves the revision at 2." \
+  -- came_back
 
 crit 1 "still scaled to 4" \
   "spec.replicas is '$spec', want 4" \

--- a/banks/ckad-mock-01/q12/validate.d/20_history.sh
+++ b/banks/ckad-mock-01/q12/validate.d/20_history.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 4
+# points: 3
 # desc: the upgrade really happened, was annotated, and was undone via rollout
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q13/validate.d/10_overlay.sh
+++ b/banks/ckad-mock-01/q13/validate.d/10_overlay.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 5
+# points: 4
 # desc: the overlay itself renders the prefix, label, image and replica count
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q13/validate.d/20_applied.sh
+++ b/banks/ckad-mock-01/q13/validate.d/20_applied.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 4
+# points: 3
 # desc: the overlay was applied to pavo and is running
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q15/validate.d/20_no-token.sh
+++ b/banks/ckad-mock-01/q15/validate.d/20_no-token.sh
@@ -17,15 +17,22 @@ token_present() {
     test -e /var/run/secrets/kubernetes.io/serviceaccount 2>/dev/null
 }
 
+# Only an absence observed inside a running container counts. exec into a Pod
+# that does not exist fails too, and a bare negate would read that as a pass.
+no_token_mounted() {
+  [ "$phase" = "Running" ] || return 1
+  negate token_present
+}
+
 crit 1 "automountServiceAccountToken is false" \
   "automountServiceAccountToken is '$auto', want false" \
   "automountServiceAccountToken: false is what stops the kubelet projecting a token volume into the container at all. The field exists on both the Pod and the ServiceAccount and the POD's setting wins — setting it on the account is the better default when nothing using it needs API access, setting it on the Pod is the targeted version the question asks for." \
   -- [ "$auto" = "false" ]
 
 crit 1 "nothing is mounted at the token path inside the container" \
-  "a token is still mounted inside the container" \
-  "What is declared and what is projected are different things. A projected volume added by hand mounts a token at that path regardless of the automount setting, and the question asks for nothing to be there at all — which is why this is verified from inside the container rather than from the spec." \
-  -- negate token_present
+  "a token is still mounted inside the container, or there is no running container to look inside" \
+  "What is declared and what is projected are different things. A projected volume added by hand mounts a token at that path regardless of the automount setting, and the question asks for nothing to be there at all — which is why this is verified from inside the container rather than from the spec. An absence only counts when there is a running container to observe it in." \
+  -- no_token_mounted
 
 crit 1 "the Pod is Running" \
   "pod phase is '$phase', want Running" \

--- a/banks/ckad-mock-01/q16/validate.d/10_probes.sh
+++ b/banks/ckad-mock-01/q16/validate.d/10_probes.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 4
+# points: 3
 # desc: startup, readiness and liveness probes with the requested settings
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q17/validate.d/20_crashlog.sh
+++ b/banks/ckad-mock-01/q17/validate.d/20_crashlog.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 3
+# points: 2
 # desc: the dead container's own log message was captured
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q18/validate.d/10_fixed-file.sh
+++ b/banks/ckad-mock-01/q18/validate.d/10_fixed-file.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 3
+# points: 2
 # desc: fixed.yaml uses current apiVersions and legacy.yaml was left alone
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q19/validate.d/10_service.sh
+++ b/banks/ckad-mock-01/q19/validate.d/10_service.sh
@@ -16,6 +16,18 @@ sel=$(kubectl -n serpens get svc inventory -o json 2>/dev/null | jq -r '.spec.se
 target=$(kubectl -n serpens get svc inventory \
   -o jsonpath='{.spec.ports[?(@.port==80)].targetPort}' 2>/dev/null)
 
+# Publishing port 80 is the one thing the broken Service already gets right, so
+# it is scored with the fault it accompanies rather than on its own: the forward
+# has to have moved, and to have moved on targetPort rather than by renumbering
+# the port clients connect to.
+fixed_on_target_port() { [ -n "$target" ] && [ "$target" != "80" ]; }
+
+if [ -n "$target" ]; then
+  port_msg="port 80 still forwards to port 80 — the fault is on targetPort, and nothing has changed it"
+else
+  port_msg="the Service publishes no port 80 for a client to connect to"
+fi
+
 # The question says the Service is wrong in two separate ways, so the two are
 # scored separately: finding the Pods, and reaching the port they listen on.
 crit 2 "selects the Pods" \
@@ -23,10 +35,10 @@ crit 2 "selects the Pods" \
   "A Service finds its Pods by label, never by name. While spec.selector matches no Pod, the EndpointSlice controller has nothing to put in the Service's endpoint list, so a connection is refused rather than forwarded." \
   -- [ "$sel" = "app=inventory" ]
 
-crit 1 "publishes port 80" \
-  "the Service publishes no port 80" \
-  "Clients connect to spec.ports[].port, and the question asks for that to be 80. Nothing in the Service publishes it." \
-  -- [ -n "$target" ]
+crit 1 "fixes the port fault on targetPort, leaving port 80 to clients" \
+  "$port_msg" \
+  "Clients connect to spec.ports[].port and the question asks for that to be 80 — which it already was, so publishing it is not work this question asked for. targetPort is the POD-side port and that is where this fault lives: renumbering port to 8080 forwards to the right place at an address nobody was told to use, and leaving both at 80 forwards to a port nothing is bound to." \
+  -- fixed_on_target_port
 
 crit 1 "targets the port the Pods listen on" \
   "targetPort for port 80 is '$target', want 8080" \

--- a/banks/ckad-mock-01/q19/validate.d/10_service.sh
+++ b/banks/ckad-mock-01/q19/validate.d/10_service.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 4
+# points: 3
 # desc: the Service selects the Pods and targets the port they listen on
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q19/validate.d/20_reachable.sh
+++ b/banks/ckad-mock-01/q19/validate.d/20_reachable.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 6
+# points: 5
 # desc: the Service has both endpoints and really answers from inside the cluster
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q20/validate.d/10_nodeport.sh
+++ b/banks/ckad-mock-01/q20/validate.d/10_nodeport.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 4
+# points: 3
 # desc: status-page is a NodePort Service on port 80 with node port 30081
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q20/validate.d/20_answers.sh
+++ b/banks/ckad-mock-01/q20/validate.d/20_answers.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 6
+# points: 5
 # desc: the node port really answers, from a node address inside the cluster
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q21/validate.d/10_containers.sh
+++ b/banks/ckad-mock-01/q21/validate.d/10_containers.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 1
+# points: 2
 # desc: Pod telemetry runs containers app and adapter on busybox:1.37
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q21/validate.d/20_shared-volume.sh
+++ b/banks/ckad-mock-01/q21/validate.d/20_shared-volume.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 2
+# points: 3
 # desc: an emptyDir named telemetry is mounted at /var/run/telemetry in both containers
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q21/validate.d/30_adapted.sh
+++ b/banks/ckad-mock-01/q21/validate.d/30_adapted.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 3
+# points: 4
 # desc: the adapter really rewrites the app's output into key/value lines
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q22/validate.d/10_containers.sh
+++ b/banks/ckad-mock-01/q22/validate.d/10_containers.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 1
+# points: 2
 # desc: Pod checkout runs app (busybox) and ambassador (nginx), and is Running
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q22/validate.d/20_wiring.sh
+++ b/banks/ckad-mock-01/q22/validate.d/20_wiring.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 2
+# points: 3
 # desc: the ambassador holds the config, and the app knows nothing about the backend
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q22/validate.d/30_proxied.sh
+++ b/banks/ckad-mock-01/q22/validate.d/30_proxied.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 3
+# points: 4
 # desc: the app reaches the backend through localhost, and only through it
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q23/validate.d/10_selector.sh
+++ b/banks/ckad-mock-01/q23/validate.d/10_selector.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 3
+# points: 2
 # desc: the Service selects exactly the green release's Pods and still publishes port 80
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q23/validate.d/10_selector.sh
+++ b/banks/ckad-mock-01/q23/validate.d/10_selector.sh
@@ -34,6 +34,16 @@ green=$(pods_for "app=checkout,release=green")
 port=$(kubectl -n lacerta get svc checkout \
   -o jsonpath='{.spec.ports[?(@.port==80)].port}' 2>/dev/null)
 
+# The question rules this one out: the Service was to be left publishing port
+# 80, so a cutover that moves the port is not a partial answer to anything. It
+# is also true of a Service nobody touched, which is why it is a gate and not a
+# criterion — respecting it earns nothing.
+[ "$port" = "80" ] || {
+  echo "the Service no longer publishes port 80"
+  evidence "The question ruled this out: the Service was to keep publishing port 80, and it no longer does. Clients hold the Service's name and port, not its selector, so a cutover that changes the published port has broken every caller in exchange for a release that was meant to reach them invisibly. Deleting the Service and writing a new one is the usual way to lose it — patch the selector on the Service that is there instead."
+  exit 1
+}
+
 match_pane() {
   show_actual text "$(printf 'selector: %s\nmatches:\n%s\n\ngreen release Pods:\n%s\n' "$sel" "$matched" "$green")"
   show_why "$1"
@@ -44,11 +54,6 @@ crit 2 "selects exactly the green release's Pods" \
   "selector '$sel' matches $(printf '%s\n' "$matched" | grep -c . || true) Pod(s), want exactly the $(printf '%s\n' "$green" | grep -c .) green one(s)" \
   "A Service routes to every Pod its labels match and has no other opinion about them, so 'switch the release' means 'change which labels the selector names'. Matching both releases at once is the failure worth knowing: it does not error, it silently load-balances across the two versions." \
   -- same_set "$matched" "$green" || pane=${pane:-match_pane}
-
-crit 1 "still publishes port 80" \
-  "the Service no longer publishes port 80" \
-  "Clients hold the Service's name and port, not its selector, so a cutover that changes the published port has broken every caller in exchange for the release it was meant to deliver invisibly." \
-  -- [ "$port" = "80" ] || pane=${pane:-evidence}
 
 crit_all_passed || "${pane:-evidence}" "$(crit_why)"
 report "selector cut over to green"

--- a/banks/ckad-mock-01/q23/validate.d/20_serves-green.sh
+++ b/banks/ckad-mock-01/q23/validate.d/20_serves-green.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 5
+# points: 4
 # desc: a request through the Service really comes back from the green release
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q23/validate.d/30_blue-standby.sh
+++ b/banks/ckad-mock-01/q23/validate.d/30_blue-standby.sh
@@ -47,17 +47,20 @@ sel_pane() {
   show_actual text "$(printf 'selector: %s\nmatches:\n%s\n\nblue release Pods:\n%s\n' "$sel" "$matched" "$blue")"
   show_why "$1"
 }
-pane=''
 
-crit 1 "blue is still at full strength" \
-  "checkout-blue has ${ready}/${want} replicas ready, want 2/2" \
-  "Scaling blue to zero costs the same as deleting it: the rollback is no longer instant, because the Pods have to be scheduled and started again before the selector can be moved back." \
-  -- at_full_strength || pane=${pane:-deploy_pane}
+# The question rules this one out: blue was to be left running at its current
+# replica count. Leaving it alone is what a candidate who has done nothing at
+# all has also done, so it earns nothing — scaling it down costs the check.
+at_full_strength || {
+  echo "checkout-blue has ${ready}/${want} replicas ready, want 2/2"
+  deploy_pane "The question ruled this out: blue was to be left running at its current replica count, because it is the rollback. Scaling it to zero costs the same as deleting it — the rollback is no longer instant, since the Pods have to be scheduled and started again before the selector can be moved back."
+  exit 1
+}
 
-crit 1 "and takes no traffic" \
+crit 1 "blue takes no traffic, so it is standing by rather than serving" \
   "the Service still sends traffic to the blue release, so nothing is on standby" \
   "Blue is the rollback only once green is the one being served. Until the selector moves, blue IS the release — and a selector that matches both is worse than either, because it silently splits live traffic across two versions." \
-  -- off_the_service || pane=${pane:-sel_pane}
+  -- off_the_service
 
-crit_all_passed || "${pane:-deploy_pane}" "$(crit_why)"
+crit_all_passed || sel_pane "$(crit_why)"
 report "blue is warm and on standby, ready to roll back to"

--- a/banks/ckad-mock-01/q25/validate.d/10_ephemeral.sh
+++ b/banks/ckad-mock-01/q25/validate.d/10_ephemeral.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 4
+# points: 3
 # desc: an ephemeral container runs busybox:1.37 targeting api, in the original Pod
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q26/validate.d/10_pull-policy.sh
+++ b/banks/ckad-mock-01/q26/validate.d/10_pull-policy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 3
+# points: 4
 # desc: both containers declare imagePullPolicy Never in the Deployment's Pod template
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q26/validate.d/20_grace.sh
+++ b/banks/ckad-mock-01/q26/validate.d/20_grace.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 2
+# points: 3
 # desc: the Pod template asks for a 45 second termination grace period
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q26/validate.d/30_running.sh
+++ b/banks/ckad-mock-01/q26/validate.d/30_running.sh
@@ -30,6 +30,10 @@ template_updated() {
 }
 rolled_out() { template_updated && [ "$want" -gt 0 ] && [ "$ready" = "$want" ]; }
 
+# "every Pod carries the settings" is vacuously true of no Pods at all, which
+# is the state a bank-wide grade with nothing seeded runs in.
+every_live_pod_updated() { [ "$ready" -gt 0 ] && [ "$live" = "$ready" ]; }
+
 list_pane() {
   show_actual text "$(kubectl -n volans get pods -l app=edge-cache 2>/dev/null)"
   show_why "$1"
@@ -55,9 +59,9 @@ crit 1 "the template carries both settings and the rollout completed" \
   -- rolled_out || pane=${pane:-template_pane}
 
 crit 1 "every live Pod carries both settings" \
-  "only ${live} of ${ready} running Pods carry both settings" \
+  "only ${live} of ${ready} running Pods carry both settings — and no Pods at all is not every Pod" \
   "Changing a Deployment's Pod template starts a rollout; it does not edit the Pods that are already there. Until the new ReplicaSet has fully replaced the old one, some of what is running is still the previous spec — 'kubectl -n volans rollout status deploy/edge-cache' is what waits for that." \
-  -- [ "$live" = "$ready" ] || pane=${pane:-settings_pane}
+  -- every_live_pod_updated || pane=${pane:-settings_pane}
 
 crit_all_passed || "${pane:-list_pane}" "$(crit_why)"
 report "rollout complete with both settings live"

--- a/banks/ckad-mock-01/q26/validate.d/30_running.sh
+++ b/banks/ckad-mock-01/q26/validate.d/30_running.sh
@@ -12,10 +12,33 @@ live=$(kubectl -n volans get pods -l app=edge-cache -o json 2>/dev/null \
   | jq -r '[.items[] | select(.spec.terminationGracePeriodSeconds == 45)
             | select([.spec.containers[].imagePullPolicy] | unique == ["Never"])] | length')
 
-rolled_out() { [ "$want" -gt 0 ] && [ "$ready" = "$want" ]; }
+grace=$(kubectl -n volans get deploy edge-cache \
+  -o jsonpath='{.spec.template.spec.terminationGracePeriodSeconds}' 2>/dev/null)
+policies=$(kubectl -n volans get deploy edge-cache \
+  -o jsonpath='{.spec.template.spec.containers[*].imagePullPolicy}' 2>/dev/null)
+
+# The seeded Deployment is healthy at 2/2 before the candidate arrives, so a
+# bare "2 of 2 are ready" is true of an untouched Namespace. A rollout is only
+# evidence of anything once what rolled out is what the question asked for.
+template_updated() {
+  [ "$grace" = "45" ] || return 1
+  [ -n "$policies" ] || return 1
+  local p
+  for p in $policies; do
+    [ "$p" = "Never" ] || return 1
+  done
+}
+rolled_out() { template_updated && [ "$want" -gt 0 ] && [ "$ready" = "$want" ]; }
 
 list_pane() {
   show_actual text "$(kubectl -n volans get pods -l app=edge-cache 2>/dev/null)"
+  show_why "$1"
+}
+template_pane() {
+  show_actual json "$(kubectl -n volans get deploy edge-cache -o json 2>/dev/null \
+    | jq '{replicas: .spec.replicas, readyReplicas: .status.readyReplicas,
+           template: {grace: .spec.template.spec.terminationGracePeriodSeconds,
+                      containers: [.spec.template.spec.containers[] | {name, imagePullPolicy}]}}')"
   show_why "$1"
 }
 settings_pane() {
@@ -26,10 +49,10 @@ settings_pane() {
 }
 pane=''
 
-crit 1 "the rollout completed" \
-  "${ready}/${want} replicas are ready" \
-  "A template edited but not rolled out has changed nothing that is running. ErrImageNeverPull is the failure to expect here: it means the kubelet was told never to pull and could not find the image already on the node, which is exactly what Never is for — a loud failure instead of a silent trip to a registry." \
-  -- rolled_out || pane=${pane:-list_pane}
+crit 1 "the template carries both settings and the rollout completed" \
+  "the template has terminationGracePeriodSeconds '$grace' and imagePullPolicy '$policies' (want 45, and Never on every container), and ${ready}/${want} replicas are ready" \
+  "A template edited but not rolled out has changed nothing that is running — and a Deployment nobody has edited is already 2/2, so the replica count alone says nothing about whether the work was done. ErrImageNeverPull is the failure to expect here: it means the kubelet was told never to pull and could not find the image already on the node, which is exactly what Never is for — a loud failure instead of a silent trip to a registry." \
+  -- rolled_out || pane=${pane:-template_pane}
 
 crit 1 "every live Pod carries both settings" \
   "only ${live} of ${ready} running Pods carry both settings" \

--- a/banks/ckad-mock-01/q26/validate.d/30_running.sh
+++ b/banks/ckad-mock-01/q26/validate.d/30_running.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# points: 1
+# points: 2
 # desc: the rollout completed and the live Pods carry the new settings
 set -uo pipefail
 . /banks/_lib/checks.sh

--- a/banks/ckad-mock-01/q27/hints.md
+++ b/banks/ckad-mock-01/q27/hints.md
@@ -1,0 +1,21 @@
+## Hint 1
+
+`kubectl explain limitrange.spec.limits` lists several maps under one
+entry. Two of them fill in what a container left out; the others are
+ceilings and floors, which is a different guarantee and not what is
+asked for here.
+
+The order you create things in matters for task 2. Admission happens
+once, when the Pod is accepted.
+
+## Hint 2
+
+The entry is keyed `type: Container`. `defaultRequest` supplies the
+missing request and `default` supplies the missing limit — the shorter
+name is the one people expect to mean "request", and it does not.
+
+There is no generator for a LimitRange, so write the manifest.
+
+Once the Pod exists, ask the Pod rather than the LimitRange what it got:
+`kubectl -n fornax get pod unspecified -o jsonpath` down to the
+container's `resources`.

--- a/banks/ckad-mock-01/q27/question.md
+++ b/banks/ckad-mock-01/q27/question.md
@@ -1,0 +1,14 @@
+Namespace `fornax` accepts manifests from several teams and most of them
+declare no resources at all. Those Pods are best-effort: the scheduler
+reserves nothing for them and the kubelet evicts them first.
+
+1. Create a LimitRange named `container-defaults` in Namespace `fornax`
+   that gives every **container** which declares none:
+   - a request of `100m` CPU and `128Mi` memory,
+   - a limit of `500m` CPU and `256Mi` memory.
+2. Create a Pod named `unspecified` in `fornax` with a single container
+   named `app`, image `nginx:1.29-alpine`, and **no `resources` block at
+   all**. It must reach `Running`.
+3. Save the CPU request that Pod actually ended up with — the quantity on
+   its own, nothing else — to `/opt/course/27/cpu-request` on
+   `instance-1`.

--- a/banks/ckad-mock-01/q27/setup.sh
+++ b/banks/ckad-mock-01/q27/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl create ns fornax --dry-run=client -o yaml | kubectl apply -f -

--- a/banks/ckad-mock-01/q27/solution.md
+++ b/banks/ckad-mock-01/q27/solution.md
@@ -1,0 +1,116 @@
+# Solution 27
+
+**1. The LimitRange first.** This is not a stylistic preference: a Pod is
+only ever touched by the LimitRanges that already exist at the moment it
+is admitted.
+
+```bash
+k apply -f - <<'EOF'
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: container-defaults
+  namespace: fornax
+spec:
+  limits:
+    - type: Container
+      defaultRequest:
+        cpu: 100m
+        memory: 128Mi
+      default:
+        cpu: 500m
+        memory: 256Mi
+EOF
+```
+
+**2. A Pod that asks for nothing.** There is no `resources` key anywhere
+in this manifest, which is the whole point of the exercise:
+
+```bash
+k apply -f - <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: unspecified
+  namespace: fornax
+spec:
+  containers:
+    - name: app
+      image: nginx:1.29-alpine
+EOF
+k -n fornax get pod unspecified
+```
+
+**3. Read back what the Pod was actually given.** Ask the Pod, not the
+LimitRange — the object you wrote and the object the API server stored
+are not the same document any more:
+
+```bash
+k -n fornax get pod unspecified -o jsonpath='{.spec.containers[0].resources}'
+```
+
+```json
+{"limits":{"cpu":"500m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}
+```
+
+```bash
+k -n fornax get pod unspecified \
+  -o jsonpath='{.spec.containers[0].resources.requests.cpu}' \
+  > /opt/course/27/cpu-request
+cat /opt/course/27/cpu-request      # 100m
+```
+
+`describe` shows the same thing with a receipt attached:
+
+```bash
+k -n fornax describe pod unspecified | head -12
+# Annotations: kubernetes.io/limit-ranger:
+#   LimitRanger plugin set: cpu, memory request for container app; ...
+```
+
+## Where this happens
+
+`LimitRanger` is an admission plugin inside the API server. It runs
+between authorisation and persistence, on the way in, and it rewrites the
+object being created. Nothing reconciles afterwards, which has two
+consequences worth carrying:
+
+- **Pods created before the LimitRange keep their emptiness.** Creating
+  the LimitRange second changes nothing about anything already running,
+  and there is no controller that will come back for them. Delete and
+  recreate the Pod if you get the order wrong.
+- **The stored Pod is the mutated one.** `kubectl get -o yaml` shows
+  requests and limits that appear in no file you wrote, and the
+  `kubernetes.io/limit-ranger` annotation names which plugin put them
+  there.
+
+## default is the limit, defaultRequest is the request
+
+The naming is the trap. `default` is the *limit* a container gets when it
+names none; `defaultRequest` is the request. Write only `default` and the
+request quietly becomes equal to the limit, so a container that asked for
+nothing reserves the full ceiling — half a CPU each, here, against a
+scheduler that then packs the node far more thinly than anyone intended.
+
+## A LimitRange is not a ResourceQuota
+
+They are separate objects doing separate jobs, and they are often
+confused because both live in a Namespace and both talk about CPU and
+memory:
+
+| | LimitRange | ResourceQuota |
+|---|---|---|
+| Applies to | one container or one Pod | the Namespace as a whole |
+| Enforced | at admission, per object | against the running total |
+| Can fill in missing values | yes | no |
+| Failure mode | the object is rejected, or defaulted | the object is rejected once the total is reached |
+
+They also work together, and this is the usual reason to reach for both:
+a ResourceQuota that constrains `requests.cpu` **rejects any Pod that
+does not declare one**. Adding a LimitRange with `defaultRequest` is what
+lets teams keep submitting bare manifests into a quota-ed Namespace at
+all.
+
+The other two maps on the same entry, which this question deliberately
+does not use, are `max` and `min` — hard ceilings and floors that reject
+an object outright rather than filling anything in.

--- a/banks/ckad-mock-01/q27/validate.d/10_limitrange.sh
+++ b/banks/ckad-mock-01/q27/validate.d/10_limitrange.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# points: 4
+# desc: LimitRange container-defaults sets default requests and limits for containers
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+lr=$(kubectl -n fornax get limitrange container-defaults -o json 2>/dev/null)
+evidence() {
+  show_actual json "$(printf '%s' "$lr" | jq '[.spec.limits[]? | {type, default, defaultRequest, max, min}]' 2>/dev/null)"
+  show_why "$1"
+}
+
+[ -n "$lr" ] || {
+  echo "LimitRange container-defaults not found in fornax"
+  show_actual text "$(kubectl -n fornax get limitrange 2>/dev/null)"
+  show_why "A LimitRange is a namespaced object and it only reaches the Namespace it was created in, so one made elsewhere defaults nothing here. Nothing of that name exists in fornax at all."
+  exit 1
+}
+
+entry=$(printf '%s' "$lr" | jq -c '[.spec.limits[]? | select(.type == "Container")] | first // {}' 2>/dev/null)
+dreq_cpu=$(printf '%s' "$entry" | jq -r '.defaultRequest.cpu // ""' 2>/dev/null)
+dreq_mem=$(printf '%s' "$entry" | jq -r '.defaultRequest.memory // ""' 2>/dev/null)
+dlim_cpu=$(printf '%s' "$entry" | jq -r '.default.cpu // ""' 2>/dev/null)
+dlim_mem=$(printf '%s' "$entry" | jq -r '.default.memory // ""' 2>/dev/null)
+
+crit 1 "defaults the CPU request to 100m" \
+  "defaultRequest.cpu is '$dreq_cpu', want 100m" \
+  "defaultRequest holds the values an admitted container is given when it REQUESTS none, and the entry carrying them has to be typed Container — a Pod-typed entry describes the sum across the Pod and defaults nothing. A quantity written 100m, 0.1 or 0.100 is the same amount, so what is here is a different figure or a different key." \
+  -- [ "$(milli "$dreq_cpu")" = "100" ]
+
+crit 1 "defaults the memory request to 128Mi" \
+  "defaultRequest.memory is '$dreq_mem', want 128Mi" \
+  "The request is what the scheduler reserves on a node, which is why filling it in is the half that stops these Pods being best-effort. Memory is compared by value here, so 128Mi and 131072Ki both count." \
+  -- [ "$(mib "$dreq_mem")" = "128" ]
+
+crit 1 "defaults the CPU limit to 500m" \
+  "default.cpu is '$dlim_cpu', want 500m" \
+  "The map called 'default' holds LIMITS, not requests — that naming is the trap in this object. Set only default and the request silently becomes equal to the limit, so a container that asked for nothing reserves the whole ceiling." \
+  -- [ "$(milli "$dlim_cpu")" = "500" ]
+
+crit 1 "defaults the memory limit to 256Mi" \
+  "default.memory is '$dlim_mem', want 256Mi" \
+  "The limit is the ceiling the kernel enforces; exceeding it gets a container killed for memory and throttled for CPU. max and min on the same entry are different fields again — they reject an object outright instead of filling anything in." \
+  -- [ "$(mib "$dlim_mem")" = "256" ]
+
+crit_all_passed || evidence "$(crit_why)"
+report "limitrange ok"

--- a/banks/ckad-mock-01/q27/validate.d/20_pod.sh
+++ b/banks/ckad-mock-01/q27/validate.d/20_pod.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# points: 3
+# desc: Pod unspecified is Running and carries the defaulted requests and limits
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+pod=$(kubectl -n fornax get pod unspecified -o json 2>/dev/null)
+[ -n "$pod" ] || {
+  echo "Pod unspecified not found in fornax"
+  show_actual text "$(kubectl -n fornax get pod 2>/dev/null)"
+  show_why "No Pod of that name exists in fornax. This half of the question is what proves the LimitRange does anything: a defaulting rule with nothing admitted under it has never been exercised."
+  exit 1
+}
+
+names=$(printf '%s' "$pod" | jq -r '[.spec.containers[].name] | join(" ")' 2>/dev/null)
+c=$(printf '%s' "$pod" | jq -c '[.spec.containers[] | select(.name == "app")] | first // {}' 2>/dev/null)
+req_cpu=$(printf '%s' "$c" | jq -r '.resources.requests.cpu // ""' 2>/dev/null)
+req_mem=$(printf '%s' "$c" | jq -r '.resources.requests.memory // ""' 2>/dev/null)
+lim_cpu=$(printf '%s' "$c" | jq -r '.resources.limits.cpu // ""' 2>/dev/null)
+lim_mem=$(printf '%s' "$c" | jq -r '.resources.limits.memory // ""' 2>/dev/null)
+phase=$(printf '%s' "$pod" | jq -r '.status.phase // ""' 2>/dev/null)
+
+evidence() {
+  show_actual json "$(printf '%s' "$pod" | jq '{phase: .status.phase, limitRanger: .metadata.annotations."kubernetes.io/limit-ranger", containers: [.spec.containers[] | {name, resources}]}' 2>/dev/null)"
+  show_why "$1"
+}
+
+requests_ok() {
+  [ "$(milli "$req_cpu")" = "100" ] && [ "$(mib "$req_mem")" = "128" ]
+}
+limits_ok() {
+  [ "$(milli "$lim_cpu")" = "500" ] && [ "$(mib "$lim_mem")" = "256" ]
+}
+
+crit 1 "the Pod is Running" \
+  "pod phase is '$phase', want Running" \
+  "Defaulting happens whether or not the Pod ever starts, so a Pod that is stuck proves only that the API server accepted it. The question asks for a workload that actually came up carrying these values." \
+  -- [ "$phase" = "Running" ]
+
+crit 1 "container app carries the defaulted requests" \
+  "container 'app' (found: $(name_list "$names")) has requests cpu='$req_cpu' memory='$req_mem', want 100m and 128Mi" \
+  "These values are on the Pod even though no manifest named them: the LimitRanger admission plugin rewrote the object on its way in. Empty ones mean the Pod was admitted before the LimitRange existed — admission runs once, nothing reconciles afterwards, so the fix is to delete the Pod and create it again." \
+  -- requests_ok
+
+crit 1 "container app carries the defaulted limits" \
+  "container 'app' has limits cpu='$lim_cpu' memory='$lim_mem', want 500m and 256Mi" \
+  "The limits come from the 'default' map while the requests come from 'defaultRequest'. Limits present with requests equal to them is the signature of a LimitRange that set only one of the two: with no defaultRequest, the request is copied from the limit." \
+  -- limits_ok
+
+crit_all_passed || evidence "$(crit_why)"
+report "pod carries the defaults"

--- a/banks/ckad-mock-01/q27/validate.d/30_recorded.sh
+++ b/banks/ckad-mock-01/q27/validate.d/30_recorded.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: /opt/course/27/cpu-request holds the CPU request the Pod was given
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+f=/opt/course/27/cpu-request
+got=$(file_text "$f")
+[ -n "$got" ] || {
+  echo "$f is missing or empty"
+  show_why "This answer is a file on the instance rather than a command that was run once, so the value has to be redirected to that path. Nothing is there at all."
+  exit 1
+}
+[ "$(milli "$got")" = "100" ] && echo "cpu request recorded" || {
+  echo "$f holds '$got', want the effective CPU request (100m)"
+  show_actual text "$(cat "$f" 2>/dev/null)"
+  show_why "The file wants the quantity on its own — 100m, or 0.1, which is the same amount — and nothing else. A whole JSON object, a key name in front of it or the value the manifest asked for (which was nothing) all land here. Read it off the Pod with a jsonpath ending at the container's resources.requests.cpu."
+  exit 1
+}

--- a/banks/ckad-mock-01/q28/hints.md
+++ b/banks/ckad-mock-01/q28/hints.md
@@ -1,0 +1,20 @@
+## Hint 1
+
+`kubectl create secret -h` lists three subcommands, and only one of them
+produces the `type` this question names. Building the JSON by hand and
+loading it as a generic Secret leaves the type `Opaque`, which the
+kubelet never looks at for credentials.
+
+Task 2 is a single list on the Pod spec. It sits beside `containers`,
+not inside one — the credential is used before any container exists.
+
+## Hint 2
+
+The subcommand is `docker-registry`, and its three flags are
+`--docker-server`, `--docker-username` and `--docker-password`.
+
+The Pod field is `spec.imagePullSecrets`: a list whose entries carry one
+key, `name`. `kubectl explain pod.spec.imagePullSecrets` has the shape.
+
+To see what was stored, decode `.data` — the single entry is keyed
+`.dockerconfigjson`, leading dot included.

--- a/banks/ckad-mock-01/q28/question.md
+++ b/banks/ckad-mock-01/q28/question.md
@@ -1,0 +1,13 @@
+Namespace `equuleus` will run workloads published to the in-cluster
+registry at `registry:5000`, and that registry expects credentials.
+
+1. Create a Secret named `registry-cred` in Namespace `equuleus`, of
+   type `kubernetes.io/dockerconfigjson`, holding the credentials for
+   server `registry:5000` — username `pipeline`, password `s3cr3t-pull`.
+2. Create a Pod named `puller` in `equuleus` with a single container
+   named `web`, image `nginx:1.29-alpine`, which presents `registry-cred`
+   to the kubelet when it pulls images.
+
+The Pod must reach `Running`. Its image is one every node already holds,
+so nothing is actually fetched — what is graded is the Secret's type and
+contents and the Pod's reference to it.

--- a/banks/ckad-mock-01/q28/setup.sh
+++ b/banks/ckad-mock-01/q28/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl create ns equuleus --dry-run=client -o yaml | kubectl apply -f -

--- a/banks/ckad-mock-01/q28/solution.md
+++ b/banks/ckad-mock-01/q28/solution.md
@@ -1,0 +1,106 @@
+# Solution 28
+
+**1. The Secret.** `docker-registry` is a Secret subcommand of its own,
+and using it is what sets the type — there is nothing to encode by hand:
+
+```bash
+k -n equuleus create secret docker-registry registry-cred \
+  --docker-server=registry:5000 \
+  --docker-username=pipeline \
+  --docker-password=s3cr3t-pull
+```
+
+Look at what it built. The type first, then the one entry it stored:
+
+```bash
+k -n equuleus get secret registry-cred -o jsonpath='{.type}'
+# kubernetes.io/dockerconfigjson
+
+k -n equuleus get secret registry-cred -o json | jq -r '.data[".dockerconfigjson"]' | base64 -d | jq .
+```
+
+```json
+{
+  "auths": {
+    "registry:5000": {
+      "username": "pipeline",
+      "password": "s3cr3t-pull",
+      "auth": "cGlwZWxpbmU6czNjcjN0LXB1bGw="
+    }
+  }
+}
+```
+
+That is a `~/.docker/config.json` with one server in it. `auth` is
+base64 of `username:password` and is what actually travels in the
+`Authorization` header; `kubectl` fills it in for you.
+
+**2. The Pod.** `imagePullSecrets` is a Pod-level list, a sibling of
+`containers`:
+
+```bash
+k apply -f - <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: puller
+  namespace: equuleus
+spec:
+  imagePullSecrets:
+    - name: registry-cred
+  containers:
+    - name: web
+      image: nginx:1.29-alpine
+EOF
+k -n equuleus get pod puller
+```
+
+Nothing is pulled here: the tag is not `latest`, so the pull policy
+defaults to `IfNotPresent`, and the image is already on the node. That is
+deliberate — the exercise is the credential, and a Pod that will not
+start teaches nothing about it.
+
+## The type is the whole point
+
+A Secret's `type` is not a label. The kubelet looks for
+`kubernetes.io/dockerconfigjson` specifically, and it requires the object
+to carry exactly one key, `.dockerconfigjson`, whose value is a docker
+config document. The two near misses both look right and neither works:
+
+| What you made | `type` | Result |
+|---|---|---|
+| `create secret generic ... --from-file=.dockerconfigjson=...` | `Opaque` | ignored; the pull is anonymous |
+| `create secret docker-registry ...` | `kubernetes.io/dockerconfigjson` | used |
+
+There is an older sibling, `kubernetes.io/dockercfg`, whose key is
+`.dockercfg` and whose body is the pre-1.13 format with no `auths`
+wrapper. It still works and you will not be asked for it.
+
+A wrong or missing credential does not fail loudly at apply time. It
+fails later, as `ImagePullBackOff`, and `kubectl describe pod` carries
+the registry's own words in the event.
+
+## Per Pod, or per ServiceAccount
+
+Naming the Secret on each Pod, as here, is explicit and travels with the
+manifest. The alternative attaches it to the identity instead:
+
+```bash
+k -n equuleus patch serviceaccount default \
+  --type=merge -p '{"imagePullSecrets":[{"name":"registry-cred"}]}'
+```
+
+Every Pod that then runs as that ServiceAccount gets the entry merged
+into its own list at admission, without any manifest mentioning it. That
+is the right shape when a whole Namespace pulls from one private
+registry; the per-Pod form is the right shape when one workload does.
+
+Both are additive. A Pod may list several, and the kubelet tries each in
+turn until one works.
+
+## Why this registry is not really private
+
+`registry:5000` in this environment is plain HTTP with no authentication
+at all, so the credential above is never checked. What the question
+grades is the shape of the object and the wiring, which is the part that
+is the same on a registry that does check.

--- a/banks/ckad-mock-01/q28/validate.d/10_secret.sh
+++ b/banks/ckad-mock-01/q28/validate.d/10_secret.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# points: 5
+# desc: Secret registry-cred is a dockerconfigjson credential for registry:5000
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+sec=$(kubectl -n equuleus get secret registry-cred -o json 2>/dev/null)
+[ -n "$sec" ] || {
+  echo "Secret registry-cred not found in equuleus"
+  show_actual text "$(kubectl -n equuleus get secret 2>/dev/null)"
+  show_why "A Secret is namespaced, so one of this name elsewhere is a different object and the kubelet in equuleus will never see it. Nothing of that name exists here."
+  exit 1
+}
+
+type=$(printf '%s' "$sec" | jq -r '.type // ""' 2>/dev/null)
+cfg=$(printf '%s' "$sec" | jq -r '.data[".dockerconfigjson"] // ""' 2>/dev/null | base64 -d 2>/dev/null)
+
+# The kubelet matches a registry host with or without a scheme, so grade the
+# same way rather than on how the server happened to be spelled.
+servers=$(printf '%s' "$cfg" | jq -r '(.auths // {}) | keys | .[]' 2>/dev/null \
+  | sed -e 's#^https\{0,1\}://##' -e 's#/*$##' | tr '\n' ' ')
+entry=$(printf '%s' "$cfg" | jq -c '[(.auths // {}) | to_entries[]
+        | select((.key | sub("^https?://"; "") | sub("/+$"; "")) == "registry:5000")
+        | .value] | first // {}' 2>/dev/null)
+user=$(printf '%s' "$entry" | jq -r '.username // ""' 2>/dev/null)
+pass=$(printf '%s' "$entry" | jq -r '.password // ""' 2>/dev/null)
+if [ -z "$user" ] || [ -z "$pass" ]; then
+  blob=$(printf '%s' "$entry" | jq -r '.auth // ""' 2>/dev/null | base64 -d 2>/dev/null)
+  case $blob in
+    *:*) user=${blob%%:*}; pass=${blob#*:} ;;
+  esac
+fi
+
+evidence() {
+  show_actual json "$(printf '%s' "$sec" | jq --arg cfg "$cfg" '{type, keys: (.data // {} | keys), dockerconfigjson: ($cfg | fromjson? // $cfg)}' 2>/dev/null)"
+  show_why "$1"
+}
+
+names_registry() { has_name "$servers" "registry:5000"; }
+creds_ok() { [ "$user" = "pipeline" ] && [ "$pass" = "s3cr3t-pull" ]; }
+
+crit 2 "the type is kubernetes.io/dockerconfigjson" \
+  "type is '$type', want kubernetes.io/dockerconfigjson" \
+  "A Secret's type is functional, not decorative: the kubelet looks for this one specifically when it assembles pull credentials, and a generic Secret holding exactly the same bytes is typed Opaque and ignored. kubectl create secret docker-registry is the subcommand that sets it." \
+  -- [ "$type" = "kubernetes.io/dockerconfigjson" ]
+
+crit 2 "the credential names registry:5000" \
+  "the credential covers $(name_list "$servers"), want registry:5000" \
+  "The body under the .dockerconfigjson key is a docker config document, and the keys of its auths map are the registry hosts the credential applies to. The kubelet matches the host of the image being pulled against those keys, so a credential filed under any other host is never offered for an image from registry:5000." \
+  -- names_registry
+
+crit 1 "carries the username and password" \
+  "the entry for registry:5000 holds username='$user', want pipeline with the given password" \
+  "The entry stores the username and password, and kubectl also derives the base64 'auth' blob that actually travels in the Authorization header. One of the two values here is wrong or absent." \
+  -- creds_ok
+
+crit_all_passed || evidence "$(crit_why)"
+report "registry credential ok"

--- a/banks/ckad-mock-01/q28/validate.d/20_pod.sh
+++ b/banks/ckad-mock-01/q28/validate.d/20_pod.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# points: 4
+# desc: Pod puller presents registry-cred as an image pull secret and is Running
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+pod=$(kubectl -n equuleus get pod puller -o json 2>/dev/null)
+[ -n "$pod" ] || {
+  echo "Pod puller not found in equuleus"
+  show_actual text "$(kubectl -n equuleus get pod 2>/dev/null)"
+  show_why "No Pod of that name exists in equuleus. The Secret on its own grants nothing — a credential is only ever used because a Pod, or the ServiceAccount it runs as, points at it."
+  exit 1
+}
+
+pull=$(printf '%s' "$pod" | jq -r '[.spec.imagePullSecrets[]?.name] | join(" ")' 2>/dev/null)
+names=$(printf '%s' "$pod" | jq -r '[.spec.containers[].name] | join(" ")' 2>/dev/null)
+img=$(printf '%s' "$pod" | jq -r '[.spec.containers[] | select(.name == "web") | .image] | first // ""' 2>/dev/null)
+phase=$(printf '%s' "$pod" | jq -r '.status.phase // ""' 2>/dev/null)
+
+evidence() {
+  show_actual json "$(printf '%s' "$pod" | jq '{imagePullSecrets: .spec.imagePullSecrets, containers: [.spec.containers[] | {name, image, imagePullPolicy}], phase: .status.phase}' 2>/dev/null)"
+  show_why "$1"
+}
+
+references_secret() { has_name "$pull" "registry-cred"; }
+
+crit 2 "presents registry-cred when pulling" \
+  "spec.imagePullSecrets holds $(name_list "$pull"), want registry-cred" \
+  "imagePullSecrets is a Pod-level list, a sibling of containers rather than a field inside one: the credential is needed before any container exists, so it cannot belong to one. Its entries are objects with a single name key, and the Secret must live in the same Namespace as the Pod." \
+  -- references_secret
+
+crit 1 "one container named web on nginx:1.29-alpine" \
+  "container 'web' (found: $(name_list "$names")) has image '$img', want nginx:1.29-alpine" \
+  "The container name and image are pinned by the question. This image is one every node already holds, which is what lets the Pod start without the credential ever being exercised." \
+  -- [ "$img" = "nginx:1.29-alpine" ]
+
+crit 1 "the Pod is Running" \
+  "pod phase is '$phase', want Running" \
+  "A Pod naming a pull secret that does not exist still starts when its image is already on the node, because with a tag other than latest the policy defaults to IfNotPresent and no pull is attempted. A Pod that is not Running here is being held back by something else — describe names it." \
+  -- [ "$phase" = "Running" ]
+
+crit_all_passed || evidence "$(crit_why)"
+report "pod wired to the credential"

--- a/banks/ckad-mock-01/q29/hints.md
+++ b/banks/ckad-mock-01/q29/hints.md
@@ -1,0 +1,21 @@
+## Hint 1
+
+A CustomResourceDefinition is itself an ordinary cluster-scoped object,
+so the verb you would use on any other resource type lists them. The
+name you want is not the kind: it is assembled from two other fields on
+the same object.
+
+Once the type is registered, everything you already know works on it —
+including the command that describes fields, because the schema arrived
+with the definition rather than being compiled into `kubectl`.
+
+## Hint 2
+
+`kubectl get crd` prints the names in exactly the form task 1 asks for.
+`kubectl get crd <name> -o jsonpath` over `.spec.group`,
+`.spec.versions[*].name` and `.spec.names.plural` gives you the three
+pieces the manifest needs.
+
+For task 3, `kubectl explain featuretoggle.spec --recursive` lists the
+fields and their types, and note that `rollout` is a number rather than
+a string. A manifest's `apiVersion` is `<group>/<version>`.

--- a/banks/ckad-mock-01/q29/question.md
+++ b/banks/ckad-mock-01/q29/question.md
@@ -1,0 +1,12 @@
+The platform team has extended this cluster's API with a resource type of
+their own, whose kind is `FeatureToggle`. Nothing about it is written
+down here — find it on the cluster.
+
+1. Save the **fully-qualified name** of the CustomResourceDefinition that
+   registers that kind to `/opt/course/29/crd-name` on `instance-1`. One
+   line, the name only.
+2. Namespace `sextans` already holds one resource of that kind. Save its
+   name — the name alone — to `/opt/course/29/existing-toggle`.
+3. Create a second resource of that kind in `sextans`, named `dark-mode`,
+   with its `enabled` field set to true, its `rollout` field set to `25`
+   and its `owner` field set to `platform-team`.

--- a/banks/ckad-mock-01/q29/setup.sh
+++ b/banks/ckad-mock-01/q29/setup.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl apply -f - <<'EOF'
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: featuretoggles.flags.kubestronaut.dev
+spec:
+  group: flags.kubestronaut.dev
+  scope: Namespaced
+  names:
+    plural: featuretoggles
+    singular: featuretoggle
+    kind: FeatureToggle
+    shortNames:
+      - ft
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: A named switch that turns one application feature on or off.
+          properties:
+            spec:
+              type: object
+              required:
+                - enabled
+                - owner
+              properties:
+                enabled:
+                  type: boolean
+                  description: Whether the feature is served at all.
+                rollout:
+                  type: integer
+                  minimum: 0
+                  maximum: 100
+                  description: Percentage of requests the feature is served to.
+                owner:
+                  type: string
+                  description: The team accountable for this toggle.
+      additionalPrinterColumns:
+        - name: Enabled
+          type: boolean
+          jsonPath: .spec.enabled
+        - name: Rollout
+          type: integer
+          jsonPath: .spec.rollout
+        - name: Owner
+          type: string
+          jsonPath: .spec.owner
+EOF
+
+kubectl wait --for=condition=Established --timeout=120s \
+  crd/featuretoggles.flags.kubestronaut.dev
+
+kubectl create ns sextans --dry-run=client -o yaml | kubectl apply -f -
+
+cr=$(mktemp)
+cat > "$cr" <<'EOF'
+apiVersion: flags.kubestronaut.dev/v1alpha1
+kind: FeatureToggle
+metadata:
+  name: legacy-checkout
+  namespace: sextans
+spec:
+  enabled: false
+  rollout: 0
+  owner: payments-team
+EOF
+
+# Established only says the API is registered; this client's own discovery cache
+# can still predate it, so retry rather than fail the seed on a stale mapping.
+for _ in $(seq 1 30); do
+  kubectl apply -f "$cr" >/dev/null 2>&1 && break
+  sleep 2
+done
+rm -f "$cr"
+
+kubectl get --raw \
+  /apis/flags.kubestronaut.dev/v1alpha1/namespaces/sextans/featuretoggles/legacy-checkout \
+  >/dev/null

--- a/banks/ckad-mock-01/q29/solution.md
+++ b/banks/ckad-mock-01/q29/solution.md
@@ -1,0 +1,114 @@
+# Solution 29
+
+**1. Find the definition.** CustomResourceDefinitions are ordinary
+cluster-scoped objects, so the ordinary verb works:
+
+```bash
+k get crd
+```
+
+```
+NAME                                    CREATED AT
+featuretoggles.flags.kubestronaut.dev   2026-01-01T00:00:00Z
+```
+
+That printed name is the fully-qualified one, and it is built as
+`<plural>.<group>`:
+
+```bash
+k get crd featuretoggles.flags.kubestronaut.dev \
+  -o jsonpath='{.spec.names.plural}.{.spec.group} {.spec.versions[*].name}{"\n"}'
+# featuretoggles.flags.kubestronaut.dev v1alpha1
+
+echo featuretoggles.flags.kubestronaut.dev > /opt/course/29/crd-name
+```
+
+**2. List what is already there.** The new type behaves like any other,
+and the definition's printer columns decide the extra columns:
+
+```bash
+k -n sextans get featuretoggles
+```
+
+```
+NAME              ENABLED   ROLLOUT   OWNER
+legacy-checkout   false     0         payments-team
+```
+
+```bash
+echo legacy-checkout > /opt/course/29/existing-toggle
+```
+
+`ft` works too — the definition declares it as a short name.
+
+**3. Read the schema before writing the manifest.** `explain` is served
+from the same OpenAPI document the API server validates against, so it
+is authoritative for a custom type as much as for a built-in one:
+
+```bash
+k explain featuretoggle.spec --recursive
+```
+
+```
+KIND:       FeatureToggle
+VERSION:    flags.kubestronaut.dev/v1alpha1
+
+FIELDS:
+  enabled       <boolean> -required-
+  owner         <string> -required-
+  rollout       <integer>
+```
+
+```bash
+k apply -f - <<'EOF'
+apiVersion: flags.kubestronaut.dev/v1alpha1
+kind: FeatureToggle
+metadata:
+  name: dark-mode
+  namespace: sextans
+spec:
+  enabled: true
+  rollout: 25
+  owner: platform-team
+EOF
+k -n sextans get ft
+```
+
+## What a CRD actually buys you
+
+Applying a CustomResourceDefinition adds a REST path to the API server
+and nothing else:
+
+```bash
+k get --raw /apis/flags.kubestronaut.dev/v1alpha1 | jq .
+```
+
+From that moment the new kind gets everything the built-in kinds get —
+validation against its schema, RBAC by resource name, labels and
+selectors, `-o jsonpath`, watch, and storage in etcd. What it does **not**
+get is behaviour. Nothing reconciles a `FeatureToggle`; it is a record
+until somebody writes a controller that watches the path and acts on
+what it finds. A CRD with a controller beside it is an operator; a CRD
+on its own, like this one, is a typed configuration store.
+
+Two fields on the definition are worth knowing because they are the ones
+that bite:
+
+- **`scope`** is `Namespaced` or `Cluster`, and it is fixed at
+  definition time. This one is namespaced, which is why `-n sextans` is
+  required and why a resource created without it lands in `default` and
+  seems to vanish.
+- **`versions[].served` and `.storage`** are separate switches. Several
+  versions may be served at once; exactly one is the version actually
+  written to etcd.
+
+## When kubectl says the kind does not exist
+
+`error: unable to recognize "STDIN": no matches for kind "FeatureToggle"`
+means the client could not map the kind to a path — almost always a
+discovery cache written before the definition existed. It is kept under
+`~/.kube/cache` and expires on its own within minutes; deleting that
+directory fixes it immediately.
+
+The same message with a *correct* cache means something simpler: a typo
+in `apiVersion`, or the group left off it entirely.

--- a/banks/ckad-mock-01/q29/validate.d/10_crd-name.sh
+++ b/banks/ckad-mock-01/q29/validate.d/10_crd-name.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: /opt/course/29/crd-name holds the fully-qualified CRD name
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+f=/opt/course/29/crd-name
+want=featuretoggles.flags.kubestronaut.dev
+got=$(file_text "$f")
+[ -n "$got" ] || {
+  echo "$f is missing or empty"
+  show_why "Nothing was written to that path. The name is on the cluster, and listing CustomResourceDefinitions prints it directly — it is not something to reconstruct from the kind."
+  exit 1
+}
+[ "$got" = "$want" ] && echo "crd name recorded" || {
+  echo "$f holds '$got', want $want"
+  show_actual text "$(cat "$f" 2>/dev/null)"
+  show_why "A CustomResourceDefinition's own name is not free-form: the API server requires it to be the resource's plural joined to its API group by a dot, which is why it is the one string that identifies the definition unambiguously. The kind on its own, or the plural on its own, names neither the object nor the API path."
+  exit 1
+}

--- a/banks/ckad-mock-01/q29/validate.d/20_existing.sh
+++ b/banks/ckad-mock-01/q29/validate.d/20_existing.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: /opt/course/29/existing-toggle names the resource that was already in sextans
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+f=/opt/course/29/existing-toggle
+want=legacy-checkout
+got=$(file_text "$f")
+[ -n "$got" ] || {
+  echo "$f is missing or empty"
+  show_why "Nothing was written to that path. Once the type is registered it lists like any other namespaced resource, so finding what is already there is a plain get in the Namespace the question named."
+  exit 1
+}
+[ "$got" = "$want" ] && echo "existing resource recorded" || {
+  echo "$f holds '$got', want the name of the resource already in sextans"
+  show_actual json "$(kubectl get --raw /apis/flags.kubestronaut.dev/v1alpha1/namespaces/sextans/featuretoggles 2>/dev/null | jq '[.items[].metadata.name]' 2>/dev/null)"
+  show_why "The pane lists the names that exist in sextans now. The one asked for is the resource that was there before you created anything — the name only, without the kind in front of it and without the one you added."
+  exit 1
+}

--- a/banks/ckad-mock-01/q29/validate.d/30_toggle.sh
+++ b/banks/ckad-mock-01/q29/validate.d/30_toggle.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# points: 5
+# desc: FeatureToggle dark-mode exists in sextans with the requested field values
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+base=/apis/flags.kubestronaut.dev/v1alpha1/namespaces/sextans/featuretoggles
+obj=$(kubectl get --raw "$base/dark-mode" 2>/dev/null)
+[ -n "$obj" ] || {
+  echo "no FeatureToggle named dark-mode in sextans"
+  show_actual json "$(kubectl get --raw "$base" 2>/dev/null | jq '[.items[] | {name: .metadata.name, spec}]' 2>/dev/null)"
+  show_why "The pane lists every FeatureToggle in sextans. A custom resource is namespaced here, so one created without -n sextans went to default instead and is invisible from this query — and a manifest whose apiVersion omits the group never reached this type at all."
+  exit 1
+}
+
+# jq's // treats false as absent, so a toggle left off would read as empty here.
+enabled=$(printf '%s' "$obj" | jq -r '.spec.enabled | if . == null then "" else tostring end' 2>/dev/null)
+rollout=$(printf '%s' "$obj" | jq -r '.spec.rollout | if . == null then "" else tostring end' 2>/dev/null)
+owner=$(printf '%s' "$obj" | jq -r '.spec.owner // ""' 2>/dev/null)
+
+evidence() {
+  show_actual json "$(printf '%s' "$obj" | jq '{apiVersion, kind, name: .metadata.name, spec}' 2>/dev/null)"
+  show_why "$1"
+}
+
+crit 2 "enabled is true" \
+  "spec.enabled is '$enabled', want true" \
+  "The definition types this field as a boolean, so the value stored is true rather than the string \"true\" — quoting it in the manifest makes the API server reject the object outright, which is the schema doing its job." \
+  -- [ "$enabled" = "true" ]
+
+crit 2 "rollout is 25" \
+  "spec.rollout is '$rollout', want 25" \
+  "This one is typed as an integer with a minimum and a maximum, and those bounds are enforced by the API server exactly as they would be for a built-in field. kubectl explain reads the same schema, which is why it works on a type nobody compiled into it." \
+  -- [ "$rollout" = "25" ]
+
+crit 1 "owner is platform-team" \
+  "spec.owner is '$owner', want platform-team" \
+  "A plain required string. Leaving it out is rejected at admission rather than accepted and defaulted, because the schema lists it under required." \
+  -- [ "$owner" = "platform-team" ]
+
+crit_all_passed || evidence "$(crit_why)"
+report "feature toggle created"

--- a/banks/ckad-mock-01/q30/hints.md
+++ b/banks/ckad-mock-01/q30/hints.md
@@ -1,0 +1,22 @@
+## Hint 1
+
+Two objects are involved and they do different jobs: one enumerates what
+may be done, the other says who may do it. Both have a namespaced form
+and a cluster-scoped form, and picking the namespaced one is what makes
+the `crater-archive` half of the requirement true without any extra
+work.
+
+For task 4, ask the ServiceAccount itself what it can currently do —
+`kubectl auth can-i` takes a flag that prints the whole list instead of
+answering one question.
+
+## Hint 2
+
+`kubectl create role` takes repeated `--verb` and `--resource` flags;
+`kubectl create rolebinding` takes `--role` and `--serviceaccount`, and
+the latter wants `<namespace>:<name>` rather than a bare name.
+
+The leftover grant is cluster-scoped, so nothing in
+`kubectl -n crater get rolebinding` will show it. Look for one naming
+this ServiceAccount among the cluster-scoped bindings instead — a
+subject there carries its own `namespace` field.

--- a/banks/ckad-mock-01/q30/question.md
+++ b/banks/ckad-mock-01/q30/question.md
@@ -1,0 +1,25 @@
+Namespace `crater` runs a reporting job that reads its configuration
+from ConfigMaps. It must be able to read those and nothing else: it may
+not change or delete anything, and it must not see into Namespace
+`crater-archive`.
+
+An earlier attempt at this left a grant behind, and the identity it names
+currently has far more access than the job needs.
+
+1. Create a ServiceAccount named `report-reader` in Namespace `crater`.
+2. Create a Role named `configmap-reader` in `crater` allowing exactly
+   `get`, `list` and `watch` on `configmaps`, and nothing else.
+3. Bind that Role to that ServiceAccount with a RoleBinding named
+   `report-reader-binding` in `crater`.
+4. Take away whatever else is still granting that ServiceAccount access
+   beyond those three verbs.
+
+When you are done, this must answer `yes`:
+
+```bash
+k auth can-i list configmaps -n crater \
+  --as=system:serviceaccount:crater:report-reader
+```
+
+and the same question asked about `delete`, or asked in
+`crater-archive`, must answer `no`.

--- a/banks/ckad-mock-01/q30/setup.sh
+++ b/banks/ckad-mock-01/q30/setup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+for ns in crater crater-archive; do
+  kubectl create ns "$ns" --dry-run=client -o yaml | kubectl apply -f -
+done
+
+kubectl -n crater create configmap report-settings \
+  --from-literal=format=csv --from-literal=schedule=nightly \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n crater-archive create configmap retention \
+  --from-literal=days=365 \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# The over-broad grant task 4 is about. It names a ServiceAccount that does not
+# exist yet, which is legal and is the point: RBAC binds a name, not an object.
+kubectl apply -f - <<'EOF'
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: report-reader-legacy
+subjects:
+  - kind: ServiceAccount
+    name: report-reader
+    namespace: crater
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+EOF

--- a/banks/ckad-mock-01/q30/solution.md
+++ b/banks/ckad-mock-01/q30/solution.md
@@ -1,0 +1,108 @@
+# Solution 30
+
+**Look before you grant.** The question says something already grants
+this identity too much, and `can-i --list` is how you see it:
+
+```bash
+k auth can-i --list -n crater \
+  --as=system:serviceaccount:crater:report-reader
+```
+
+```
+Resources        Non-Resource URLs   Resource Names   Verbs
+configmaps       []                  []               [create delete deletecollection get list patch update watch]
+deployments.apps []                  []               [create delete deletecollection get list patch update watch]
+...
+```
+
+That is the built-in `edit` ClusterRole. Find what attaches it:
+
+```bash
+k get clusterrolebinding -o json \
+  | jq -r '.items[] | select(.subjects[]? | .name == "report-reader") | .metadata.name'
+# report-reader-legacy
+```
+
+**1-3. Build the narrow grant.** All three objects have generators, so
+none of this is typed by hand:
+
+```bash
+k -n crater create serviceaccount report-reader
+
+k -n crater create role configmap-reader \
+  --verb=get --verb=list --verb=watch --resource=configmaps
+
+k -n crater create rolebinding report-reader-binding \
+  --role=configmap-reader --serviceaccount=crater:report-reader
+```
+
+`--serviceaccount` wants `<namespace>:<name>`, because a subject is
+identified by both — a RoleBinding in one Namespace may perfectly well
+name a ServiceAccount from another.
+
+Check what the Role says:
+
+```bash
+k -n crater get role configmap-reader -o jsonpath='{.rules}'
+# [{"apiGroups":[""],"resources":["configmaps"],"verbs":["get","list","watch"]}]
+```
+
+The empty string in `apiGroups` is the **core** group, which is where
+ConfigMaps, Secrets, Pods and Services live. It is easy to read as a
+mistake; it is not.
+
+**4. Remove the leftover:**
+
+```bash
+k delete clusterrolebinding report-reader-legacy
+```
+
+Now verify each half, including the ones that must fail:
+
+```bash
+sa=--as=system:serviceaccount:crater:report-reader
+k auth can-i list configmaps  -n crater         $sa    # yes
+k auth can-i get  configmaps  -n crater         $sa    # yes
+k auth can-i delete configmaps -n crater        $sa    # no
+k auth can-i get  configmaps  -n crater-archive $sa    # no
+k auth can-i get  secrets     -n crater         $sa    # no
+```
+
+## Why the Namespace half comes for free
+
+A Role is namespaced, and a RoleBinding grants its Role's rules **only
+inside the RoleBinding's own Namespace**. Nothing about the Role
+mentions `crater-archive`, so nothing needed to deny it: RBAC is purely
+additive and has no deny rule at all. Anything not granted is refused.
+
+That is also why task 4 exists. Adding a correct narrow Role does not
+undo a wide one — the union of every binding that names the subject is
+what applies, so the only way to reduce access is to take a grant away.
+
+The four combinations are worth being able to name on sight:
+
+| | Role | ClusterRole |
+|---|---|---|
+| **RoleBinding** | rules apply in the binding's Namespace | the ClusterRole's rules, narrowed to the binding's Namespace |
+| **ClusterRoleBinding** | not legal | rules apply cluster-wide |
+
+The second cell is the useful one and the least known: it is how the
+built-in `view` and `edit` ClusterRoles are meant to be handed out, one
+Namespace at a time, without redefining them.
+
+## can-i, and what it is really asking
+
+```bash
+k auth can-i <verb> <resource> -n <ns> --as=<user>
+```
+
+`--as` turns a "can I" into a SubjectAccessReview about somebody else,
+which is the fastest way to test a grant without holding a token for it.
+A ServiceAccount's user name is always
+`system:serviceaccount:<namespace>:<name>` — that string, not the object,
+is what RBAC matches on, which is why the binding this question asks you
+to delete worked before the ServiceAccount existed.
+
+`--list` is the same idea widened: every rule that resolves for that
+subject in that Namespace. Reach for it before writing a Role, not only
+when something is denied.

--- a/banks/ckad-mock-01/q30/validate.d/10_role.sh
+++ b/banks/ckad-mock-01/q30/validate.d/10_role.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# points: 3
+# desc: Role configmap-reader grants get, list and watch on core ConfigMaps only
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+role=$(kubectl -n crater get role configmap-reader -o json 2>/dev/null)
+[ -n "$role" ] || {
+  echo "Role configmap-reader not found in crater"
+  show_actual text "$(kubectl -n crater get role 2>/dev/null)"
+  show_why "A Role is namespaced and its rules only ever apply inside its own Namespace, so one of this name elsewhere grants nothing here. A ClusterRole of the same name is a different object again and would not be found by this lookup."
+  exit 1
+}
+
+verbs=$(printf '%s' "$role" | jq -r '[.rules[]?.verbs[]?] | unique | join(" ")' 2>/dev/null)
+res=$(printf '%s' "$role" | jq -r '[.rules[]?.resources[]?] | unique | join(" ")' 2>/dev/null)
+groups=$(printf '%s' "$role" | jq -r '[.rules[]?.apiGroups[]?] | unique | map(if . == "" then "(core)" else . end) | join(" ")' 2>/dev/null)
+
+evidence() {
+  show_actual json "$(printf '%s' "$role" | jq '.rules' 2>/dev/null)"
+  show_why "$1"
+}
+
+verbs_ok() {
+  printf '%s' "$role" | jq -e '([.rules[]?.verbs[]?] | unique) == ["get","list","watch"]' >/dev/null 2>&1
+}
+target_ok() {
+  printf '%s' "$role" | jq -e '([.rules[]?.resources[]?] | unique) == ["configmaps"]
+      and ([.rules[]?.apiGroups[]?] | unique) == [""]' >/dev/null 2>&1
+}
+
+crit 2 "the verbs are exactly get, list and watch" \
+  "the Role allows verbs [$verbs], want exactly get, list and watch" \
+  "RBAC is additive and has no deny rule, so 'and nothing else' is expressed by leaving verbs out rather than by forbidding them. A wildcard verb, or the update and patch that a copied read-write rule brings along, is extra access nothing later takes back." \
+  -- verbs_ok
+
+crit 1 "it covers configmaps in the core API group and nothing else" \
+  "the Role covers resources [$res] in groups [$groups], want configmaps in the core group" \
+  "The empty string in apiGroups is the CORE group, which is where ConfigMaps, Secrets, Pods and Services live — it reads like an omission and is not one. Naming a second resource here, secrets most often, widens the grant past what the job needs." \
+  -- target_ok
+
+crit_all_passed || evidence "$(crit_why)"
+report "role scoped correctly"

--- a/banks/ckad-mock-01/q30/validate.d/20_binding.sh
+++ b/banks/ckad-mock-01/q30/validate.d/20_binding.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: ServiceAccount report-reader exists and report-reader-binding binds the Role to it
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+sas=$(kubectl -n crater get serviceaccount -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)
+rb=$(kubectl -n crater get rolebinding report-reader-binding -o json 2>/dev/null)
+
+sa_pane() {
+  show_actual text "$(kubectl -n crater get serviceaccount 2>/dev/null)"
+  show_why "$1"
+}
+rb_pane() {
+  show_actual json "$(printf '%s' "$rb" | jq '{roleRef, subjects}' 2>/dev/null)"
+  show_why "$1"
+}
+pane=''
+
+binds_correctly() {
+  printf '%s' "$rb" | jq -e '.roleRef.kind == "Role" and .roleRef.name == "configmap-reader"
+      and ([.subjects[]? | select(.kind == "ServiceAccount" and .name == "report-reader"
+            and (.namespace // "crater") == "crater")] | length) > 0' >/dev/null 2>&1
+}
+
+crit 1 "ServiceAccount report-reader exists in crater" \
+  "no ServiceAccount named report-reader in crater (found: $(name_list "$sas"))" \
+  "A ServiceAccount is the identity a workload presents to the API server, and it is namespaced. RBAC matches the string system:serviceaccount:crater:report-reader rather than the object, so a binding can name one that does not exist and still take effect — which is exactly what makes the leftover grant in this question possible." \
+  -- has_name "$sas" "report-reader" || pane=${pane:-sa_pane}
+
+crit 1 "report-reader-binding binds configmap-reader to that account" \
+  "RoleBinding report-reader-binding does not bind Role configmap-reader to report-reader" \
+  "A RoleBinding joins one roleRef to a list of subjects, and both halves have to be right: roleRef.kind must be Role rather than ClusterRole for a Role of this name to resolve, and a ServiceAccount subject carries its own namespace field. An empty pane means no RoleBinding of that name exists in crater." \
+  -- binds_correctly || pane=${pane:-rb_pane}
+
+crit_all_passed || "${pane:-rb_pane}" "$(crit_why)"
+report "binding in place"

--- a/banks/ckad-mock-01/q30/validate.d/30_authorization.sh
+++ b/banks/ckad-mock-01/q30/validate.d/30_authorization.sh
@@ -38,22 +38,27 @@ evidence() {
 
 allowed() { [ "$1" = "yes" ]; }
 
-# can-i answers for a subject that was never created, and the legacy binding
-# setup.sh plants already says yes to both reads — so on an untouched
-# environment these two would score without anything having been done. An
-# allowed read only counts once the account it names exists.
-sa_exists() { kubectl -n crater get serviceaccount report-reader >/dev/null 2>&1; }
-granted() { sa_exists && allowed "$1"; }
+# can-i answers for a subject that was never created, so every criterion here
+# is meaningless until the account exists: the reads are allowed by the legacy
+# binding setup.sh plants, and on a Namespace where nothing was seeded at all
+# the two denials are true because nothing grants anything. A gate rather than
+# four guards — none of these four questions can be asked of nobody.
+kubectl -n crater get serviceaccount report-reader >/dev/null 2>&1 || {
+  echo "there is no ServiceAccount report-reader in crater to authorize"
+  show_actual text "$(kubectl -n crater get serviceaccount 2>/dev/null)"
+  show_why "Every criterion in this check asks what report-reader may do. RBAC answers those questions for a subject that was never created — a binding names a subject by string, and can-i reports on the rules that resolve for it either way — so the answers only mean something once the account the question asks for exists. Create it first; 20_binding.sh scores it."
+  exit 1
+}
 
 crit 1 "may list ConfigMaps in crater" \
-  "listing ConfigMaps as report-reader answers '$a_list', want yes from an account that exists" \
+  "listing ConfigMaps as report-reader answers '$a_list', want yes" \
   "The pane shows every rule that resolves for this ServiceAccount in crater. Nothing grants list on configmaps: either the Role does not carry the verb, or the RoleBinding never joined the Role to this subject — a Role with no binding grants nobody anything." \
-  -- granted "$a_list"
+  -- allowed "$a_list"
 
 crit 1 "may get a ConfigMap in crater" \
-  "getting a ConfigMap as report-reader answers '$a_get', want yes from an account that exists" \
+  "getting a ConfigMap as report-reader answers '$a_get', want yes" \
   "get and list are separate verbs on the same resource. Reading one object by name and enumerating them are different requests to the API server, and a Role that carries only one of the two is a common way for a workload to half-work." \
-  -- granted "$a_get"
+  -- allowed "$a_get"
 
 crit 1 "may NOT delete ConfigMaps in crater" \
   "deleting a ConfigMap in crater answers '$a_delete', want no" \

--- a/banks/ckad-mock-01/q30/validate.d/30_authorization.sh
+++ b/banks/ckad-mock-01/q30/validate.d/30_authorization.sh
@@ -38,15 +38,22 @@ evidence() {
 
 allowed() { [ "$1" = "yes" ]; }
 
+# can-i answers for a subject that was never created, and the legacy binding
+# setup.sh plants already says yes to both reads — so on an untouched
+# environment these two would score without anything having been done. An
+# allowed read only counts once the account it names exists.
+sa_exists() { kubectl -n crater get serviceaccount report-reader >/dev/null 2>&1; }
+granted() { sa_exists && allowed "$1"; }
+
 crit 1 "may list ConfigMaps in crater" \
-  "listing ConfigMaps in crater answers '$a_list', want yes" \
+  "listing ConfigMaps as report-reader answers '$a_list', want yes from an account that exists" \
   "The pane shows every rule that resolves for this ServiceAccount in crater. Nothing grants list on configmaps: either the Role does not carry the verb, or the RoleBinding never joined the Role to this subject — a Role with no binding grants nobody anything." \
-  -- allowed "$a_list"
+  -- granted "$a_list"
 
 crit 1 "may get a ConfigMap in crater" \
-  "getting a ConfigMap in crater answers '$a_get', want yes" \
+  "getting a ConfigMap as report-reader answers '$a_get', want yes from an account that exists" \
   "get and list are separate verbs on the same resource. Reading one object by name and enumerating them are different requests to the API server, and a Role that carries only one of the two is a common way for a workload to half-work." \
-  -- allowed "$a_get"
+  -- granted "$a_get"
 
 crit 1 "may NOT delete ConfigMaps in crater" \
   "deleting a ConfigMap in crater answers '$a_delete', want no" \

--- a/banks/ckad-mock-01/q30/validate.d/30_authorization.sh
+++ b/banks/ckad-mock-01/q30/validate.d/30_authorization.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# points: 4
+# desc: report-reader may read ConfigMaps in crater and may do nothing more
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+SUBJECT=system:serviceaccount:crater:report-reader
+
+# One SubjectAccessReview each, asked up front so the messages can quote the
+# answers. The first word is all of it: some versions append a reason.
+answer() {
+  kubectl auth can-i "$1" configmaps -n "$2" --as="$SUBJECT" 2>/dev/null \
+    | head -1 | awk '{print $1}'
+}
+a_list=$(answer list crater)
+a_get=$(answer get crater)
+a_delete=$(answer delete crater)
+a_archive=$(answer get crater-archive)
+
+decided() {
+  case $1 in
+    yes|no) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+for a in "$a_list" "$a_get" "$a_delete" "$a_archive"; do
+  decided "$a" || {
+    echo "the authorization queries returned no answer ('$a')"
+    show_why "This check asks the API server, as that ServiceAccount, whether each action is permitted. Getting no answer at all is an environment fault rather than a wrong answer, so report it: nothing about the Role or the binding is being judged here."
+    exit 1
+  }
+done
+
+evidence() {
+  show_actual text "$(kubectl auth can-i --list -n crater --as="$SUBJECT" 2>/dev/null)"
+  show_why "$1"
+}
+
+allowed() { [ "$1" = "yes" ]; }
+
+crit 1 "may list ConfigMaps in crater" \
+  "listing ConfigMaps in crater answers '$a_list', want yes" \
+  "The pane shows every rule that resolves for this ServiceAccount in crater. Nothing grants list on configmaps: either the Role does not carry the verb, or the RoleBinding never joined the Role to this subject — a Role with no binding grants nobody anything." \
+  -- allowed "$a_list"
+
+crit 1 "may get a ConfigMap in crater" \
+  "getting a ConfigMap in crater answers '$a_get', want yes" \
+  "get and list are separate verbs on the same resource. Reading one object by name and enumerating them are different requests to the API server, and a Role that carries only one of the two is a common way for a workload to half-work." \
+  -- allowed "$a_get"
+
+crit 1 "may NOT delete ConfigMaps in crater" \
+  "deleting a ConfigMap in crater answers '$a_delete', want no" \
+  "This is the half the question is really about. RBAC is purely additive and has no deny rule, so adding a narrow Role never takes away a wide grant already in force — the union of every binding naming this subject is what applies. Something still gives it write access, and it has to be removed rather than overridden. Asking can-i with --list is how you find what." \
+  -- negate allowed "$a_delete"
+
+crit 1 "may NOT read ConfigMaps in crater-archive" \
+  "getting a ConfigMap in crater-archive answers '$a_archive', want no" \
+  "A RoleBinding grants its Role's rules only inside its own Namespace, so a correct answer denies this without anything being written about crater-archive at all. An answer of yes means the grant is cluster-scoped somewhere — a ClusterRoleBinding reaches every Namespace at once." \
+  -- negate allowed "$a_archive"
+
+crit_all_passed || evidence "$(crit_why)"
+report "least privilege enforced"

--- a/banks/ckad-mock-01/q31/hints.md
+++ b/banks/ckad-mock-01/q31/hints.md
@@ -1,0 +1,27 @@
+## Hint 1
+
+Pausing and resuming are both subcommands of the same `kubectl` verb —
+the one you already use to watch and to undo a Deployment's rollouts.
+
+Step 3 is the evidence that pausing did anything at all. A Deployment
+creates a ReplicaSet per Pod template it has ever rolled out, so counting
+them tells you whether the new template was acted on:
+
+```bash
+k -n pyxis get rs
+```
+
+## Hint 2
+
+`kubectl -n pyxis rollout pause deploy/feed-api`, then the image edit,
+then `kubectl -n pyxis rollout resume deploy/feed-api`.
+
+The field behind those two commands is `spec.paused`, and resuming
+removes it. Read it back before you decide you are finished:
+
+```bash
+k -n pyxis get deploy feed-api -o jsonpath='{.spec.paused}'
+```
+
+Order is the whole question. Edit the image before pausing and the
+rollout is already gone.

--- a/banks/ckad-mock-01/q31/question.md
+++ b/banks/ckad-mock-01/q31/question.md
@@ -1,0 +1,16 @@
+Deployment `feed-api` in Namespace `pyxis` runs `nginx:1.27-alpine` with
+3 ready replicas.
+
+A new image has been approved, but the release window has not opened yet.
+Stage the change first and let it out afterwards, in this order:
+
+1. Pause the rollout of `feed-api`.
+2. **While it is paused**, change the container's image to
+   `nginx:1.29-alpine`. No Pod may be replaced by this.
+3. **Still while it is paused**, count the ReplicaSets in Namespace
+   `pyxis` and save that number — digits only — to
+   `/opt/course/31/replicasets-while-paused` on `instance-1`.
+4. Resume the rollout and wait until it finishes.
+
+At the end `feed-api` must run `nginx:1.29-alpine` with 3 ready
+replicas, and must no longer be paused.

--- a/banks/ckad-mock-01/q31/setup.sh
+++ b/banks/ckad-mock-01/q31/setup.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl create ns pyxis --dry-run=client -o yaml | kubectl apply -f -
+
+# The question is answered by counting ReplicaSets, and a Deployment keeps one
+# per template it has ever rolled out. Re-applying over an attempt would leave
+# those behind and make the expected count wrong, so a reseed starts the history
+# again from nothing.
+kubectl -n pyxis delete deploy feed-api --ignore-not-found --cascade=foreground --wait >/dev/null
+
+kubectl -n pyxis apply -f - <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: feed-api
+  namespace: pyxis
+spec:
+  replicas: 3
+  selector:
+    matchLabels: {app: feed-api}
+  template:
+    metadata:
+      labels: {app: feed-api}
+    spec:
+      containers:
+        - name: api
+          image: nginx:1.27-alpine
+          ports: [{containerPort: 80}]
+EOF
+
+kubectl -n pyxis rollout status deploy/feed-api --timeout=180s

--- a/banks/ckad-mock-01/q31/solution.md
+++ b/banks/ckad-mock-01/q31/solution.md
@@ -1,0 +1,102 @@
+# Solution 31
+
+Look at what is there before pausing anything, so the ReplicaSet count in
+step 3 means something:
+
+```bash
+k -n pyxis get deploy,rs
+# deployment.apps/feed-api   3/3   3   3
+# replicaset.apps/feed-api-6c8d9f7b45   3   3   3
+```
+
+One ReplicaSet, because the Deployment has only ever had one Pod
+template.
+
+**1. Pause:**
+
+```bash
+k -n pyxis rollout pause deploy/feed-api
+```
+
+**2. Change the image while it is paused:**
+
+```bash
+k -n pyxis set image deploy/feed-api api=nginx:1.29-alpine
+```
+
+Nothing happens, and that is the point. No Pod is deleted, no Pod is
+created, and `kubectl get pods` shows the same three names as before.
+
+**3. Count the ReplicaSets and record it:**
+
+```bash
+k -n pyxis get rs --no-headers | wc -l
+# 1
+
+echo 1 > /opt/course/31/replicasets-while-paused
+```
+
+Still one. The new Pod template is sitting in `spec.template` with
+nothing acting on it.
+
+**4. Resume, and watch the rollout you deferred happen all at once:**
+
+```bash
+k -n pyxis rollout resume deploy/feed-api
+k -n pyxis rollout status deploy/feed-api
+# deployment "feed-api" successfully rolled out
+
+k -n pyxis get rs
+# feed-api-6c8d9f7b45   0   0   0
+# feed-api-79bb5c4f8c   3   3   3
+```
+
+Two now: the old one scaled to zero and kept for a rollback, and the new
+one carrying the Pods.
+
+## What pausing actually stops
+
+`spec.paused: true` stops the Deployment **controller**, not the API
+server. Writes to the Deployment still succeed — the image edit is
+accepted and stored exactly as it would be otherwise — but the controller
+declines to reconcile, so it never creates the ReplicaSet that the new
+Pod template calls for.
+
+That gap is the feature. Every field you touch while paused accumulates
+into one rollout:
+
+```bash
+k -n pyxis rollout pause deploy/feed-api
+k -n pyxis set image deploy/feed-api api=nginx:1.29-alpine
+k -n pyxis set resources deploy/feed-api -c api --limits=memory=256Mi
+k -n pyxis rollout resume deploy/feed-api      # one rollout, one new ReplicaSet
+```
+
+Without the pause, that is two rollouts and two new ReplicaSets, and the
+first one's Pods are torn down half-started by the second.
+
+## Things a paused Deployment will not do
+
+- **It will not roll back.** `kubectl rollout undo` on a paused
+  Deployment is refused outright.
+- **It will not report progress.** `rollout status` blocks and then times
+  out, because there is no rollout to have a status.
+- **It still scales.** `spec.replicas` is handled by the ReplicaSet, and
+  the current ReplicaSet is not paused, so `kubectl scale` works
+  normally. Only the *template* change is held back.
+
+## Resuming, and the field underneath
+
+```bash
+k -n pyxis get deploy feed-api -o jsonpath='{.spec.paused}'
+```
+
+After a resume this prints nothing, because `paused` is a boolean with
+`omitempty` and `kubectl rollout resume` removes it rather than writing
+`false`. Empty and `false` mean the same thing to the controller; `true`
+is the only value that stops it.
+
+Leaving a Deployment paused is a quiet way to lose an afternoon. Every
+subsequent change is accepted and none of it reaches a Pod, so the
+cluster disagrees with the manifest and nothing anywhere reports an
+error.

--- a/banks/ckad-mock-01/q31/validate.d/10_image.sh
+++ b/banks/ckad-mock-01/q31/validate.d/10_image.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: feed-api ends on nginx:1.29-alpine with 3 ready replicas
+set -uo pipefail
+. /banks/_lib/checks.sh
+evidence() {
+  show_actual text "$(kubectl -n pyxis get deploy feed-api -o wide 2>/dev/null; echo; kubectl -n pyxis get pods 2>/dev/null)"
+  show_why "$1"
+}
+
+img=$(kubectl -n pyxis get deploy feed-api \
+  -o jsonpath='{.spec.template.spec.containers[?(@.name=="api")].image}' 2>/dev/null)
+ready=$(kubectl -n pyxis get deploy feed-api -o jsonpath='{.status.readyReplicas}' 2>/dev/null)
+
+kubectl -n pyxis get deploy feed-api >/dev/null 2>&1 || {
+  echo "Deployment feed-api is gone from namespace pyxis"
+  evidence "The task stages a change on this Deployment and then releases it. Deleting and recreating it reaches a similar-looking cluster with no rollout history and no paused revision, which is the whole subject of the question."
+  exit 1
+}
+
+crit 1 "runs the approved image" \
+  "image is '$img', want nginx:1.29-alpine" \
+  "The image belongs to the container in the Deployment's Pod template. A paused Deployment accepts that edit and stores it exactly as an unpaused one would — pausing changes what the CONTROLLER does with the template, never whether the write lands." \
+  -- [ "$img" = "nginx:1.29-alpine" ]
+
+crit 1 "all 3 replicas are ready on it" \
+  "readyReplicas is '$ready', want 3" \
+  "status.readyReplicas is what the cluster has, not what spec.replicas asked for. A Deployment left paused sits here forever: the new Pod template is stored, no ReplicaSet is created for it, and the old Pods stay ready while nothing reports an error." \
+  -- [ "$ready" = "3" ]
+
+crit_all_passed || evidence "$(crit_why)"
+report "feed-api is on nginx:1.29-alpine, 3/3 ready"

--- a/banks/ckad-mock-01/q31/validate.d/10_image.sh
+++ b/banks/ckad-mock-01/q31/validate.d/10_image.sh
@@ -23,10 +23,15 @@ crit 1 "runs the approved image" \
   "The image belongs to the container in the Deployment's Pod template. A paused Deployment accepts that edit and stores it exactly as an unpaused one would — pausing changes what the CONTROLLER does with the template, never whether the write lands." \
   -- [ "$img" = "nginx:1.29-alpine" ]
 
+# 3 ready replicas is where the Deployment started, so it grades nothing on its
+# own. It grades the end state the question asks for once they are ready ON the
+# approved image.
+on_new_image_and_ready() { [ "$img" = "nginx:1.29-alpine" ] && [ "$ready" = "3" ]; }
+
 crit 1 "all 3 replicas are ready on it" \
-  "readyReplicas is '$ready', want 3" \
-  "status.readyReplicas is what the cluster has, not what spec.replicas asked for. A Deployment left paused sits here forever: the new Pod template is stored, no ReplicaSet is created for it, and the old Pods stay ready while nothing reports an error." \
-  -- [ "$ready" = "3" ]
+  "image is '$img' with readyReplicas '$ready'; want 3 replicas ready on nginx:1.29-alpine" \
+  "status.readyReplicas is what the cluster has, not what spec.replicas asked for — and it has to be 3 on the NEW image, which is the whole end state the question describes. A Deployment left paused sits at three ready replicas forever: the new Pod template is stored, no ReplicaSet is created for it, and the old Pods stay ready while nothing reports an error." \
+  -- on_new_image_and_ready
 
 crit_all_passed || evidence "$(crit_why)"
 report "feed-api is on nginx:1.29-alpine, 3/3 ready"

--- a/banks/ckad-mock-01/q31/validate.d/20_resumed.sh
+++ b/banks/ckad-mock-01/q31/validate.d/20_resumed.sh
@@ -14,14 +14,20 @@ evidence() {
 paused=$(kubectl -n pyxis get deploy feed-api -o jsonpath='{.spec.paused}' 2>/dev/null)
 want=$(kubectl -n pyxis get deploy feed-api -o jsonpath='{.spec.replicas}' 2>/dev/null)
 updated=$(kubectl -n pyxis get deploy feed-api -o jsonpath='{.status.updatedReplicas}' 2>/dev/null)
+img=$(kubectl -n pyxis get deploy feed-api \
+  -o jsonpath='{.spec.template.spec.containers[?(@.name=="api")].image}' 2>/dev/null)
 sets=$(kubectl -n pyxis get rs -l app=feed-api -o json 2>/dev/null | jq '.items | length')
 
 rolled_out() { [ -n "$want" ] && [ "$updated" = "$want" ] && [ "${sets:-0}" -ge 2 ] 2>/dev/null; }
 
-crit 2 "the Deployment is no longer paused" \
-  "spec.paused is '$paused'; the Deployment is still paused" \
-  "spec.paused stops the Deployment controller, not the API server, so every later edit is accepted and none of it reaches a Pod. Resuming removes the field rather than writing false — the two mean the same thing to the controller, and only true stops it." \
-  -- [ "$paused" != "true" ]
+# A Deployment nobody has touched is not paused either, so 'not paused' only
+# means 'resumed' once there is a staged change to have been holding back.
+let_out() { [ "$img" = "nginx:1.29-alpine" ] && [ "$paused" != "true" ]; }
+
+crit 2 "the staged change is in the template and no longer held back" \
+  "image is '$img' with spec.paused '$paused'; want nginx:1.29-alpine staged and the Deployment resumed" \
+  "spec.paused stops the Deployment controller, not the API server, so every later edit is accepted and none of it reaches a Pod. That is why this reads the staged image and the pause together: a Deployment that was never paused and never edited is 'not paused' too. Resuming removes the field rather than writing false — the two mean the same thing to the controller, and only true stops it." \
+  -- let_out
 
 crit 1 "the staged change was rolled out, not just stored" \
   "updatedReplicas is '$updated' of '$want', across ${sets:-0} ReplicaSet(s)" \

--- a/banks/ckad-mock-01/q31/validate.d/20_resumed.sh
+++ b/banks/ckad-mock-01/q31/validate.d/20_resumed.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# points: 3
+# desc: the rollout was resumed and the staged change really rolled out
+set -uo pipefail
+. /banks/_lib/checks.sh
+evidence() {
+  show_actual text "$(kubectl -n pyxis get deploy feed-api \
+    -o custom-columns='NAME:.metadata.name,PAUSED:.spec.paused,DESIRED:.spec.replicas,UPDATED:.status.updatedReplicas,READY:.status.readyReplicas' 2>/dev/null
+    echo
+    kubectl -n pyxis get rs 2>/dev/null)"
+  show_why "$1"
+}
+
+paused=$(kubectl -n pyxis get deploy feed-api -o jsonpath='{.spec.paused}' 2>/dev/null)
+want=$(kubectl -n pyxis get deploy feed-api -o jsonpath='{.spec.replicas}' 2>/dev/null)
+updated=$(kubectl -n pyxis get deploy feed-api -o jsonpath='{.status.updatedReplicas}' 2>/dev/null)
+sets=$(kubectl -n pyxis get rs -l app=feed-api -o json 2>/dev/null | jq '.items | length')
+
+rolled_out() { [ -n "$want" ] && [ "$updated" = "$want" ] && [ "${sets:-0}" -ge 2 ] 2>/dev/null; }
+
+crit 2 "the Deployment is no longer paused" \
+  "spec.paused is '$paused'; the Deployment is still paused" \
+  "spec.paused stops the Deployment controller, not the API server, so every later edit is accepted and none of it reaches a Pod. Resuming removes the field rather than writing false — the two mean the same thing to the controller, and only true stops it." \
+  -- [ "$paused" != "true" ]
+
+crit 1 "the staged change was rolled out, not just stored" \
+  "updatedReplicas is '$updated' of '$want', across ${sets:-0} ReplicaSet(s)" \
+  "A Deployment holds one ReplicaSet per Pod template it has rolled out, so a second one appearing IS the rollout. While paused there is one, carrying the old template and the old Pods; resuming creates the second, moves the Pods onto it and leaves the first scaled to zero as the rollback." \
+  -- rolled_out
+
+crit_all_passed || evidence "$(crit_why)"
+report "resumed, and the new ReplicaSet carries the Pods"

--- a/banks/ckad-mock-01/q31/validate.d/30_recorded.sh
+++ b/banks/ckad-mock-01/q31/validate.d/30_recorded.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: the ReplicaSet count taken while paused was recorded as 1
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+got=$(file_text /opt/course/31/replicasets-while-paused)
+
+[ "$got" = "1" ] && echo "the paused ReplicaSet count was recorded" || {
+  echo "/opt/course/31/replicasets-while-paused contains '$got', want '1'"
+  show_actual text "$(cat /opt/course/31/replicasets-while-paused 2>/dev/null)"
+  show_why "This number is the evidence that pausing did anything, and it can only be read in the window the question describes: after the image was changed and before the rollout was resumed. There is one ReplicaSet then, because the new Pod template was stored and no controller acted on it. Two means the image was changed before the pause — the rollout had already started and there was nothing left to hold back. An empty file means the count was never taken; resuming first destroys the answer, since the second ReplicaSet exists from that moment on."
+  exit 1
+}

--- a/banks/ckad-mock-01/q32/hints.md
+++ b/banks/ckad-mock-01/q32/hints.md
@@ -1,0 +1,23 @@
+## Hint 1
+
+There is a single `kubectl` subcommand for exactly this, and it sits
+beside the ones for watching, pausing and undoing a Deployment's
+rollouts. `kubectl rollout -h` lists it.
+
+Requirement 3 rules out the obvious workarounds — bumping the image tag
+and putting it back, or scaling to zero and back up.
+
+## Hint 2
+
+`rollout restart` is the subcommand, and it takes a Deployment the same
+way `rollout status` does.
+
+It works by writing a timestamp annotation into
+`spec.template.metadata.annotations`, which is a Pod-template change like
+any other, so it triggers a normal rolling update. Read it back to see
+what it did:
+
+```bash
+k -n sagitta get deploy session-store \
+  -o jsonpath='{.spec.template.metadata.annotations}'
+```

--- a/banks/ckad-mock-01/q32/question.md
+++ b/banks/ckad-mock-01/q32/question.md
@@ -1,0 +1,17 @@
+Deployment `session-store` in Namespace `sagitta` runs 3 replicas of
+`nginx:1.27-alpine`. Its ConfigMap `session-store-conf` has been edited,
+and the containers only read it at start-up, so every Pod is serving a
+stale value.
+
+Replace all three Pods, so that:
+
+1. Every Pod currently backing `session-store` was created **after** the
+   replacement, and none of the original three is left.
+2. The replacement happens as a Deployment rollout that the Pod template
+   records, not by deleting Pods and letting the ReplicaSet make new
+   ones.
+3. **Nothing about what the Deployment runs changes.** The image, the
+   replica count, the container name and the container's configuration
+   must all be exactly what they are now.
+
+Wait until the rollout finishes and all 3 replicas are ready again.

--- a/banks/ckad-mock-01/q32/setup.sh
+++ b/banks/ckad-mock-01/q32/setup.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl create ns sagitta --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n sagitta apply -f - <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: session-store-conf
+  namespace: sagitta
+data:
+  SESSION_TTL: "3600"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: session-store
+  namespace: sagitta
+spec:
+  replicas: 3
+  selector:
+    matchLabels: {app: session-store}
+  template:
+    metadata:
+      labels: {app: session-store}
+    spec:
+      containers:
+        - name: store
+          image: nginx:1.27-alpine
+          ports: [{containerPort: 80}]
+          envFrom:
+            - configMapRef: {name: session-store-conf}
+EOF
+
+# apply never removes an annotation it did not put there, so a restartedAt left
+# by an earlier attempt would survive the reseed and hand the next candidate a
+# question that is already answered.
+kubectl -n sagitta patch deploy session-store --type=json \
+  -p '[{"op": "remove", "path": "/spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt"}]' \
+  >/dev/null 2>&1 || true
+
+kubectl -n sagitta rollout status deploy/session-store --timeout=180s

--- a/banks/ckad-mock-01/q32/solution.md
+++ b/banks/ckad-mock-01/q32/solution.md
@@ -1,0 +1,78 @@
+# Solution 32
+
+The whole task is one command:
+
+```bash
+k -n sagitta rollout restart deploy/session-store
+k -n sagitta rollout status deploy/session-store
+# deployment "session-store" successfully rolled out
+```
+
+Three new Pod names, three new ReplicaSet-backed Pods, and a Deployment
+spec that still asks for exactly what it asked for before.
+
+## How it does it without changing anything
+
+There is no "restart" verb in the Kubernetes API. `kubectl` fakes one by
+writing a timestamp into the Pod template:
+
+```bash
+k -n sagitta get deploy session-store \
+  -o jsonpath='{.spec.template.metadata.annotations}'
+# {"kubectl.kubernetes.io/restartedAt":"2026-02-11T09:14:03Z"}
+```
+
+That annotation is part of `spec.template`, so changing it is a Pod
+template change, so the Deployment controller does what it always does
+with one: it creates a new ReplicaSet and moves the Pods across under
+`spec.strategy`. The image, the replica count and every other field are
+untouched — nothing about the workload has changed, only the timestamp
+that identifies this generation of it.
+
+Two consequences follow:
+
+- **It is a rolling update**, so it respects `maxSurge` and
+  `maxUnavailable`, it shows up in `kubectl rollout status`, and it can
+  be watched and rolled back like any other.
+- **It is idempotent to re-run.** A second restart writes a new
+  timestamp, which is a new template, which is a new rollout.
+
+## Why not just delete the Pods
+
+```bash
+k -n sagitta delete pod -l app=session-store       # DO NOT
+```
+
+The ReplicaSet notices the shortfall and replaces them, so the end state
+looks similar and the route there is worse:
+
+- All three go at once. `maxUnavailable` does not apply, because no
+  rollout is happening — the ReplicaSet is only refilling to its replica
+  count, and there is a window with no Pod serving at all.
+- Nothing records it. There is no new revision, no `rollout status` to
+  watch and nothing in the history to say the workload was cycled.
+- There is nothing to roll back to.
+
+Deleting one Pod at a time and waiting is a hand-cranked rolling update
+that still leaves no record.
+
+## Why not touch the image
+
+Setting the tag to something else and back is two rollouts to achieve one
+restart, and in between, every Pod is running a version nobody chose.
+Scaling to zero and back up is a full outage. Both change the spec the
+question said to leave alone.
+
+## Reading a ConfigMap without a restart
+
+This task exists because the containers read their configuration once, at
+start-up, which is true of `envFrom` and of environment variables
+generally: the values are copied into the container at creation and
+nothing updates them afterwards. A restart is the only way to pick up the
+new ones.
+
+A ConfigMap mounted as a **volume** behaves differently — the kubelet
+refreshes the files in place within about a minute, and an application
+that re-reads them needs no restart at all. Which of the two you chose
+when you wrote the manifest decides whether config changes cost you a
+rollout for the life of the workload.

--- a/banks/ckad-mock-01/q32/validate.d/10_restarted.sh
+++ b/banks/ckad-mock-01/q32/validate.d/10_restarted.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# points: 3
+# desc: the Pod template records a rollout restart and every Pod came from it
+set -uo pipefail
+. /banks/_lib/checks.sh
+KEY=kubectl.kubernetes.io/restartedAt
+evidence() {
+  show_actual json "$(kubectl -n sagitta get deploy session-store -o json 2>/dev/null \
+    | jq '{templateAnnotations: .spec.template.metadata.annotations}')"
+  show_why "$1"
+}
+
+kubectl -n sagitta get deploy session-store >/dev/null 2>&1 || {
+  echo "Deployment session-store is gone from namespace sagitta"
+  show_actual text "$(kubectl -n sagitta get deploy 2>/dev/null)"
+  show_why "The task is to cycle this Deployment's Pods in place. Deleting it and creating it again replaces the Pods too, and loses the revision history, the rollback and every field the question said to leave exactly as it was."
+  exit 1
+}
+
+stamp=$(kubectl -n sagitta get deploy session-store -o json 2>/dev/null \
+  | jq -r --arg k "$KEY" '.spec.template.metadata.annotations[$k] // empty')
+
+pods=$(kubectl -n sagitta get pods -l app=session-store -o json 2>/dev/null)
+live=$(printf '%s' "$pods" | jq '[.items[] | select(.metadata.deletionTimestamp == null)] | length')
+stamped=$(printf '%s' "$pods" | jq --arg k "$KEY" \
+  '[.items[] | select(.metadata.deletionTimestamp == null) | select(.metadata.annotations[$k] != null)] | length')
+
+all_from_the_restart() { [ "${live:-0}" -gt 0 ] && [ "$stamped" = "$live" ]; }
+
+pod_pane() {
+  show_actual json "$(printf '%s' "$pods" | jq --arg k "$KEY" \
+    '[.items[] | {name: .metadata.name, created: .metadata.creationTimestamp, restartedAt: (.metadata.annotations[$k] // null)}]')"
+  show_why "$1"
+}
+pane=''
+
+crit 2 "the Pod template records the restart" \
+  "spec.template.metadata.annotations has no $KEY" \
+  "There is no restart verb in the Kubernetes API. kubectl makes one by writing a timestamp annotation into the POD TEMPLATE, which is a template change like any other, so the controller rolls the Pods over under spec.strategy. Annotating the Deployment itself instead of its template changes no template, triggers no rollout and replaces no Pod." \
+  -- [ -n "$stamp" ] || pane=${pane:-evidence}
+
+crit 1 "and every Pod was created by it" \
+  "${stamped:-0} of ${live:-0} Pods carry $KEY" \
+  "Pods inherit their template's annotations at creation, so a Pod without this one predates the restart. Editing the template without letting the rollout finish, or deleting Pods by hand alongside it, leaves a mix of old and new — which is exactly the state the question asks you to leave behind." \
+  -- all_from_the_restart || pane=${pane:-pod_pane}
+
+crit_all_passed || "${pane:-evidence}" "$(crit_why)"
+report "restarted through the Pod template, ${live} Pod(s) from it"

--- a/banks/ckad-mock-01/q32/validate.d/20_unchanged.sh
+++ b/banks/ckad-mock-01/q32/validate.d/20_unchanged.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: the restart changed nothing about what the Deployment runs
+set -uo pipefail
+. /banks/_lib/checks.sh
+evidence() {
+  show_actual json "$(kubectl -n sagitta get deploy session-store -o json 2>/dev/null \
+    | jq '{replicas: .spec.replicas,
+           containers: [.spec.template.spec.containers[] | {name, image, envFrom}]}')"
+  show_why "$1"
+}
+
+img=$(kubectl -n sagitta get deploy session-store \
+  -o jsonpath='{.spec.template.spec.containers[?(@.name=="store")].image}' 2>/dev/null)
+want=$(kubectl -n sagitta get deploy session-store -o jsonpath='{.spec.replicas}' 2>/dev/null)
+conf=$(kubectl -n sagitta get deploy session-store -o json 2>/dev/null \
+  | jq -r '[.spec.template.spec.containers[] | select(.name == "store")
+            | .envFrom[]?.configMapRef.name] | join(",")')
+
+crit 1 "the container still runs the image it started on" \
+  "container 'store' has image '$img', want nginx:1.27-alpine" \
+  "A restart is not an upgrade. Bumping the tag and putting it back reaches the same string through two rollouts, and in between every Pod is serving a version nobody asked for. An empty value here usually means the container was renamed, which is a template change of its own." \
+  -- [ "$img" = "nginx:1.27-alpine" ]
+
+shape_intact() { [ "$want" = "3" ] && [ "$conf" = "session-store-conf" ]; }
+
+crit 1 "the replica count and the config source are untouched" \
+  "replicas='$want' (want 3), envFrom ConfigMaps='$conf' (want session-store-conf)" \
+  "Scaling to zero and back up cycles every Pod at the cost of a total outage, and it changes spec.replicas twice on the way. The ConfigMap reference is checked with it because dropping and re-adding envFrom is another way to force a rollout by changing the very thing the question protects." \
+  -- shape_intact
+
+crit_all_passed || evidence "$(crit_why)"
+report "spec unchanged: nginx:1.27-alpine, 3 replicas, session-store-conf"

--- a/banks/ckad-mock-01/q32/validate.d/20_unchanged.sh
+++ b/banks/ckad-mock-01/q32/validate.d/20_unchanged.sh
@@ -3,10 +3,12 @@
 # desc: the restart changed nothing about what the Deployment runs
 set -uo pipefail
 . /banks/_lib/checks.sh
+KEY=kubectl.kubernetes.io/restartedAt
 evidence() {
   show_actual json "$(kubectl -n sagitta get deploy session-store -o json 2>/dev/null \
     | jq '{replicas: .spec.replicas,
-           containers: [.spec.template.spec.containers[] | {name, image, envFrom}]}')"
+           containers: [.spec.template.spec.containers[] | {name, image, envFrom}],
+           templateAnnotations: .spec.template.metadata.annotations}')"
   show_why "$1"
 }
 
@@ -16,18 +18,32 @@ want=$(kubectl -n sagitta get deploy session-store -o jsonpath='{.spec.replicas}
 conf=$(kubectl -n sagitta get deploy session-store -o json 2>/dev/null \
   | jq -r '[.spec.template.spec.containers[] | select(.name == "store")
             | .envFrom[]?.configMapRef.name] | join(",")')
-
-crit 1 "the container still runs the image it started on" \
-  "container 'store' has image '$img', want nginx:1.27-alpine" \
-  "A restart is not an upgrade. Bumping the tag and putting it back reaches the same string through two rollouts, and in between every Pod is serving a version nobody asked for. An empty value here usually means the container was renamed, which is a template change of its own." \
-  -- [ "$img" = "nginx:1.27-alpine" ]
+stamp=$(kubectl -n sagitta get deploy session-store -o json 2>/dev/null \
+  | jq -r --arg k "$KEY" '.spec.template.metadata.annotations[$k] // empty')
 
 shape_intact() { [ "$want" = "3" ] && [ "$conf" = "session-store-conf" ]; }
 
-crit 1 "the replica count and the config source are untouched" \
-  "replicas='$want' (want 3), envFrom ConfigMaps='$conf' (want session-store-conf)" \
-  "Scaling to zero and back up cycles every Pod at the cost of a total outage, and it changes spec.replicas twice on the way. The ConfigMap reference is checked with it because dropping and re-adding envFrom is another way to force a rollout by changing the very thing the question protects." \
-  -- shape_intact
+# Both of these are gates rather than criteria. The question rules the edits
+# out, so making one is not a partial answer — and leaving the spec alone is
+# also what a candidate who has done nothing at all has done, so respecting
+# them cannot earn anything either. What is scored below is the restart that
+# these two protect.
+[ "$img" = "nginx:1.27-alpine" ] || {
+  echo "container 'store' has image '$img', want nginx:1.27-alpine"
+  evidence "The question ruled this out: nothing about what the Deployment runs was to change. A restart is not an upgrade — bumping the tag and putting it back reaches the same string through two rollouts, and in between every Pod is serving a version nobody asked for. An empty value here usually means the container was renamed, which is a template change of its own."
+  exit 1
+}
+
+shape_intact || {
+  echo "replicas='$want' (want 3), envFrom ConfigMaps='$conf' (want session-store-conf)"
+  evidence "The question ruled this out: the replica count and the container's configuration were to be exactly what they were. Scaling to zero and back up cycles every Pod at the cost of a total outage, and it changes spec.replicas twice on the way. The ConfigMap reference goes with it because dropping and re-adding envFrom is another way to force a rollout by changing the very thing the question protects."
+  exit 1
+}
+
+crit 1 "the Pods were cycled by a restart, not by an edit to any of that" \
+  "the Pod template carries no $KEY: nothing here has changed, but nothing has restarted it either" \
+  "This is what makes 'nothing changed' worth anything: a Deployment nobody has touched has trivially changed nothing. What is graded is that the image, the replica count and the config source are still exactly as they were AFTER a rollout restart cycled the Pods. kubectl records that restart as a timestamp in the POD TEMPLATE — a template change that alters nothing about what the workload runs, which is precisely why it is the tool for this. Deleting the Pods by hand cycles them and records nothing at all." \
+  -- [ -n "$stamp" ]
 
 crit_all_passed || evidence "$(crit_why)"
 report "spec unchanged: nginx:1.27-alpine, 3 replicas, session-store-conf"

--- a/banks/ckad-mock-01/q32/validate.d/30_complete.sh
+++ b/banks/ckad-mock-01/q32/validate.d/30_complete.sh
@@ -3,28 +3,38 @@
 # desc: the rollout finished and all 3 replicas are ready again
 set -uo pipefail
 . /banks/_lib/checks.sh
+KEY=kubectl.kubernetes.io/restartedAt
 evidence() {
   show_actual text "$(kubectl -n sagitta get deploy session-store -o wide 2>/dev/null
     echo
-    kubectl -n sagitta get pods -l app=session-store 2>/dev/null)"
+    kubectl -n sagitta get pods -l app=session-store 2>/dev/null
+    echo
+    printf 'template %s: %s\n' "$KEY" "${stamp:-<none>}")"
   show_why "$1"
 }
 
 want=$(kubectl -n sagitta get deploy session-store -o jsonpath='{.spec.replicas}' 2>/dev/null)
 ready=$(kubectl -n sagitta get deploy session-store -o jsonpath='{.status.readyReplicas}' 2>/dev/null)
 updated=$(kubectl -n sagitta get deploy session-store -o jsonpath='{.status.updatedReplicas}' 2>/dev/null)
+stamp=$(kubectl -n sagitta get deploy session-store -o json 2>/dev/null \
+  | jq -r --arg k "$KEY" '.spec.template.metadata.annotations[$k] // empty')
 
-fully_updated() { [ -n "$want" ] && [ "$updated" = "$want" ]; }
+# A Deployment nobody has touched is already 3-of-3 updated and ready, so both
+# counts are read against the restart: it is the restart's rollout that has to
+# have finished, and the three ready Pods have to be the ones it made.
+restarted() { [ -n "$stamp" ]; }
+fully_updated() { restarted && [ -n "$want" ] && [ "$updated" = "$want" ]; }
+ready_again() { restarted && [ "$ready" = "3" ]; }
 
-crit 1 "every Pod is on the newest template" \
-  "updatedReplicas is '$updated' of '$want'" \
-  "status.updatedReplicas counts the Pods created from the CURRENT Pod template. While a rollout is in flight it sits below the replica count, and a rollout that cannot finish — an unschedulable Pod, an image that will not pull — leaves it there permanently rather than reporting an error." \
+crit 1 "every Pod is on the restarted template" \
+  "updatedReplicas is '$updated' of '$want', on a template whose $KEY is '${stamp:-<none>}'" \
+  "status.updatedReplicas counts the Pods created from the CURRENT Pod template, and the current template has to be the restarted one — without the restart stamp there has been no rollout to finish and these are the Pods the question asked you to replace. While a rollout is in flight this sits below the replica count, and a rollout that cannot finish — an unschedulable Pod, an image that will not pull — leaves it there permanently rather than reporting an error." \
   -- fully_updated
 
-crit 1 "and all 3 are ready" \
-  "readyReplicas is '$ready', want 3" \
-  "A restart is a rolling update, so it respects spec.strategy and takes as long as the Pods take to become ready. Cycling the Pods and walking away leaves the workload short-handed, which is the failure this replacement was meant to avoid." \
-  -- [ "$ready" = "3" ]
+crit 1 "and all 3 are ready again" \
+  "readyReplicas is '$ready' (want 3), on a template whose $KEY is '${stamp:-<none>}'" \
+  "'Again' is the word doing the work: three ready replicas is where this Deployment started, so what is graded is three ready Pods AFTER the restart cycled them. A restart is a rolling update, so it respects spec.strategy and takes as long as the Pods take to become ready; cycling them and walking away leaves the workload short-handed, which is the failure this replacement was meant to avoid." \
+  -- ready_again
 
 crit_all_passed || evidence "$(crit_why)"
 report "rollout complete, 3/3 ready"

--- a/banks/ckad-mock-01/q32/validate.d/30_complete.sh
+++ b/banks/ckad-mock-01/q32/validate.d/30_complete.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: the rollout finished and all 3 replicas are ready again
+set -uo pipefail
+. /banks/_lib/checks.sh
+evidence() {
+  show_actual text "$(kubectl -n sagitta get deploy session-store -o wide 2>/dev/null
+    echo
+    kubectl -n sagitta get pods -l app=session-store 2>/dev/null)"
+  show_why "$1"
+}
+
+want=$(kubectl -n sagitta get deploy session-store -o jsonpath='{.spec.replicas}' 2>/dev/null)
+ready=$(kubectl -n sagitta get deploy session-store -o jsonpath='{.status.readyReplicas}' 2>/dev/null)
+updated=$(kubectl -n sagitta get deploy session-store -o jsonpath='{.status.updatedReplicas}' 2>/dev/null)
+
+fully_updated() { [ -n "$want" ] && [ "$updated" = "$want" ]; }
+
+crit 1 "every Pod is on the newest template" \
+  "updatedReplicas is '$updated' of '$want'" \
+  "status.updatedReplicas counts the Pods created from the CURRENT Pod template. While a rollout is in flight it sits below the replica count, and a rollout that cannot finish — an unschedulable Pod, an image that will not pull — leaves it there permanently rather than reporting an error." \
+  -- fully_updated
+
+crit 1 "and all 3 are ready" \
+  "readyReplicas is '$ready', want 3" \
+  "A restart is a rolling update, so it respects spec.strategy and takes as long as the Pods take to become ready. Cycling the Pods and walking away leaves the workload short-handed, which is the failure this replacement was meant to avoid." \
+  -- [ "$ready" = "3" ]
+
+crit_all_passed || evidence "$(crit_why)"
+report "rollout complete, 3/3 ready"

--- a/banks/ckad-mock-01/q33/hints.md
+++ b/banks/ckad-mock-01/q33/hints.md
@@ -1,0 +1,26 @@
+## Hint 1
+
+Read the Service's selector before you write anything, and ask which of
+the stable Pods' labels it actually names:
+
+```bash
+k -n lupus get svc search -o jsonpath='{.spec.selector}'
+k -n lupus get pods --show-labels
+```
+
+Nothing routes here in proportions. There is only one endpoint list and
+kube-proxy picks from it evenly, so the fraction is decided entirely by
+how many Pods of each kind are in it.
+
+## Hint 2
+
+The canary's Pod template needs both labels: the one the Service selects
+on, so it joins the endpoint list, and `track: canary`, so you can still
+tell the two apart with `-l` and so its own `spec.selector.matchLabels`
+does not overlap the stable Deployment's.
+
+One fifth of five Pods is one Pod, and the total has to stay 5 — so the
+stable Deployment does not stay where it is.
+
+`kubectl create deployment --image=... --dry-run=client -o yaml` writes
+the skeleton; the labels are the part you add by hand.

--- a/banks/ckad-mock-01/q33/question.md
+++ b/banks/ckad-mock-01/q33/question.md
@@ -1,0 +1,24 @@
+Namespace `lupus` runs Deployment `search-stable` on `nginx:1.27-alpine`
+with 5 replicas, behind Service `search` on port `80`.
+
+`nginx:1.29-alpine` is ready to trial. Put it in front of real traffic,
+but only **one request in five**, by making the two versions share the
+Service and letting their replica counts decide the proportion:
+
+1. Create a Deployment named `search-canary` in `lupus` running
+   `nginx:1.29-alpine`, with container port `80`.
+2. Its Pods must be picked up by the **existing** Service `search`, and
+   must still be distinguishable from the stable Pods by a label of their
+   own. Give them `track: canary`; the stable Pods carry `track: stable`.
+3. Set the two replica counts so that the canary serves one fifth of the
+   requests and the Service is backed by **5 Pods in total**, exactly as
+   many as it is backed by now.
+
+Do not edit or replace Service `search`, and do not change what
+`search-stable` runs.
+
+When you are done, every Pod behind the Service should be ready:
+
+```bash
+k -n lupus get endpointslice -l kubernetes.io/service-name=search
+```

--- a/banks/ckad-mock-01/q33/setup.sh
+++ b/banks/ckad-mock-01/q33/setup.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl create ns lupus --dry-run=client -o yaml | kubectl apply -f -
+
+# The canary is the candidate's to create, so re-seeding has to take it away
+# again or the Service starts the question with six endpoints behind it.
+kubectl -n lupus delete deploy search-canary --ignore-not-found >/dev/null
+
+# The Service selects on app=search alone. That is what makes a canary possible
+# here at all: a second Deployment carrying the same app label joins the same
+# endpoint list without the Service being touched.
+kubectl -n lupus apply -f - <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: search-stable
+  namespace: lupus
+spec:
+  replicas: 5
+  selector:
+    matchLabels: {app: search, track: stable}
+  template:
+    metadata:
+      labels: {app: search, track: stable}
+    spec:
+      containers:
+        - name: web
+          image: nginx:1.27-alpine
+          ports: [{containerPort: 80}]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: search
+  namespace: lupus
+spec:
+  selector: {app: search}
+  ports: [{port: 80, targetPort: 80, protocol: TCP}]
+EOF
+
+kubectl -n lupus rollout status deploy/search-stable --timeout=180s

--- a/banks/ckad-mock-01/q33/solution.md
+++ b/banks/ckad-mock-01/q33/solution.md
@@ -1,0 +1,117 @@
+# Solution 33
+
+Start with the Service, because it decides whether any of this is
+possible:
+
+```bash
+k -n lupus get svc search -o jsonpath='{.spec.selector}'
+# {"app":"search"}
+
+k -n lupus get pods --show-labels
+# search-stable-...   app=search,track=stable,pod-template-hash=...
+```
+
+The selector names `app` and says nothing about `track`. So anything in
+this Namespace carrying `app=search` joins the same endpoint list, and
+the canary is just a second Deployment that wears that label.
+
+Write it:
+
+```yaml
+# canary.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: search-canary
+  namespace: lupus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: search
+      track: canary
+  template:
+    metadata:
+      labels:
+        app: search
+        track: canary
+    spec:
+      containers:
+        - name: web
+          image: nginx:1.29-alpine
+          ports:
+            - containerPort: 80
+```
+
+```bash
+k -n lupus apply -f canary.yaml
+k -n lupus scale deploy/search-stable --replicas=4
+k -n lupus rollout status deploy/search-canary
+```
+
+Five endpoints, one of them the new version:
+
+```bash
+k -n lupus get endpointslice -l kubernetes.io/service-name=search
+k -n lupus get pods -l app=search --show-labels
+k -n lupus get pods -l app=search,track=canary
+```
+
+## Why the counts are the split
+
+There is no weighting anywhere in a Service. The EndpointSlice
+controller collects every ready Pod matching the selector into one flat
+list, and kube-proxy picks from that list evenly. So the only lever is
+how many Pods of each kind are in it:
+
+```
+canary share = canary ready Pods / all ready Pods behind the Service
+```
+
+One canary Pod out of five is 20%. That also fixes the granularity:
+with five Pods the smallest step you can take is 20%, and 5% would need
+twenty Pods. This is the honest limitation of replica-count canaries, and
+the reason service meshes and Ingress controllers exist — they can weight
+by request instead of by Pod, at the price of another component to run.
+
+Scaling the stable Deployment down at the same time is what keeps
+capacity constant. Adding a canary Pod on top of five would be a 6-Pod
+Service serving one sixth to the canary, and quietly 20% more capacity
+than the workload was sized for.
+
+## Why both labels
+
+`app: search` is what puts the Pod in the endpoint list.
+
+`track: canary` does two things:
+
+- It keeps the two Deployments' `spec.selector.matchLabels` **disjoint**.
+  If the canary selected on `app: search` alone, its ReplicaSet would
+  count the stable Pods as its own — two controllers fighting over one
+  set of Pods, deleting each other's, forever. `selector` is immutable
+  after creation, so the recovery is deleting the Deployment.
+- It gives you a handle on each version:
+  `kubectl -n lupus get pods -l app=search,track=canary`, and
+  `kubectl -n lupus logs -l track=canary` when you go looking for the
+  errors the trial is meant to surface.
+
+## Reading the result
+
+Do not try to prove the split by sending ten requests and counting. The
+selection is per connection and unweighted, so ten requests to a 1-in-5
+split land two canary hits *on average* and quite often none — you would
+be measuring a random variable, not a configuration. What you can read
+directly is the endpoint list and the replica counts, which is what the
+split actually is.
+
+## Rolling it out or rolling it back
+
+Promotion is `kubectl -n lupus scale` in a loop: canary up, stable down,
+one step at a time, watching the canary's logs at each step. Rollback is
+one command — `kubectl -n lupus scale deploy/search-canary --replicas=0`
+— and it takes effect as fast as the endpoint list is rebuilt.
+
+Compare that with blue/green, where the whole of the traffic moves the
+instant the Service's selector moves. Blue/green trades exposure for
+speed: nobody is ever served a mixture, and nobody trials the new version
+on 20% of users first either.

--- a/banks/ckad-mock-01/q33/validate.d/10_canary.sh
+++ b/banks/ckad-mock-01/q33/validate.d/10_canary.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# points: 3
+# desc: search-canary runs one Pod of nginx:1.29-alpine labelled into the Service
+set -uo pipefail
+. /banks/_lib/checks.sh
+evidence() {
+  show_actual json "$(kubectl -n lupus get deploy search-canary -o json 2>/dev/null \
+    | jq '{replicas: .spec.replicas, ready: .status.readyReplicas,
+           selector: .spec.selector.matchLabels,
+           templateLabels: .spec.template.metadata.labels,
+           images: [.spec.template.spec.containers[].image]}')"
+  show_why "$1"
+}
+
+kubectl -n lupus get deploy search-canary >/dev/null 2>&1 || {
+  echo "Deployment search-canary does not exist in namespace lupus"
+  show_actual text "$(kubectl -n lupus get deploy 2>/dev/null)"
+  show_why "The canary is a second Deployment alongside the stable one, not a change to it. Both are owned separately, scaled separately and rolled back separately — which is the point: the trial can be removed without touching the release that is serving everybody else."
+  exit 1
+}
+
+spec=$(kubectl -n lupus get deploy search-canary -o json 2>/dev/null)
+img=$(printf '%s' "$spec" | jq -r '[.spec.template.spec.containers[].image] | join(",")')
+app=$(printf '%s' "$spec" | jq -r '.spec.template.metadata.labels.app // ""')
+track=$(printf '%s' "$spec" | jq -r '.spec.template.metadata.labels.track // ""')
+ready=$(printf '%s' "$spec" | jq -r '.status.readyReplicas // 0')
+
+labelled() { [ "$app" = "search" ] && [ "$track" = "canary" ]; }
+
+crit 1 "runs the version being trialled" \
+  "container image is '$img', want nginx:1.29-alpine" \
+  "The canary exists to put a specific new version in front of a slice of real traffic. Running the same image as the stable Deployment splits the traffic between two identical things and measures nothing." \
+  -- [ "$img" = "nginx:1.29-alpine" ]
+
+crit 1 "its Pods carry app=search and track=canary" \
+  "Pod template labels are app='$app' track='$track', want app=search and track=canary" \
+  "app=search is what the Service already selects on, so it is what puts these Pods into the same endpoint list as the stable ones — that is the entire wiring. track=canary keeps the two Deployments' matchLabels disjoint, without which the canary's ReplicaSet would adopt the stable Pods and the two controllers would delete each other's work, and it is also the handle that gets you this version's logs on their own." \
+  -- labelled
+
+crit 1 "exactly one canary Pod is ready" \
+  "search-canary has $ready ready replica(s), want 1" \
+  "One Pod in five is the 20% the question asks for. The count is not a detail of the answer here, it IS the answer: a Service has no weighting of any kind, so the proportion is decided purely by how many ready Pods of each kind are behind it." \
+  -- [ "$ready" = "1" ]
+
+crit_all_passed || evidence "$(crit_why)"
+report "canary running one Pod of nginx:1.29-alpine"

--- a/banks/ckad-mock-01/q33/validate.d/20_stable.sh
+++ b/banks/ckad-mock-01/q33/validate.d/20_stable.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# points: 1
+# desc: search-stable was scaled to 4 and still runs what it ran before
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+want=$(kubectl -n lupus get deploy search-stable -o jsonpath='{.spec.replicas}' 2>/dev/null)
+ready=$(kubectl -n lupus get deploy search-stable -o jsonpath='{.status.readyReplicas}' 2>/dev/null)
+img=$(kubectl -n lupus get deploy search-stable \
+  -o jsonpath='{.spec.template.spec.containers[?(@.name=="web")].image}' 2>/dev/null)
+
+[ "$want" = "4" ] && [ "$ready" = "4" ] && [ "$img" = "nginx:1.27-alpine" ] && {
+  echo "search-stable holds the other 4 fifths"
+  exit 0
+}
+
+echo "search-stable: replicas='$want' ready='$ready' image='$img'; want 4, 4 and nginx:1.27-alpine"
+show_actual json "$(kubectl -n lupus get deploy search-stable -o json 2>/dev/null \
+  | jq '{replicas: .spec.replicas, ready: .status.readyReplicas,
+         images: [.spec.template.spec.containers[].image]}')"
+show_why "Capacity is the reason the stable Deployment moves. Adding a canary Pod on top of five leaves six Pods behind the Service — one sixth to the canary rather than one fifth, and 20% more capacity than the workload was sized for. Scaling stable to 4 keeps the total at 5 and makes the canary's share exactly one in five. The image is checked with it because the stable release is the control in this experiment: change what it runs and the trial compares nothing."
+exit 1

--- a/banks/ckad-mock-01/q33/validate.d/30_split.sh
+++ b/banks/ckad-mock-01/q33/validate.d/30_split.sh
@@ -22,6 +22,16 @@ port=$(kubectl -n lupus get svc search -o jsonpath='{.spec.ports[?(@.port==80)].
   exit 1
 }
 
+# The question rules this one out: Service search was not to be edited or
+# replaced. It is a gate rather than a criterion because leaving it alone is
+# what a candidate who has done nothing at all has also done.
+[ "$port" = "80" ] || {
+  echo "Service search no longer publishes port 80 (selector: $sel)"
+  show_actual json "$(kubectl -n lupus get svc search -o json 2>/dev/null | jq '{selector: .spec.selector, ports: .spec.ports}')"
+  show_why "The question ruled this out: Service search was not to be edited or replaced, and it no longer publishes the port it was published on. Clients hold the Service's name and port. A canary that changes either has broken every caller in exchange for a trial that was supposed to be invisible to them — the whole point of this shape is that the Service needs no edit, because it already selects on the one label both releases share."
+  exit 1
+}
+
 names=$(printf '%s' "$slices" | jq -r '.items[].endpoints[]? | select(.conditions.ready == true) | .targetRef.name // empty')
 total=$(printf '%s\n' "$names" | grep -c . || true)
 canary_pods=$(kubectl -n lupus get pods -l app=search,track=canary \
@@ -32,15 +42,14 @@ for n in $names; do
   has_name "$canary_pods" "$n" && canary=$((canary + 1))
 done
 
-crit 1 "the Service was left as it was" \
-  "Service search no longer publishes port 80 (selector: $sel)" \
-  "Clients hold the Service's name and port. A canary that changes either has broken every caller in exchange for a trial that was supposed to be invisible to them." \
-  -- [ "$port" = "80" ]
+# Five ready endpoints is the number the Service started with, so the count
+# grades the answer only once the canary is one of them.
+held_at_five() { [ "$total" = "5" ] && [ "${canary:-0}" -ge 1 ]; }
 
-crit 1 "5 Pods are behind it, as before" \
-  "the Service has $total ready endpoint(s), want 5" \
-  "Every ready Pod matching the selector lands in one flat endpoint list, and kube-proxy picks from it evenly. Six endpoints means the canary was added on top of the stable five instead of taking a share of them, which is both the wrong proportion and more capacity than the workload was sized for; fewer than five means Pods are still starting or the labels do not match." \
-  -- [ "$total" = "5" ]
+crit 1 "5 Pods are behind it, as before, and the canary is among them" \
+  "the Service has $total ready endpoint(s), $canary of them canary; want 5 in total with the canary in the list" \
+  "Every ready Pod matching the selector lands in one flat endpoint list, and kube-proxy picks from it evenly. Five is where this Service started, so it counts once the canary has joined that list: capacity held constant WITH the trial running is the thing being graded. Six endpoints means the canary was added on top of the stable five instead of taking a share of them, which is both the wrong proportion and more capacity than the workload was sized for; five with no canary in the list means its Pods do not carry the label the Service selects on." \
+  -- held_at_five
 
 crit 1 "exactly one of them is the canary" \
   "$canary of the $total ready endpoints belong to track=canary Pods, want 1" \

--- a/banks/ckad-mock-01/q33/validate.d/30_split.sh
+++ b/banks/ckad-mock-01/q33/validate.d/30_split.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# points: 3
+# desc: the untouched Service is backed by 5 ready endpoints, 1 of them canary
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+slices=$(kubectl -n lupus get endpointslice -l kubernetes.io/service-name=search -o json 2>/dev/null)
+evidence() {
+  show_actual json "$(printf '%s' "$slices" | jq '[.items[].endpoints[]? |
+    {pod: .targetRef.name, ready: .conditions.ready}]')"
+  show_why "$1"
+}
+
+sel=$(kubectl -n lupus get svc search -o json 2>/dev/null \
+  | jq -r '.spec.selector // {} | to_entries | map("\(.key)=\(.value)") | sort | join(",")')
+port=$(kubectl -n lupus get svc search -o jsonpath='{.spec.ports[?(@.port==80)].port}' 2>/dev/null)
+
+[ -n "$sel" ] || {
+  echo "Service search has no selector, so nothing is behind it"
+  show_actual json "$(kubectl -n lupus get svc search -o json 2>/dev/null | jq '{spec: .spec.selector, ports: .spec.ports}')"
+  show_why "The Service is the pre-seeded half of this question and the task says to leave it alone. It already selects on the one label both releases can share; a Service with no spec.selector is never given endpoints by the controller at all, so removing or replacing it takes the canary and the stable release offline together."
+  exit 1
+}
+
+names=$(printf '%s' "$slices" | jq -r '.items[].endpoints[]? | select(.conditions.ready == true) | .targetRef.name // empty')
+total=$(printf '%s\n' "$names" | grep -c . || true)
+canary_pods=$(kubectl -n lupus get pods -l app=search,track=canary \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null)
+
+canary=0
+for n in $names; do
+  has_name "$canary_pods" "$n" && canary=$((canary + 1))
+done
+
+crit 1 "the Service was left as it was" \
+  "Service search no longer publishes port 80 (selector: $sel)" \
+  "Clients hold the Service's name and port. A canary that changes either has broken every caller in exchange for a trial that was supposed to be invisible to them." \
+  -- [ "$port" = "80" ]
+
+crit 1 "5 Pods are behind it, as before" \
+  "the Service has $total ready endpoint(s), want 5" \
+  "Every ready Pod matching the selector lands in one flat endpoint list, and kube-proxy picks from it evenly. Six endpoints means the canary was added on top of the stable five instead of taking a share of them, which is both the wrong proportion and more capacity than the workload was sized for; fewer than five means Pods are still starting or the labels do not match." \
+  -- [ "$total" = "5" ]
+
+crit 1 "exactly one of them is the canary" \
+  "$canary of the $total ready endpoints belong to track=canary Pods, want 1" \
+  "This is the split itself, read off the object that decides it. Zero means the canary's Pods do not carry the label the Service selects on, so they are running and serving nobody. More than one means the counts do not divide the way the question asked." \
+  -- [ "$canary" = "1" ]
+
+crit_all_passed || evidence "$(crit_why)"
+report "5 ready endpoints, 1 canary — one request in five"

--- a/banks/ckad-mock-01/q34/hints.md
+++ b/banks/ckad-mock-01/q34/hints.md
@@ -1,0 +1,23 @@
+## Hint 1
+
+Find out what the chart is willing to be told before writing anything
+down. `helm show values` prints the defaults, and the shape of that
+output is the shape your file has to be in — one of the two keys is
+nested inside another.
+
+The flag that reads a values file is the same short flag `kubectl` uses
+for a manifest.
+
+## Hint 2
+
+```bash
+helm show values sim/sim-cache
+```
+
+Override the tag only, not the repository or the pull policy: Helm merges
+your file into the chart's defaults key by key, so anything you leave out
+keeps coming from the chart.
+
+Install with `helm -n caelum install <release> <chart> -f <file>`, then
+read back what the release believes it was given with
+`helm -n caelum get values object-cache`.

--- a/banks/ckad-mock-01/q34/question.md
+++ b/banks/ckad-mock-01/q34/question.md
@@ -1,0 +1,19 @@
+The chart repository `sim` is already configured, and Namespace `caelum`
+is empty. Chart `sim/sim-cache` installs a cache workload whose defaults
+are one replica of `nginx:1.29-alpine`.
+
+Team Caelum keeps every deviation from a chart's defaults in a file that
+is reviewed and committed, never in a shell command.
+
+1. Write a values file at `/opt/course/34/cache-values.yaml` on
+   `instance-2` that overrides **only** two of the chart's values: the
+   replica count, to `3`, and the image tag, to `1.27-alpine`. Everything
+   else must keep coming from the chart.
+2. Install chart `sim/sim-cache` into Namespace `caelum` as release
+   `object-cache`, **taking those values from that file**, not from
+   `--set` arguments.
+3. Leave the file where it is. It is the reviewed artifact, and the
+   grader reads it.
+
+The release must end up `deployed`, with 3 ready replicas running
+`nginx:1.27-alpine`.

--- a/banks/ckad-mock-01/q34/setup.sh
+++ b/banks/ckad-mock-01/q34/setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl create ns caelum --dry-run=client -o yaml | kubectl apply -f -
+
+# The candidate installs the release themselves, so re-seeding this question
+# means going back to an empty Namespace — and the release record has to go with
+# the objects, which is why this is not a kubectl delete.
+helm -n caelum uninstall object-cache >/dev/null 2>&1 || true

--- a/banks/ckad-mock-01/q34/solution.md
+++ b/banks/ckad-mock-01/q34/solution.md
@@ -1,0 +1,109 @@
+# Solution 34
+
+Ask the chart what it accepts before writing anything. Guessing key names
+is the slow way to do this, and a key the chart does not have is accepted
+silently and then ignored:
+
+```bash
+helm show values sim/sim-cache
+# replicaCount: 1
+# image:
+#   repository: nginx
+#   tag: 1.29-alpine
+#   pullPolicy: IfNotPresent
+```
+
+Two of those need overriding, and the second one is nested. The file
+mirrors that structure exactly:
+
+```yaml
+# /opt/course/34/cache-values.yaml
+replicaCount: 3
+image:
+  tag: 1.27-alpine
+```
+
+Note what is *not* in it. `repository` and `pullPolicy` are left out, so
+they keep coming from the chart — Helm merges maps key by key rather than
+replacing them wholesale.
+
+Install with it:
+
+```bash
+helm -n caelum install object-cache sim/sim-cache -f /opt/course/34/cache-values.yaml
+helm -n caelum list
+# NAME          REVISION  STATUS    CHART            APP VERSION
+# object-cache  1         deployed  sim-cache-1.0.0  1.29-alpine
+```
+
+Then check what the release actually believes it was given, which is a
+different question from what you meant to give it:
+
+```bash
+helm -n caelum get values object-cache
+# replicaCount: 3
+# image:
+#   tag: 1.27-alpine
+
+k -n caelum get deploy object-cache
+# object-cache   3/3   3   3
+```
+
+`APP VERSION` still reads `1.29-alpine` because that comes from
+`Chart.yaml` and is metadata about the chart, not about what you asked it
+to run. The Pods are on 1.27:
+
+```bash
+k -n caelum get deploy object-cache \
+  -o jsonpath='{.spec.template.spec.containers[*].image}'
+# nginx:1.27-alpine
+```
+
+## Why a file rather than --set
+
+`--set replicaCount=3 --set image.tag=1.27-alpine` produces an identical
+release. Everything that differs is outside Helm:
+
+- **It is reviewable.** A values file goes through the same review as
+  code. A flag lives in one person's shell history.
+- **It is the input to the next upgrade.** `helm upgrade` does not
+  inherit the previous revision's values unless you say so, so an
+  upgrade without the file or without `--reuse-values` silently reverts
+  every override to the chart's defaults. With a file, the upgrade is
+  the install command with one word changed.
+- **It types things properly.** `--set` parses its own miniature syntax:
+  commas separate values, dots descend into maps, and both have to be
+  escaped when they are part of the data. `--set` also coerces what looks
+  numeric, which is why `--set version=1.10` becomes `1.1`. YAML has none
+  of these problems.
+- **It nests without ceremony.** `image.tag` is a two-line block in a
+  file and a dotted path in a flag, and the dots get worse with depth.
+
+`--set` earns its place for the one value that must not be written down
+— a password, a token — and for scripted one-offs.
+
+## How the values are merged
+
+Helm layers values in this order, each overriding the one before:
+
+1. the chart's own `values.yaml`
+2. each `-f` file, in the order given on the command line
+3. `--set` and `--set-string`, applied last
+
+So `-f base.yaml -f prod.yaml` is a legitimate way to keep a common file
+and a per-environment one, and a stray `--set` always wins over both.
+
+`helm get values <release>` shows only what *you* supplied. To see the
+whole merged set the templates actually rendered against, ask for all of
+it:
+
+```bash
+helm -n caelum get values object-cache --all
+```
+
+And to see the manifests a values file would produce without installing
+anything:
+
+```bash
+helm template object-cache sim/sim-cache -f /opt/course/34/cache-values.yaml
+```

--- a/banks/ckad-mock-01/q34/validate.d/10_values-file.sh
+++ b/banks/ckad-mock-01/q34/validate.d/10_values-file.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: /opt/course/34/cache-values.yaml overrides the replica count and the tag
+set -uo pipefail
+. /banks/_lib/checks.sh
+F=/opt/course/34/cache-values.yaml
+evidence() {
+  show_actual text "$(cat "$F" 2>/dev/null)"
+  show_why "$1"
+}
+
+[ -f "$F" ] || {
+  echo "$F does not exist"
+  show_actual text "$(ls -l /opt/course/34/ 2>/dev/null)"
+  show_why "The file is the deliverable this question is about, not scaffolding for it. A release installed with --set reaches the same cluster and leaves nothing behind to review, nothing to commit, and nothing to hand the next upgrade — which is why the path is graded on its own."
+  exit 1
+}
+
+reps=$(yq -r '.replicaCount // ""' "$F" 2>/dev/null)
+tag=$(yq -r '.image.tag // ""' "$F" 2>/dev/null)
+
+crit 1 "sets replicaCount to 3" \
+  "replicaCount in the values file is '$reps', want 3" \
+  "The keys in a values file are the chart's own, spelled exactly as its values.yaml spells them — 'helm show values sim/sim-cache' prints them. A key the chart does not use is not an error: Helm accepts it, no template reads it, and the release comes out with the defaults." \
+  -- [ "$reps" = "3" ]
+
+crit 1 "sets image.tag to 1.27-alpine, nested under image" \
+  "image.tag in the values file is '$tag', want 1.27-alpine" \
+  "The tag lives inside the image map, so it is two lines in a file rather than the one dotted path --set would need. Writing it flat as 'image.tag: 1.27-alpine' creates a top-level key with a dot in its name, which no template ever reads. Leaving repository and pullPolicy out is deliberate and correct: Helm merges a values file into the chart's defaults key by key, so anything absent keeps coming from the chart." \
+  -- [ "$tag" = "1.27-alpine" ]
+
+crit_all_passed || evidence "$(crit_why)"
+report "values file overrides replicaCount and image.tag"

--- a/banks/ckad-mock-01/q34/validate.d/20_release.sh
+++ b/banks/ckad-mock-01/q34/validate.d/20_release.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# points: 3
+# desc: object-cache is a deployed sim-cache release carrying those values
+set -uo pipefail
+. /banks/_lib/checks.sh
+export HELM_NAMESPACE=caelum
+evidence() {
+  show_actual text "$(helm ls -a 2>/dev/null; echo; helm get values object-cache 2>/dev/null)"
+  show_why "$1"
+}
+
+info=$(helm ls -a -o json 2>/dev/null | jq -r '.[] | select(.name == "object-cache") | "\(.chart)|\(.status)"')
+[ -n "$info" ] || {
+  echo "there is no release named object-cache in namespace caelum"
+  show_actual text "$(helm ls -a 2>/dev/null)"
+  show_why "The release name is chosen at install time and is what every later helm command addresses; one chart backs as many releases as you like, each with its own values and its own history. Creating the Deployment with kubectl instead reaches similar objects that Helm does not know about and will never upgrade."
+  exit 1
+}
+
+chart=${info%%|*}
+status=${info##*|}
+reps=$(helm get values object-cache -o json 2>/dev/null | jq -r '.replicaCount // empty')
+tag=$(helm get values object-cache -o json 2>/dev/null | jq -r '.image.tag // empty')
+
+from_sim_cache() { printf '%s' "$chart" | grep -q '^sim-cache-'; }
+carries_values() { [ "$reps" = "3" ] && [ "$tag" = "1.27-alpine" ]; }
+
+crit 1 "installed from sim/sim-cache" \
+  "object-cache uses chart '$chart', want sim-cache" \
+  "The chart supplies the templates and the defaults; the release name says nothing about which one was used. Installing the wrong chart under the right release name produces a release that looks correct in helm ls and renders something else entirely." \
+  -- from_sim_cache
+
+crit 1 "the release is deployed" \
+  "release status is '$status', want deployed" \
+  "A release that is not deployed did not finish. An install that fails leaves the record behind marked failed, with whatever objects it managed to create still in the cluster — helm ls hides it unless you ask for all releases." \
+  -- [ "$status" = "deployed" ]
+
+crit 1 "the overrides reached the release" \
+  "the release was given replicaCount='$reps' and image.tag='$tag', want 3 and 1.27-alpine" \
+  "This is what the release itself believes it was given, which is a different question from what the file says. A values file that was written but never passed on the command line leaves this empty and the release on the chart's defaults, and the difference does not show up until an upgrade re-renders the chart and reverts everything." \
+  -- carries_values
+
+crit_all_passed || evidence "$(crit_why)"
+report "object-cache is a deployed ${chart} release with the file's values"

--- a/banks/ckad-mock-01/q34/validate.d/30_deployment.sh
+++ b/banks/ckad-mock-01/q34/validate.d/30_deployment.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: the rendered Deployment runs 3 ready replicas of nginx:1.27-alpine
+set -uo pipefail
+. /banks/_lib/checks.sh
+evidence() {
+  show_actual text "$(kubectl -n caelum get deploy,pod 2>/dev/null)"
+  show_why "$1"
+}
+
+img=$(kubectl -n caelum get deploy object-cache \
+  -o jsonpath='{.spec.template.spec.containers[*].image}' 2>/dev/null)
+ready=$(kubectl -n caelum get deploy object-cache -o jsonpath='{.status.readyReplicas}' 2>/dev/null)
+
+crit 1 "the tag override was rendered into the Pod template" \
+  "the Deployment runs '$img', want nginx:1.27-alpine" \
+  "The chart builds this string from image.repository and image.tag together, so overriding only the tag keeps nginx as the repository and swaps the version. The release's APP VERSION column still reads the chart's appVersion and is metadata about the chart rather than about what it was told to run — read the Pod template, not the release listing." \
+  -- [ "$img" = "nginx:1.27-alpine" ]
+
+crit 1 "all 3 replicas are ready" \
+  "readyReplicas is '$ready', want 3" \
+  "The replica count is rendered from replicaCount into the Deployment's spec, and the cluster then has to satisfy it. A gap here is Pods still starting, or an image tag the nodes cannot fetch — this cluster is air-gapped, so a tag that is not already on the node never arrives." \
+  -- [ "$ready" = "3" ]
+
+crit_all_passed || evidence "$(crit_why)"
+report "object-cache: 3/3 ready on nginx:1.27-alpine"

--- a/banks/ckad-mock-01/q35/files/base/deployment.yaml
+++ b/banks/ckad-mock-01/q35/files/base/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ledger-api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: ledger-api
+  template:
+    metadata:
+      labels:
+        app: ledger-api
+    spec:
+      containers:
+        - name: api
+          image: nginx:1.29-alpine
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 30
+            periodSeconds: 10

--- a/banks/ckad-mock-01/q35/files/base/kustomization.yaml
+++ b/banks/ckad-mock-01/q35/files/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml

--- a/banks/ckad-mock-01/q35/files/overlays/prod/kustomization.yaml
+++ b/banks/ckad-mock-01/q35/files/overlays/prod/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# The base this overlay builds on. Everything else is up to you.
+resources:
+  - ../../base
+
+# TODO: neither change the question asks for is something a kustomize
+# transformer can express, so add a patch. Do not edit anything under base/.

--- a/banks/ckad-mock-01/q35/hints.md
+++ b/banks/ckad-mock-01/q35/hints.md
@@ -1,0 +1,22 @@
+## Hint 1
+
+A transformer changes one well-known thing across every resource. A patch
+changes anything at all, in one named resource, and that is why this
+question needs one.
+
+The key is plural, and each entry is either a fragment of the object you
+want merged in, or a file holding one. `kubectl kustomize` renders the
+result without applying it — run it after every edit.
+
+## Hint 2
+
+Under `patches:`, an entry with `patch: |` and an inline document is
+enough; the document needs `apiVersion`, `kind` and
+`metadata.name` so kustomize knows which resource it belongs to.
+
+Everything below that is merged into the base, so write only the fields
+you are changing. Lists of containers merge on the container's `name`
+field, so name the container and give it just the `env` entry and the one
+probe field.
+
+Apply with `kubectl -n norma apply -k /opt/course/35/overlays/prod`.

--- a/banks/ckad-mock-01/q35/question.md
+++ b/banks/ckad-mock-01/q35/question.md
@@ -1,0 +1,24 @@
+A Kustomize base lives at `/opt/course/35/base` on `instance-1`, holding
+Deployment `ledger-api`. Its unfinished production overlay is at
+`/opt/course/35/overlays/prod`.
+
+Complete **only** `/opt/course/35/overlays/prod/kustomization.yaml` — do
+not edit anything under `base/` — so that building the overlay renders a
+Deployment whose container `api`:
+
+1. has the environment variable `LEDGER_MODE` set to `prod`
+2. becomes ready sooner: `readinessProbe.initialDelaySeconds` is `5`
+   instead of the base's `30`, with the rest of the probe unchanged
+
+Neither of those is something a `kustomization.yaml` field such as
+`images`, `replicas` or `namePrefix` can express, so the overlay must
+carry a **patch**.
+
+Then apply the overlay to Namespace `norma`, so that Deployment
+`ledger-api` exists there with 2 ready replicas.
+
+Preview your work before applying it:
+
+```bash
+kubectl kustomize /opt/course/35/overlays/prod
+```

--- a/banks/ckad-mock-01/q35/setup.sh
+++ b/banks/ckad-mock-01/q35/setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl create ns norma --dry-run=client -o yaml | kubectl apply -f -
+
+# Applying the overlay is the candidate's step, so re-seeding undoes it. The
+# overlay itself lives on the instance, out of this script's reach.
+kubectl -n norma delete deploy ledger-api --ignore-not-found >/dev/null

--- a/banks/ckad-mock-01/q35/solution.md
+++ b/banks/ckad-mock-01/q35/solution.md
@@ -1,0 +1,127 @@
+# Solution 35
+
+Read the base first, and confirm it renders on its own:
+
+```bash
+cd /opt/course/35
+cat base/kustomization.yaml base/deployment.yaml
+kubectl kustomize base
+```
+
+Neither requirement has a `kustomization.yaml` field behind it. There is
+no `env:` transformer and no probe transformer — `images`, `replicas`,
+`namePrefix`, `namespace` and `labels` are the whole vocabulary, and it
+is deliberately small. Anything outside it is a patch.
+
+```yaml
+# /opt/course/35/overlays/prod/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ledger-api
+      spec:
+        template:
+          spec:
+            containers:
+              - name: api
+                env:
+                  - name: LEDGER_MODE
+                    value: prod
+                readinessProbe:
+                  initialDelaySeconds: 5
+```
+
+Render it, read what came out, and only then apply:
+
+```bash
+kubectl kustomize overlays/prod
+kubectl -n norma apply -k overlays/prod
+kubectl -n norma rollout status deploy/ledger-api
+kubectl -n norma get deploy ledger-api \
+  -o jsonpath='{.spec.template.spec.containers[0].env}{"\n"}'
+```
+
+## Why this merges rather than replaces
+
+That fragment is a **strategic merge patch**, and strategic merge knows
+the Kubernetes types:
+
+- `spec.template.spec.containers` is a list whose merge key is `name`, so
+  the entry named `api` is merged into the base's `api` container rather
+  than replacing the list. Omit the name and kustomize has nothing to
+  match on.
+- `readinessProbe` is a struct, so it merges field by field. Supplying
+  `initialDelaySeconds` alone leaves `httpGet`, `path`, `port` and
+  `periodSeconds` exactly as the base has them. This is the part worth
+  internalising — the same patch written against a plain list would have
+  wiped the probe.
+- `env` is a list with merge key `name` too, so `LEDGER_MODE` is added
+  beside anything already there rather than replacing it.
+
+Everything you do not mention is left alone. A patch is a description of
+the difference, not a replacement document.
+
+## The JSON 6902 alternative
+
+The same two changes, addressed by path instead:
+
+```yaml
+patches:
+  - target:
+      kind: Deployment
+      name: ledger-api
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: LEDGER_MODE
+            value: prod
+      - op: replace
+        path: /spec/template/spec/containers/0/readinessProbe/initialDelaySeconds
+        value: 5
+```
+
+It is exact and it is brittle: `/containers/0` is a position, so
+inserting a sidecar ahead of `api` silently retargets the patch at the
+wrong container. `op: replace` also fails outright if the path does not
+exist, where `add` on a list index inserts. Reach for 6902 when strategic
+merge cannot express the change — deleting a list element, or patching a
+custom resource whose schema kustomize does not know — and prefer
+strategic merge otherwise.
+
+## Why the base is off limits
+
+Editing `base/deployment.yaml` reaches the same rendered output and
+destroys the reason the directory is laid out this way. The base is what
+every environment shares; the overlay is what one environment differs by.
+Put `LEDGER_MODE=prod` in the base and staging gets it too, silently, the
+next time anyone builds it — and the overlay that is supposed to document
+production's differences documents nothing.
+
+The check builds the overlay *and* reads what the base still says, so the
+shortcut scores zero for the same reason.
+
+## `patches` versus the older keys
+
+`patchesStrategicMerge` and `patchesJson6902` are the deprecated
+predecessors of the single `patches` field, which infers which of the two
+a document is by looking at it. They still build; `patches` is what to
+write in anything new.
+
+A patch entry can also point at a file instead of inlining the document:
+
+```yaml
+patches:
+  - path: probe-and-env.yaml
+```
+
+which is the better shape once a patch outgrows a few lines, because the
+file is a real manifest that an editor will validate and highlight.

--- a/banks/ckad-mock-01/q35/validate.d/10_rendered.sh
+++ b/banks/ckad-mock-01/q35/validate.d/10_rendered.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# points: 3
+# desc: the overlay renders the env var and the shortened probe delay
+set -uo pipefail
+. /banks/_lib/checks.sh
+evidence() {
+  show_actual yaml "$out"
+  show_why "$1"
+}
+
+out=$(kubectl kustomize /opt/course/35/overlays/prod 2>&1)
+[ $? -eq 0 ] || {
+  echo "kubectl kustomize failed: $(printf '%s' "$out" | head -2)"
+  show_actual text "$out"
+  show_why "The overlay does not build at all, and the error above names the field. Building it costs nothing and touches nothing, so it is the fastest way to see what a kustomization produces before applying it — every key is validated strictly, and a misspelled one is refused rather than ignored."
+  exit 1
+}
+
+dep=$(printf '%s' "$out" | yq 'select(.kind == "Deployment")' - 2>/dev/null)
+[ -n "$dep" ] || {
+  echo "the overlay renders no Deployment"
+  evidence "The build produced no Deployment, which means the base is not being included: an overlay lists the base under resources, and without it there is nothing to patch and the build renders only what the overlay itself declares."
+  exit 1
+}
+
+api='.spec.template.spec.containers[] | select(.name == "api")'
+mode=$(printf '%s' "$dep" | yq -r "$api | .env[]? | select(.name == \"LEDGER_MODE\") | .value" - 2>/dev/null)
+delay=$(printf '%s' "$dep" | yq -r "$api | .readinessProbe.initialDelaySeconds" - 2>/dev/null)
+probe=$(printf '%s %s %s' \
+  "$(printf '%s' "$dep" | yq -r "$api | .readinessProbe.httpGet.path" - 2>/dev/null)" \
+  "$(printf '%s' "$dep" | yq -r "$api | .readinessProbe.httpGet.port" - 2>/dev/null)" \
+  "$(printf '%s' "$dep" | yq -r "$api | .readinessProbe.periodSeconds" - 2>/dev/null)")
+
+crit 1 "the container carries LEDGER_MODE=prod" \
+  "rendered LEDGER_MODE is '$mode', want prod" \
+  "There is no env transformer in a kustomization, which is why this needs a patch. A strategic merge patch matches the container by its name field and merges into it, so the container's name has to appear in the patch even though nothing about it is changing." \
+  -- [ "$mode" = "prod" ]
+
+crit 1 "the readiness probe starts after 5 seconds" \
+  "rendered initialDelaySeconds is '$delay', want 5" \
+  "The base waits 30 seconds before probing at all. Overriding one field of a probe is again beyond any transformer, so it belongs in the same patch." \
+  -- [ "$delay" = "5" ]
+
+crit 1 "and the rest of the probe survived the patch" \
+  "rendered probe is path/port/period '$probe', want '/ 80 10'" \
+  "readinessProbe is a struct, so a strategic merge patch merges it field by field: naming initialDelaySeconds alone leaves httpGet and periodSeconds exactly as the base has them. This is what separates a patch from a replacement — everything you do not mention is left alone — and it is also where a JSON 6902 'replace' on the whole probe would have taken the rest of it with it." \
+  -- [ "$probe" = "/ 80 10" ]
+
+crit_all_passed || evidence "$(crit_why)"
+report "the overlay renders the env var and the shortened probe"

--- a/banks/ckad-mock-01/q35/validate.d/10_rendered.sh
+++ b/banks/ckad-mock-01/q35/validate.d/10_rendered.sh
@@ -41,10 +41,14 @@ crit 1 "the readiness probe starts after 5 seconds" \
   "The base waits 30 seconds before probing at all. Overriding one field of a probe is again beyond any transformer, so it belongs in the same patch." \
   -- [ "$delay" = "5" ]
 
+# The base's probe renders unharmed when nothing has been patched at all, so
+# "survived" only means anything once the probe has actually been patched.
+probe_survived() { [ "$delay" = "5" ] && [ "$probe" = "/ 80 10" ]; }
+
 crit 1 "and the rest of the probe survived the patch" \
-  "rendered probe is path/port/period '$probe', want '/ 80 10'" \
-  "readinessProbe is a struct, so a strategic merge patch merges it field by field: naming initialDelaySeconds alone leaves httpGet and periodSeconds exactly as the base has them. This is what separates a patch from a replacement — everything you do not mention is left alone — and it is also where a JSON 6902 'replace' on the whole probe would have taken the rest of it with it." \
-  -- [ "$probe" = "/ 80 10" ]
+  "rendered initialDelaySeconds is '$delay' with path/port/period '$probe'; want the delay at 5 and the rest still '/ 80 10'" \
+  "readinessProbe is a struct, so a strategic merge patch merges it field by field: naming initialDelaySeconds alone leaves httpGet and periodSeconds exactly as the base has them. This is graded together with the delay because an unpatched probe survives trivially — what is worth points is the probe coming through a patch with only the field you named changed. It is where a JSON 6902 'replace' on the whole probe would have taken the rest of it with it." \
+  -- probe_survived
 
 crit_all_passed || evidence "$(crit_why)"
 report "the overlay renders the env var and the shortened probe"

--- a/banks/ckad-mock-01/q35/validate.d/20_patched.sh
+++ b/banks/ckad-mock-01/q35/validate.d/20_patched.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: the change lives in the overlay as a patch, and base/ was left alone
+set -uo pipefail
+. /banks/_lib/checks.sh
+K=/opt/course/35/overlays/prod/kustomization.yaml
+BASE=/opt/course/35/base/deployment.yaml
+
+overlay_pane() {
+  show_actual text "$(cat "$K" 2>/dev/null)"
+  show_why "$1"
+}
+base_pane() {
+  show_actual text "$(cat "$BASE" 2>/dev/null)"
+  show_expected text "/banks/${BANK:-ckad-mock-01}/q35/files/base/deployment.yaml"
+  show_why "$1"
+}
+
+[ -f "$BASE" ] || {
+  echo "$BASE no longer exists"
+  show_actual text "$(ls -R /opt/course/35 2>/dev/null)"
+  show_expected text "/banks/${BANK:-ckad-mock-01}/q35/files/base/deployment.yaml"
+  show_why "The overlay builds on this file, so deleting it is not a way of getting out of the rule against editing it. Restore it from the document beside this pane and put the change in the overlay's kustomization instead."
+  exit 1
+}
+
+patches=$(yq -r '((.patches // []) | length)
+                 + ((.patchesStrategicMerge // []) | length)
+                 + ((.patchesJson6902 // []) | length)' "$K" 2>/dev/null)
+
+api='.spec.template.spec.containers[] | select(.name == "api")'
+base_env=$(yq -r "$api | (.env // []) | length" "$BASE" 2>/dev/null)
+base_delay=$(yq -r "$api | .readinessProbe.initialDelaySeconds" "$BASE" 2>/dev/null)
+
+declares_a_patch() { [ -n "$patches" ] && [ "$patches" -ge 1 ] 2>/dev/null; }
+base_untouched() { [ "$base_env" = "0" ] && [ "$base_delay" = "30" ]; }
+pane=''
+
+crit 1 "the overlay declares a patch" \
+  "the overlay's kustomization declares no patches at all" \
+  "A transformer changes one well-known thing across every resource, and its vocabulary is deliberately small — images, replicas, namePrefix, namespace, labels. Anything outside it is a patch, and both of this question's changes are outside it. Hand-writing the finished Deployment into the overlay's resources reaches the same rendered output and abandons the base, which is the one thing the layout exists to share." \
+  -- declares_a_patch || pane=${pane:-overlay_pane}
+
+crit 1 "the base still says what it said" \
+  "base/deployment.yaml has been edited: container 'api' now has $base_env env var(s) and initialDelaySeconds '$base_delay', want 0 and 30" \
+  "The base is what every environment shares; the overlay is what one environment differs by. Putting LEDGER_MODE=prod in the base gives it to staging too, silently, the next time anyone builds that overlay — and the overlay that was supposed to document production's differences documents nothing at all." \
+  -- base_untouched || pane=${pane:-base_pane}
+
+crit_all_passed || "${pane:-overlay_pane}" "$(crit_why)"
+report "patched in the overlay, base untouched"

--- a/banks/ckad-mock-01/q35/validate.d/20_patched.sh
+++ b/banks/ckad-mock-01/q35/validate.d/20_patched.sh
@@ -34,17 +34,20 @@ base_delay=$(yq -r "$api | .readinessProbe.initialDelaySeconds" "$BASE" 2>/dev/n
 
 declares_a_patch() { [ -n "$patches" ] && [ "$patches" -ge 1 ] 2>/dev/null; }
 base_untouched() { [ "$base_env" = "0" ] && [ "$base_delay" = "30" ]; }
-pane=''
+
+# The question rules this one out: only the overlay's kustomization was to be
+# completed. Leaving base/ alone is a gate rather than a criterion because a
+# candidate who has written nothing anywhere has left it alone too.
+base_untouched || {
+  echo "base/deployment.yaml has been edited: container 'api' now has $base_env env var(s) and initialDelaySeconds '$base_delay', want 0 and 30"
+  base_pane "The question ruled this out: nothing under base/ was to be edited. The base is what every environment shares; the overlay is what one environment differs by. Putting LEDGER_MODE=prod in the base gives it to staging too, silently, the next time anyone builds that overlay — and the overlay that was supposed to document production's differences documents nothing at all. Restore the file from the document beside this pane and make the change in the overlay."
+  exit 1
+}
 
 crit 1 "the overlay declares a patch" \
   "the overlay's kustomization declares no patches at all" \
   "A transformer changes one well-known thing across every resource, and its vocabulary is deliberately small — images, replicas, namePrefix, namespace, labels. Anything outside it is a patch, and both of this question's changes are outside it. Hand-writing the finished Deployment into the overlay's resources reaches the same rendered output and abandons the base, which is the one thing the layout exists to share." \
-  -- declares_a_patch || pane=${pane:-overlay_pane}
+  -- declares_a_patch
 
-crit 1 "the base still says what it said" \
-  "base/deployment.yaml has been edited: container 'api' now has $base_env env var(s) and initialDelaySeconds '$base_delay', want 0 and 30" \
-  "The base is what every environment shares; the overlay is what one environment differs by. Putting LEDGER_MODE=prod in the base gives it to staging too, silently, the next time anyone builds that overlay — and the overlay that was supposed to document production's differences documents nothing at all." \
-  -- base_untouched || pane=${pane:-base_pane}
-
-crit_all_passed || "${pane:-overlay_pane}" "$(crit_why)"
+crit_all_passed || overlay_pane "$(crit_why)"
 report "patched in the overlay, base untouched"

--- a/banks/ckad-mock-01/q35/validate.d/30_applied.sh
+++ b/banks/ckad-mock-01/q35/validate.d/30_applied.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: the overlay was applied to norma and is running
+set -uo pipefail
+. /banks/_lib/checks.sh
+evidence() {
+  show_actual json "$(kubectl -n norma get deploy ledger-api -o json 2>/dev/null \
+    | jq '{ready: .status.readyReplicas,
+            container: [.spec.template.spec.containers[] | select(.name == "api")
+                        | {env, readinessProbe}]}')"
+  show_why "$1"
+}
+
+kubectl -n norma get deploy ledger-api >/dev/null 2>&1 || {
+  echo "Deployment ledger-api does not exist in namespace norma"
+  show_actual text "$(kubectl -n norma get deploy 2>/dev/null)"
+  show_why "An overlay can render perfectly and still not be in the cluster — building it and applying it are two separate acts. A kustomization directory is applied the way a file is, with -k in place of -f, and until that runs this Namespace holds whatever was there before."
+  exit 1
+}
+
+spec=$(kubectl -n norma get deploy ledger-api -o json 2>/dev/null)
+mode=$(printf '%s' "$spec" | jq -r '[.spec.template.spec.containers[] | select(.name == "api")
+  | (.env // [])[] | select(.name == "LEDGER_MODE") | .value] | join(",")')
+delay=$(kubectl -n norma get deploy ledger-api \
+  -o jsonpath='{.spec.template.spec.containers[?(@.name=="api")].readinessProbe.initialDelaySeconds}' 2>/dev/null)
+ready=$(printf '%s' "$spec" | jq -r '.status.readyReplicas // 0')
+
+patch_landed() { [ "$mode" = "prod" ] && [ "$delay" = "5" ]; }
+
+crit 1 "the patched fields reached the cluster" \
+  "in-cluster LEDGER_MODE is '$mode' and initialDelaySeconds is '$delay', want prod and 5" \
+  "This is the rendered overlay as the API server stored it. A mismatch with what kubectl kustomize prints means the build was right and something else was applied — usually a hand-written manifest, or the overlay applied before the last edit to it." \
+  -- patch_landed
+
+crit 1 "both replicas are ready" \
+  "readyReplicas is '$ready', want 2" \
+  "The base asks for 2 replicas and this overlay does not change that. A shorter initialDelaySeconds makes them ready sooner rather than less often, so a gap here is Pods still starting or an image the nodes cannot fetch." \
+  -- [ "$ready" = "2" ]
+
+crit_all_passed || evidence "$(crit_why)"
+report "applied to norma, 2/2 ready with the patch in place"

--- a/banks/ckad-mock-01/q36/hints.md
+++ b/banks/ckad-mock-01/q36/hints.md
@@ -1,0 +1,18 @@
+## Hint 1
+
+This Service has no selector and no endpoints, and it never carries
+traffic. It exists only so that a name inside one Namespace becomes an
+alias for a name somewhere else, which the cluster's DNS then answers
+with a CNAME record.
+
+Look at the Service types you know and pick the one that stores a name
+rather than a set of Pods.
+
+## Hint 2
+
+`spec.type` and `spec.externalName` are the only two fields that matter,
+and `kubectl create service externalname` writes both for you.
+
+The alias has to be the target's full DNS name, all four labels of it —
+a short form such as `catalog.mensa` is not inside the cluster's DNS
+zone, so the resolver treats it as an outside name and gives up.

--- a/banks/ckad-mock-01/q36/question.md
+++ b/banks/ckad-mock-01/q36/question.md
@@ -1,0 +1,19 @@
+Namespace `mensa` runs Deployment `catalog`, already exposed inside the
+cluster by a ClusterIP Service named `catalog` on port `80`.
+
+Namespace `octans` runs Deployment `shopfront`. It has to read that
+catalog, and it only ever asks for the name `catalog` — it knows nothing
+about the Namespace the catalog lives in.
+
+1. Create a Service named `catalog` in Namespace `octans` of type
+   `ExternalName`, aimed at the fully-qualified name of the Service in
+   `mensa`: `catalog.mensa.svc.cluster.local`.
+2. From a Pod in `octans`, request `http://catalog/` and save the
+   response body to `/opt/course/36/catalog-check` on `instance-2`.
+
+The catalog answers with a single word naming itself, so you will know
+when you have crossed the Namespace boundary:
+
+```bash
+k -n octans exec deploy/shopfront -- curl -s http://catalog/
+```

--- a/banks/ckad-mock-01/q36/setup.sh
+++ b/banks/ckad-mock-01/q36/setup.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+for ns in mensa octans; do
+  kubectl create ns "$ns" --dry-run=client -o yaml | kubectl apply -f -
+done
+
+kubectl -n mensa apply -f - <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: catalog-conf
+  namespace: mensa
+data:
+  default.conf: |
+    server {
+      listen 80;
+      location / {
+        add_header Content-Type text/plain;
+        return 200 'catalog-mensa\n';
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: catalog
+  namespace: mensa
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: catalog}
+  template:
+    metadata:
+      labels: {app: catalog}
+    spec:
+      volumes:
+        - name: conf
+          configMap:
+            name: catalog-conf
+      containers:
+        - name: web
+          image: nginx:1.29-alpine
+          ports: [{containerPort: 80}]
+          volumeMounts:
+            - name: conf
+              mountPath: /etc/nginx/conf.d
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: catalog
+  namespace: mensa
+spec:
+  selector: {app: catalog}
+  ports:
+    - port: 80
+      targetPort: 80
+EOF
+
+kubectl -n octans apply -f - <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shopfront
+  namespace: octans
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: shopfront}
+  template:
+    metadata:
+      labels: {app: shopfront}
+    spec:
+      containers:
+        - name: web
+          image: nginx:1.29-alpine
+          ports: [{containerPort: 80}]
+EOF
+
+# The alias is the candidate's to create; a leftover one from an earlier attempt
+# would hand them the answer.
+kubectl -n octans delete svc catalog --ignore-not-found >/dev/null
+
+kubectl -n mensa rollout status deploy/catalog --timeout=180s
+kubectl -n octans rollout status deploy/shopfront --timeout=180s

--- a/banks/ckad-mock-01/q36/solution.md
+++ b/banks/ckad-mock-01/q36/solution.md
@@ -1,0 +1,79 @@
+# Solution 36
+
+An `ExternalName` Service is two fields and nothing else — no selector,
+no ports, no cluster IP:
+
+```bash
+k -n octans apply -f - <<'EOF'
+apiVersion: v1
+kind: Service
+metadata:
+  name: catalog
+  namespace: octans
+spec:
+  type: ExternalName
+  externalName: catalog.mensa.svc.cluster.local
+EOF
+```
+
+The generator writes the same object in one line, which is faster under
+a clock:
+
+```bash
+k -n octans create service externalname catalog \
+  --external-name=catalog.mensa.svc.cluster.local
+```
+
+Then prove it and record the answer:
+
+```bash
+k -n octans exec deploy/shopfront -- curl -s http://catalog/
+# catalog-mensa
+
+k -n octans exec deploy/shopfront -- curl -s http://catalog/ \
+  > /opt/course/36/catalog-check
+cat /opt/course/36/catalog-check
+```
+
+## What actually happens to the request
+
+Nothing in the data path. This is the one Service type that is purely a
+DNS answer:
+
+1. `shopfront` resolves `catalog`. The Pod's search list turns that into
+   `catalog.octans.svc.cluster.local`.
+2. CoreDNS finds the ExternalName Service and answers with a **CNAME**
+   pointing at `catalog.mensa.svc.cluster.local`.
+3. That target is inside the cluster's own zone, so CoreDNS resolves it
+   too and returns the `mensa` Service's cluster IP in the same answer.
+4. The client connects to that address. kube-proxy forwards it to a
+   `catalog` Pod in `mensa`, exactly as it would for any ClusterIP.
+
+There is no proxying, no second hop and no object in `octans` holding an
+address. Delete the Service in `mensa` and the alias resolves to nothing.
+
+## Why the name has to be fully qualified
+
+CoreDNS chases a CNAME itself only when the target is inside the zone it
+serves. `catalog.mensa.svc.cluster.local` is; `catalog.mensa` is not, so
+that answer would be handed to the upstream resolver, which has never
+heard of it. The Pod's search list does not help here — it is applied to
+what the *client* asked for, not to a CNAME target the server returned.
+
+## Where this is worth reaching for
+
+- A managed database or an S3-compatible endpoint, so application config
+  says `db` and the environment decides which host that is.
+- Migrating a workload between Namespaces or clusters: point the alias at
+  the new place and nothing that calls it has to be rebuilt.
+- It carries **no** port mapping. Whatever port the client asks for is
+  the port it gets on the target, so an ExternalName cannot renumber a
+  service the way a ClusterIP's `port`/`targetPort` pair can.
+
+## The one that catches people
+
+`https://` to an ExternalName usually fails certificate verification. The
+client asked for `catalog`, so that is the name it puts in SNI and the
+name it checks the certificate against, while the certificate names the
+real host. TLS sees through the alias even though the connection does
+not.

--- a/banks/ckad-mock-01/q36/validate.d/10_externalname.sh
+++ b/banks/ckad-mock-01/q36/validate.d/10_externalname.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# points: 3
+# desc: Service catalog in octans is an ExternalName alias for catalog.mensa.svc.cluster.local
+set -uo pipefail
+. /banks/_lib/checks.sh
+evidence() {
+  show_actual yaml "$(kubectl -n octans get svc catalog -o yaml 2>/dev/null | k8s_clean)"
+  show_why "$1"
+}
+
+kubectl -n octans get svc catalog >/dev/null 2>&1 || {
+  echo "no Service named catalog in Namespace octans"
+  show_actual text "$(kubectl -n octans get svc 2>/dev/null)"
+  show_why "The alias itself is missing, so nothing in octans answers to the name catalog at all. The Service the question asks for lives in octans beside the client, not in mensa beside the application — mensa's Service already exists and was not yours to change."
+  exit 1
+}
+
+type=$(kubectl -n octans get svc catalog -o jsonpath='{.spec.type}' 2>/dev/null)
+target=$(kubectl -n octans get svc catalog -o jsonpath='{.spec.externalName}' 2>/dev/null)
+target=${target%.}
+
+crit 1 "type ExternalName" \
+  "type is '$type', want ExternalName" \
+  "ExternalName is the one Service type with no selector, no endpoints and no cluster IP: it is answered entirely by DNS, as a CNAME record. Any other type makes spec.externalName inert — the field is stored and ignored, and the Service either selects Pods that do not exist here or has nothing to select at all." \
+  -- [ "$type" = "ExternalName" ]
+
+crit 2 "aimed at the catalog Service in mensa" \
+  "externalName is '$target', want catalog.mensa.svc.cluster.local" \
+  "externalName holds the name the alias resolves to, and it has to be the target's fully-qualified name. CoreDNS follows a CNAME on its own only while the target is inside the cluster zone, so catalog.mensa.svc.cluster.local is chased and answered while a short form such as catalog.mensa is handed upstream, where nothing has heard of it. The Pod's search list cannot rescue that: it expands what the client asked for, never a name the server returned." \
+  -- [ "$target" = "catalog.mensa.svc.cluster.local" ]
+
+crit_all_passed || evidence "$(crit_why)"
+report "externalName alias ok"

--- a/banks/ckad-mock-01/q36/validate.d/20_reaches.sh
+++ b/banks/ckad-mock-01/q36/validate.d/20_reaches.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# points: 5
+# desc: a Pod in octans really reaches the mensa catalog through the local name
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+out=$(kubectl -n octans exec deploy/shopfront -- \
+  sh -c 'for i in 1 2 3; do
+           curl -s -m 4 http://catalog/ && exit 0
+           sleep 2
+         done; exit 1' 2>/dev/null)
+
+printf '%s' "$out" | grep -q 'catalog-mensa' && echo "the alias reaches mensa" || {
+  echo "http://catalog/ answered '$(printf '%s' "$out" | tr '\n' ' ' | head -c 120)', want catalog-mensa"
+  show_actual yaml "$(kubectl -n octans get svc catalog -o yaml 2>/dev/null | k8s_clean)"
+  show_why "A Pod in octans asked for the name catalog and did not get mensa's application back. Resolution runs the Pod's search list first, so catalog becomes catalog.octans.svc.cluster.local — the alias — and CoreDNS answers that with a CNAME and then resolves the target itself. An empty answer is the alias missing, or aimed at a name the cluster's DNS does not serve, which is what a short target such as catalog.mensa produces. An answer that arrives but says something else means the name resolved to some other Service: an ExternalName carries no port mapping, so whatever port the client asks for is the port it gets on the target."
+  exit 1
+}

--- a/banks/ckad-mock-01/q36/validate.d/30_recorded.sh
+++ b/banks/ckad-mock-01/q36/validate.d/30_recorded.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# points: 1
+# desc: the response body was saved on the instance
+set -uo pipefail
+. /banks/_lib/checks.sh
+got=$(cat /opt/course/36/catalog-check 2>/dev/null | tr -d '[:space:]')
+[ "$got" = "catalog-mensa" ] && echo "response recorded" || {
+  echo "/opt/course/36/catalog-check contains '$got', want 'catalog-mensa'"
+  show_actual text "$(cat /opt/course/36/catalog-check 2>/dev/null)"
+  show_why "This records what the alias ANSWERED, so it can only be captured once the request really crosses into mensa — the catalog replies with a single word naming itself. An empty file is the request having failed, and a file full of escape characters is a TTY having been allocated for a command whose output was being redirected to a file."
+  exit 1
+}

--- a/banks/ckad-mock-01/q37/hints.md
+++ b/banks/ckad-mock-01/q37/hints.md
@@ -1,0 +1,26 @@
+## Hint 1
+
+Three objects in order, and each one needs the previous: a key pair on
+disk, a Secret built from it, an Ingress that names the Secret.
+
+`openssl req` writes a certificate and a key in one invocation when you
+ask it for a self-signed one and tell it not to encrypt the key. It will
+prompt for a subject unless you pass one on the command line.
+
+`kubectl create secret` has a subcommand per Secret type, and one of them
+is for exactly this pair of files — it sets the type and the two data
+keys for you, and both are fixed names you do not get to choose.
+
+## Hint 2
+
+The routing and the certificate are separate blocks of the same Ingress.
+`spec.rules` decides where a request goes; `spec.tls` decides which
+Secret ends the encryption, and it lists the host names it covers. A
+host that appears in `rules` but not in `tls` is served over plain HTTP
+only.
+
+If the controller answers but the certificate says it belongs to
+`Kubernetes Ingress Controller Fake Certificate`, the Ingress was
+admitted and your Secret was not found — check the Secret's Namespace,
+its name in `spec.tls`, and that the host in `spec.tls` matches the host
+in `spec.rules` exactly.

--- a/banks/ckad-mock-01/q37/question.md
+++ b/banks/ckad-mock-01/q37/question.md
@@ -1,0 +1,28 @@
+Namespace `sculptor` runs Deployment `portal`, already exposed inside the
+cluster by a ClusterIP Service named `portal` on port `80`. It has to be
+published over HTTPS at the host name `sculptor.sim.local`, and this
+cluster has no certificate authority to ask.
+
+1. Generate a self-signed certificate and its private key for
+   `sculptor.sim.local`, and save them as `/opt/course/37/tls.crt` and
+   `/opt/course/37/tls.key` on `instance-1`. `openssl` is installed.
+2. Create a Secret named `portal-tls` in Namespace `sculptor`, of type
+   `kubernetes.io/tls`, from those two files.
+3. Create an Ingress named `portal-https` in Namespace `sculptor` using
+   IngressClass `nginx`. It serves host `sculptor.sim.local`, routes path
+   `/` by **prefix** to Service `portal` on port `80`, and terminates TLS
+   for that host with Secret `portal-tls`.
+
+The certificate signs for itself, so any client that checks it will
+refuse it — test with `curl -k`. The Ingress matches on the host name,
+and that name resolves nowhere, so the request also has to be pointed at
+the controller by hand:
+
+```bash
+ip=$(k -n ingress-nginx get svc ingress-nginx-controller -o jsonpath='{.spec.clusterIP}')
+k -n sculptor exec deploy/portal -- \
+  curl -sk --resolve "sculptor.sim.local:443:${ip}" https://sculptor.sim.local/
+```
+
+The application answers with a single word, so you can tell it apart from
+the controller's own error pages.

--- a/banks/ckad-mock-01/q37/setup.sh
+++ b/banks/ckad-mock-01/q37/setup.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl create ns sculptor --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n sculptor apply -f - <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: portal-conf
+  namespace: sculptor
+data:
+  default.conf: |
+    server {
+      listen 80;
+      location / {
+        add_header Content-Type text/plain;
+        return 200 'portal-ok\n';
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: portal
+  namespace: sculptor
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: portal}
+  template:
+    metadata:
+      labels: {app: portal}
+    spec:
+      volumes:
+        - name: conf
+          configMap:
+            name: portal-conf
+      containers:
+        - name: web
+          image: nginx:1.29-alpine
+          ports: [{containerPort: 80}]
+          volumeMounts:
+            - name: conf
+              mountPath: /etc/nginx/conf.d
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: portal
+  namespace: sculptor
+spec:
+  selector: {app: portal}
+  ports:
+    - port: 80
+      targetPort: 80
+EOF
+
+# Both are the candidate's to create, and one left behind by an earlier attempt
+# would score this question without them doing anything.
+kubectl -n sculptor delete ingress portal-https --ignore-not-found >/dev/null
+kubectl -n sculptor delete secret portal-tls --ignore-not-found >/dev/null
+
+kubectl -n sculptor rollout status deploy/portal --timeout=180s

--- a/banks/ckad-mock-01/q37/solution.md
+++ b/banks/ckad-mock-01/q37/solution.md
@@ -1,0 +1,119 @@
+# Solution 37
+
+## 1. A certificate for the host name
+
+One `openssl` invocation writes both halves. `-nodes` leaves the key
+unencrypted, which is what a Secret needs — a passphrase-protected key is
+one nginx can never load:
+
+```bash
+openssl req -x509 -nodes -newkey rsa:2048 -days 365 \
+  -keyout /opt/course/37/tls.key \
+  -out    /opt/course/37/tls.crt \
+  -subj   '/CN=sculptor.sim.local' \
+  -addext 'subjectAltName=DNS:sculptor.sim.local'
+```
+
+`-x509` is what makes it a certificate rather than a signing request:
+there is nobody to send a request to, so it signs itself.
+
+## 2. The Secret
+
+```bash
+k -n sculptor create secret tls portal-tls \
+  --cert=/opt/course/37/tls.crt \
+  --key=/opt/course/37/tls.key
+```
+
+`create secret tls` is not a convenience — it is the only thing that
+produces type `kubernetes.io/tls`, and the two data keys it writes,
+`tls.crt` and `tls.key`, are the exact names ingress-nginx looks for.
+Build the same Secret with `create secret generic` and it is type
+`Opaque`; the API takes it, the Ingress references it, and the controller
+quietly serves its own default certificate instead.
+
+```bash
+k -n sculptor get secret portal-tls
+# NAME         TYPE                DATA   AGE
+# portal-tls   kubernetes.io/tls   2      5s
+```
+
+## 3. The Ingress
+
+```bash
+k -n sculptor apply -f - <<'EOF'
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: portal-https
+  namespace: sculptor
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - sculptor.sim.local
+      secretName: portal-tls
+  rules:
+    - host: sculptor.sim.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: portal
+                port:
+                  number: 80
+EOF
+```
+
+`kubectl create ingress` writes it too:
+
+```bash
+k -n sculptor create ingress portal-https --class=nginx \
+  --rule="sculptor.sim.local/*=portal:80,tls=portal-tls"
+```
+
+## Verify
+
+```bash
+ip=$(k -n ingress-nginx get svc ingress-nginx-controller -o jsonpath='{.spec.clusterIP}')
+
+k -n sculptor exec deploy/portal -- \
+  curl -skv --resolve "sculptor.sim.local:443:${ip}" https://sculptor.sim.local/
+# * Server certificate:
+# *  subject: CN=sculptor.sim.local
+# *  issuer: CN=sculptor.sim.local
+# portal-ok
+```
+
+Read the `subject` line, not just the body. `Kubernetes Ingress
+Controller Fake Certificate` there means the handshake succeeded on the
+controller's built-in placeholder and your Secret was never loaded.
+
+`--resolve` matters for two reasons at once. It sends the request to an
+address the name does not resolve to, and it makes curl put
+`sculptor.sim.local` in **SNI** — which is what nginx selects the
+certificate by. A `Host:` header would route correctly and still get the
+default certificate, because the certificate is chosen during the
+handshake, before any header has been sent.
+
+## Termination, not encryption end to end
+
+The Ingress ends TLS. Behind it, the controller talks to Service `portal`
+on port `80` in plain HTTP, inside the cluster network. That is what
+"terminate at the Ingress" means, and it is why the backend Service in
+`spec.rules` names an ordinary HTTP port.
+
+## What each half does
+
+| Block | Decides |
+|---|---|
+| `spec.rules[].host` | Which requests this rule answers, by `Host` header |
+| `spec.tls[].hosts` | Which host names get a certificate, by SNI |
+| `spec.tls[].secretName` | Which Secret holds it — in the Ingress's own Namespace |
+
+The two lists are independent, and a host in `rules` alone is served over
+plain HTTP. ingress-nginx also redirects HTTP to HTTPS once a host has a
+`tls` entry, which is why `http://` starts answering `308` the moment
+this lands.

--- a/banks/ckad-mock-01/q37/validate.d/10_secret.sh
+++ b/banks/ckad-mock-01/q37/validate.d/10_secret.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: Secret portal-tls is a kubernetes.io/tls Secret built from the generated key pair
+set -uo pipefail
+. /banks/_lib/checks.sh
+evidence() {
+  show_actual text "$(kubectl -n sculptor get secret 2>/dev/null)"
+  show_why "$1"
+}
+
+kubectl -n sculptor get secret portal-tls >/dev/null 2>&1 || {
+  echo "no Secret named portal-tls in Namespace sculptor"
+  show_actual text "$(kubectl -n sculptor get secret 2>/dev/null)"
+  show_why "The Ingress can only end TLS with a Secret that exists in its own Namespace, and this one is not there. A Secret in another Namespace is not visible to it: ingress-nginx looks the name up in the Ingress's Namespace and falls back to its own placeholder certificate when it finds nothing."
+  exit 1
+}
+
+type=$(kubectl -n sculptor get secret portal-tls -o jsonpath='{.type}' 2>/dev/null)
+cert=$(kubectl -n sculptor get secret portal-tls -o jsonpath='{.data.tls\.crt}' 2>/dev/null | base64 -d 2>/dev/null)
+
+on_disk() { [ -s /opt/course/37/tls.crt ] && [ -s /opt/course/37/tls.key ]; }
+is_cert() { printf '%s' "$cert" | grep -q 'BEGIN CERTIFICATE'; }
+
+crit 1 "the key pair was written to /opt/course/37" \
+  "/opt/course/37/tls.crt and /opt/course/37/tls.key are not both present and non-empty" \
+  "The question asks for the certificate and the key at those two paths. openssl req writes both in one go when it is asked for a self-signed certificate — -x509 because there is no authority here to send a signing request to, and -nodes because a passphrase-protected key is one nginx can never load unattended." \
+  -- on_disk
+
+crit 2 "the Secret is of type kubernetes.io/tls" \
+  "type is '$type', want kubernetes.io/tls" \
+  "kubectl create secret tls is the only thing that produces this type, and the type is not decoration: it is what fixes the two data keys at tls.crt and tls.key, which is where ingress-nginx looks. Built with create secret generic the same two files land in an Opaque Secret, the API accepts it, the Ingress references it happily, and the controller serves its own placeholder certificate instead." \
+  -- [ "$type" = "kubernetes.io/tls" ]
+
+crit 1 "tls.crt holds the certificate" \
+  "tls.crt does not decode to a PEM certificate" \
+  "The data under tls.crt should be the PEM certificate itself, base64-encoded once by the API. Passing the private key to --cert, or a signing request instead of a certificate, produces a Secret of the right type that no controller can serve." \
+  -- is_cert
+
+crit_all_passed || evidence "$(crit_why)"
+report "tls secret ok"

--- a/banks/ckad-mock-01/q37/validate.d/20_ingress.sh
+++ b/banks/ckad-mock-01/q37/validate.d/20_ingress.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# points: 3
+# desc: Ingress portal-https routes sculptor.sim.local to portal:80 and ends TLS with portal-tls
+set -uo pipefail
+. /banks/_lib/checks.sh
+evidence() {
+  show_actual yaml "$(kubectl -n sculptor get ingress portal-https -o yaml 2>/dev/null | k8s_clean)"
+  show_why "$1"
+}
+
+kubectl -n sculptor get ingress portal-https >/dev/null 2>&1 || {
+  echo "no Ingress named portal-https in Namespace sculptor"
+  show_actual text "$(kubectl -n sculptor get ingress 2>/dev/null)"
+  show_why "Nothing publishes the portal outside the cluster yet. The Service in front of it is a ClusterIP and stays one; an Ingress is a separate object that names it as a backend."
+  exit 1
+}
+
+class=$(kubectl -n sculptor get ingress portal-https -o jsonpath='{.spec.ingressClassName}' 2>/dev/null)
+rules=$(kubectl -n sculptor get ingress portal-https -o json 2>/dev/null \
+  | jq -r '[.spec.rules[]? | .host as $h | .http.paths[]?
+            | "\($h)|\(.path)|\(.pathType)|\(.backend.service.name)|\(.backend.service.port.number)"]
+           | sort | join(" ")')
+tlshosts=$(kubectl -n sculptor get ingress portal-https -o json 2>/dev/null \
+  | jq -r '[.spec.tls[]?.hosts[]?] | sort | join(",")')
+tlssecret=$(kubectl -n sculptor get ingress portal-https -o json 2>/dev/null \
+  | jq -r '[.spec.tls[]?.secretName] | unique | join(",")')
+
+tls_ok() { [ "$tlshosts" = "sculptor.sim.local" ] && [ "$tlssecret" = "portal-tls" ]; }
+
+crit 1 "handed to the nginx IngressClass" \
+  "ingressClassName is '$class', want nginx" \
+  "ingressClassName is what hands the object to a controller. Without one that matches an IngressClass in the cluster the Ingress is created quite happily and never admitted by anything, which looks identical to a working one until a request arrives." \
+  -- [ "$class" = "nginx" ]
+
+crit 1 "routes sculptor.sim.local / to portal:80 by prefix" \
+  "rules are '$rules', want 'sculptor.sim.local|/|Prefix|portal|80'" \
+  "The rule decides where a request goes once it has arrived: its host is matched against the request's Host header, and the backend names a SERVICE and a port on it, never a Pod. Prefix matches whole path segments beneath /, which is every path on this host." \
+  -- [ "$rules" = "sculptor.sim.local|/|Prefix|portal|80" ]
+
+crit 2 "ends TLS for that host with Secret portal-tls" \
+  "spec.tls covers hosts '$tlshosts' with secret '$tlssecret', want sculptor.sim.local and portal-tls" \
+  "spec.tls and spec.rules are separate lists that happen to name the same host. rules decides routing, by Host header, after the connection is up; tls decides which Secret ends the encryption, selected during the handshake by SNI. A host listed under rules alone is served over plain HTTP only, and a secretName that resolves to nothing leaves the controller serving its own placeholder certificate to anyone who asks." \
+  -- tls_ok
+
+crit_all_passed || evidence "$(crit_why)"
+report "ingress ok"

--- a/banks/ckad-mock-01/q37/validate.d/30_https.sh
+++ b/banks/ckad-mock-01/q37/validate.d/30_https.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# points: 4
+# desc: the controller really serves the portal over HTTPS, with the Secret's certificate
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+ip=$(kubectl -n ingress-nginx get svc ingress-nginx-controller \
+  -o jsonpath='{.spec.clusterIP}' 2>/dev/null)
+[ -n "$ip" ] || {
+  echo "could not find the ingress controller's address"
+  show_actual text "$(kubectl -n ingress-nginx get svc 2>/dev/null)"
+  show_why "The ingress-nginx controller Service reported no cluster address, so there is nowhere to send the request. That is a property of the cluster rather than of the answer."
+  exit 1
+}
+
+out=$(kubectl -n sculptor exec deploy/portal -- sh -c \
+  "for i in 1 2; do
+     curl -skv -m 5 --resolve sculptor.sim.local:443:${ip} https://sculptor.sim.local/ 2>&1 && exit 0
+     sleep 2
+   done; exit 1" 2>/dev/null)
+
+# curl -v prefixes its own transcript; whatever is left unprefixed is the body.
+body=$(printf '%s' "$out" | grep -v '^[*<>{}]' | tr -d '\r' | tr '\n' ' ' | head -c 120)
+
+evidence() {
+  show_actual text "$(printf '%s' "$out" | head -c 3000)"
+  show_why "$1"
+}
+
+saw() { printf '%s' "$out" | grep -q "$1"; }
+own_cert() { saw 'Server certificate' && negate saw 'Fake Certificate'; }
+
+crit 3 "the portal answers over HTTPS on sculptor.sim.local" \
+  "https://sculptor.sim.local/ answered '$body', want portal-ok" \
+  "The request went to the controller carrying sculptor.sim.local as its name and did not come back with the application. An Ingress the controller never admitted looks exactly like one that works — the object exists, the rules read correctly and nothing routes — and a class matching no IngressClass, or a backend Service that is not in this Namespace, are the two usual causes. A 404 page instead of the body means the request arrived and no rule claimed it, which is the host or the path." \
+  -- saw 'portal-ok'
+
+crit 1 "served with the certificate from your Secret" \
+  "the handshake used the controller's own placeholder certificate, not portal-tls" \
+  "ingress-nginx keeps a self-signed placeholder called 'Kubernetes Ingress Controller Fake Certificate' and serves it whenever it cannot load the one an Ingress asked for. Seeing it means the routing works and the TLS half does not: the Secret is missing from this Namespace, is named differently under spec.tls, is not of type kubernetes.io/tls, or its host does not match the one the request put in SNI. SNI is settled during the handshake, before any header is sent, which is why a Host header cannot select a certificate and --resolve can." \
+  -- own_cert
+
+crit_all_passed || evidence "$(crit_why)"
+report "https served from the portal-tls certificate"

--- a/banks/ckad-mock-01/q38/hints.md
+++ b/banks/ckad-mock-01/q38/hints.md
@@ -1,0 +1,23 @@
+## Hint 1
+
+Policies do not override one another and there is no ordering between
+them. Every policy that selects a Pod contributes what it allows, and the
+Pod ends up permitting the union of those allowances — so a second policy
+can only ever widen the first, never narrow it.
+
+That is what makes the pair work. One of them selects everything and
+allows nothing; the other selects one workload and allows one thing.
+
+## Hint 2
+
+The first policy needs a selector that matches every Pod in the
+Namespace, a declaration that it governs ingress, and no rules at all.
+An empty selector is written `{}`; a rule list that is absent is what
+"allows nothing" looks like. Watch what happens if you write an empty
+*rule* instead of an empty *list* — that allows everything.
+
+The second is one rule with both halves present: who may connect, and on
+which port. Leave the port list out and the rule opens every port on
+those Pods.
+
+Neither policy should name the outbound direction anywhere.

--- a/banks/ckad-mock-01/q38/question.md
+++ b/banks/ckad-mock-01/q38/question.md
@@ -1,0 +1,23 @@
+Namespace `reticulum` runs Deployments `ledger` (`role=ledger`), `teller`
+(`role=teller`) and `auditor` (`role=auditor`). Nothing restricts traffic
+between them today: every Pod can reach every other one.
+
+Close the Namespace with a default and then open one path through it.
+
+1. Create a NetworkPolicy named `default-deny-ingress` in Namespace
+   `reticulum` that denies **all** ingress to **every** Pod in the
+   Namespace. On its own it must allow nothing.
+2. Create a second NetworkPolicy named `allow-teller` that permits
+   ingress to the `role=ledger` Pods from the `role=teller` Pods, on TCP
+   port `80` and nothing else.
+3. Neither policy may restrict egress.
+
+When you are done, `teller` must reach `ledger` on port `80` and
+`auditor` must not. Prove it rather than reading it back — a request that
+a policy denies does not fail, it hangs, so give the client a timeout:
+
+```bash
+ip=$(k -n reticulum get pod -l role=ledger -o jsonpath='{.items[0].status.podIP}')
+k -n reticulum exec deploy/teller  -- curl -s -m 3 "http://${ip}"
+k -n reticulum exec deploy/auditor -- curl -s -m 3 "http://${ip}"
+```

--- a/banks/ckad-mock-01/q38/setup.sh
+++ b/banks/ckad-mock-01/q38/setup.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl create ns reticulum --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n reticulum apply -f - <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ledger-conf
+  namespace: reticulum
+data:
+  default.conf: |
+    server {
+      listen 80;
+      location / {
+        add_header Content-Type text/plain;
+        return 200 'ledger-ok\n';
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ledger
+  namespace: reticulum
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {role: ledger}
+  template:
+    metadata:
+      labels: {role: ledger}
+    spec:
+      volumes:
+        - name: conf
+          configMap:
+            name: ledger-conf
+      containers:
+        - name: web
+          image: nginx:1.29-alpine
+          ports: [{containerPort: 80}]
+          volumeMounts:
+            - name: conf
+              mountPath: /etc/nginx/conf.d
+EOF
+
+for role in teller auditor; do
+  kubectl -n reticulum apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: $role
+  namespace: reticulum
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {role: $role}
+  template:
+    metadata:
+      labels: {role: $role}
+    spec:
+      containers:
+      - name: main
+        image: nginx:1.29-alpine
+        ports: [{containerPort: 80}]
+EOF
+done
+
+# Both policies are the candidate's to write, and ones left behind by an earlier
+# attempt would mean the Namespace starts closed instead of open.
+kubectl -n reticulum delete netpol default-deny-ingress allow-teller \
+  --ignore-not-found >/dev/null
+
+kubectl -n reticulum rollout status deploy/ledger --timeout=180s
+kubectl -n reticulum rollout status deploy/teller --timeout=180s
+kubectl -n reticulum rollout status deploy/auditor --timeout=180s

--- a/banks/ckad-mock-01/q38/solution.md
+++ b/banks/ckad-mock-01/q38/solution.md
@@ -1,0 +1,110 @@
+# Solution 38
+
+## The default
+
+```bash
+k -n reticulum apply -f - <<'EOF'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: reticulum
+spec:
+  podSelector: {}
+  policyTypes: [Ingress]
+EOF
+```
+
+Three things do the work, and each is easy to write slightly wrong:
+
+- `podSelector: {}` selects **every** Pod in the Namespace. An empty
+  selector is the widest one, not the narrowest.
+- `policyTypes: [Ingress]` is what turns the Pods it selects from
+  unrestricted into deny-by-default inbound. A direction that is not
+  listed here is left completely alone no matter what is written below.
+- **No `ingress:` key at all.** That is the deny.
+
+`ingress: []` means the same thing. `ingress: [{}]` does not — that is
+one rule with no restrictions, which allows everything from everywhere,
+and it is the classic way to ship a default-deny that denies nothing.
+
+## The exception
+
+```bash
+k -n reticulum apply -f - <<'EOF'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-teller
+  namespace: reticulum
+spec:
+  podSelector:
+    matchLabels: {role: ledger}
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels: {role: teller}
+      ports:
+        - {protocol: TCP, port: 80}
+EOF
+```
+
+## Verify
+
+```bash
+ip=$(k -n reticulum get pod -l role=ledger -o jsonpath='{.items[0].status.podIP}')
+
+k -n reticulum exec deploy/teller  -- curl -s -m 3 "http://${ip}"
+# ledger-ok
+
+k -n reticulum exec deploy/auditor -- curl -s -m 3 "http://${ip}"
+# (nothing, then exit status 28)
+```
+
+Use a timeout on both. A denied packet is dropped, not refused, so the
+client waits for a handshake that will never be answered — without `-m`
+the second command sits there for over two minutes and tells you nothing
+you did not already suspect.
+
+## Why two policies and not one
+
+They compose by union, and nothing about the order they were created in
+matters:
+
+- Selecting a Pod with **any** policy that names a direction flips that
+  Pod to deny-by-default in that direction.
+- Every policy selecting that Pod then contributes its allowances.
+- The Pod permits the union. There is no `deny` rule in the API, and no
+  precedence to reason about.
+
+So `default-deny-ingress` closes the whole Namespace and `allow-teller`
+reopens exactly one path, and the pair can be read separately. Delete
+`allow-teller` and the Namespace is shut again; add a third policy and it
+can only ever open more.
+
+This is also why a default-deny is worth writing as its own object rather
+than folding it into the workload's policy. It states the Namespace's
+posture in four lines that never change, and every later policy is an
+exception you can read in isolation.
+
+## Egress is untouched
+
+Neither policy names `Egress` in `policyTypes`, so outbound traffic —
+including DNS — is unrestricted for every Pod here. Adding `Egress` to
+the default-deny is the other classic mistake: it is a defensible thing
+to want, but it breaks name resolution instantly, and the symptom looks
+like a broken application rather than a policy.
+
+## Reading a policy that is not working
+
+```bash
+k -n reticulum get netpol
+k -n reticulum describe netpol allow-teller
+k -n reticulum get pod --show-labels
+```
+
+The last one settles most of it. A policy whose `podSelector` matches
+nothing does not fail and does not warn — it simply never applies, which
+leaves its Pods unrestricted rather than protected, and the traffic that
+should have been denied flows perfectly.

--- a/banks/ckad-mock-01/q38/validate.d/10_default-deny.sh
+++ b/banks/ckad-mock-01/q38/validate.d/10_default-deny.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: default-deny-ingress selects every Pod in reticulum, governs ingress and allows nothing
+set -uo pipefail
+. /banks/_lib/checks.sh
+evidence() {
+  show_actual yaml "$(kubectl -n reticulum get netpol default-deny-ingress -o yaml 2>/dev/null | k8s_clean)"
+  show_why "$1"
+}
+
+kubectl -n reticulum get netpol default-deny-ingress >/dev/null 2>&1 || {
+  echo "no NetworkPolicy named default-deny-ingress in Namespace reticulum"
+  show_actual text "$(kubectl -n reticulum get netpol 2>/dev/null)"
+  show_why "The Namespace has no default at all, so every Pod in it is still unrestricted. A Pod becomes deny-by-default in a direction only once some policy selects it and names that direction; with nothing selecting them, the second policy's allowance is meaningless because nothing was ever denied."
+  exit 1
+}
+
+pol=$(kubectl -n reticulum get netpol default-deny-ingress -o json 2>/dev/null)
+selects=$(printf '%s' "$pol" | jq '((.spec.podSelector.matchLabels // {}) | length)
+                                 + ((.spec.podSelector.matchExpressions // []) | length)')
+types=$(printf '%s' "$pol" | jq -r '.spec.policyTypes[]?')
+rules=$(printf '%s' "$pol" | jq '(.spec.ingress // []) | length')
+
+crit 2 "selects every Pod in the Namespace" \
+  "podSelector narrows to $selects condition(s), want an empty selector" \
+  "An empty podSelector is the widest one there is: it selects every Pod in the policy's own Namespace, which is what makes this a default rather than a rule about one workload. Written as podSelector: {} it reads like nothing and means everything." \
+  -- [ "$selects" = "0" ]
+
+crit 1 "governs ingress only" \
+  "policyTypes are '$(printf '%s' "$types" | tr '\n' ' ')', want Ingress alone" \
+  "policyTypes is what flips the selected Pods from unrestricted to deny-by-default, and it does so per direction: a direction listed here is denied except for what the rules allow, and a direction left out is untouched no matter what appears below. Adding Egress here would also cut off DNS for every Pod in the Namespace, which the question rules out." \
+  -- same_set "$types" "Ingress"
+
+crit 1 "allows nothing itself" \
+  "the policy carries $rules ingress rule(s), want none" \
+  "The deny is the ABSENCE of rules. An omitted ingress key and an empty list both mean it, but a list holding one empty rule does not — that is a rule with no restrictions on peer or port, which allows everything from everywhere and is the usual way a default-deny ends up denying nothing." \
+  -- [ "$rules" = "0" ]
+
+crit_all_passed || evidence "$(crit_why)"
+report "default-deny ok"

--- a/banks/ckad-mock-01/q38/validate.d/20_allow.sh
+++ b/banks/ckad-mock-01/q38/validate.d/20_allow.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# points: 3
+# desc: allow-teller opens exactly one path — role=teller to role=ledger on TCP 80
+set -uo pipefail
+. /banks/_lib/checks.sh
+evidence() {
+  show_actual yaml "$(kubectl -n reticulum get netpol allow-teller -o yaml 2>/dev/null | k8s_clean)"
+  show_why "$1"
+}
+
+kubectl -n reticulum get netpol allow-teller >/dev/null 2>&1 || {
+  echo "no NetworkPolicy named allow-teller in Namespace reticulum"
+  show_actual text "$(kubectl -n reticulum get netpol 2>/dev/null)"
+  show_why "Nothing reopens a path through the default. There is no deny rule in this API and no precedence between policies: a Pod permits the union of what every policy selecting it allows, so the exception has to be its own object contributing that one allowance."
+  exit 1
+}
+
+pol=$(kubectl -n reticulum get netpol allow-teller -o json 2>/dev/null)
+sel=$(printf '%s' "$pol" | jq -r '.spec.podSelector.matchLabels // {} | to_entries | map("\(.key)=\(.value)") | sort | join(",")')
+n=$(printf '%s' "$pol" | jq '(.spec.ingress // []) | length')
+peers=$(printf '%s' "$pol" | jq -r '[.spec.ingress[]?.from[]? | .podSelector.matchLabels // {} | to_entries[] | "\(.key)=\(.value)"] | .[]')
+wider=$(printf '%s' "$pol" | jq '[.spec.ingress[]?.from[]? | select(has("namespaceSelector") or has("ipBlock"))] | length')
+ports=$(printf '%s' "$pol" | jq -r '[.spec.ingress[]?.ports[]? | "\(.port)/\(.protocol // "TCP")"] | .[]')
+
+only_teller() { same_set "$peers" "role=teller" && [ "$wider" = "0" ]; }
+
+crit 1 "protects the ledger Pods" \
+  "podSelector is '$sel', want role=ledger" \
+  "spec.podSelector names the Pods the policy applies TO — the destination being protected — matched inside the policy's own Namespace. Naming the source here instead is the classic swap: it would leave the ledger Pods with no allowance at all, which the default-deny then makes total." \
+  -- [ "$sel" = "role=ledger" ]
+
+crit 1 "exactly one ingress rule" \
+  "the policy carries $n ingress rule(s), want 1" \
+  "Ingress rules are additive: each entry is a separate way in, so a second rule widens the opening rather than narrowing it. One source on one port is one rule." \
+  -- [ "$n" = "1" ]
+
+crit 1 "only the teller Pods may connect" \
+  "ingress peers are '$(printf '%s' "$peers" | tr '\n' ' ')', want role=teller alone" \
+  "A podSelector under 'from' picks the Pods allowed to connect, by label, inside this same Namespace — peers are never named, only labelled. An empty from list allows every source, and a namespaceSelector or ipBlock beside it widens the rule to other Namespaces or to raw addresses instead of narrowing it." \
+  -- only_teller
+
+crit 1 "only on TCP 80" \
+  "ingress ports are '$(printf '%s' "$ports" | tr '\n' ' ')', want 80/TCP" \
+  "The ports list restricts a rule to those destination ports on the selected Pods; leave it out and the rule opens every port to that source. protocol defaults to TCP, so omitting it is a correct answer — the number is what has to be 80." \
+  -- same_set "$ports" "80/TCP"
+
+crit_all_passed || evidence "$(crit_why)"
+report "allow rule ok"

--- a/banks/ckad-mock-01/q38/validate.d/30_enforced.sh
+++ b/banks/ckad-mock-01/q38/validate.d/30_enforced.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# points: 4
+# desc: the pair is really enforced — teller reaches ledger, auditor times out
+set -uo pipefail
+. /banks/_lib/checks.sh
+evidence() {
+  show_actual text "$(kubectl -n reticulum get netpol 2>/dev/null; echo; kubectl -n reticulum get pod --show-labels 2>/dev/null)"
+  show_why "$1"
+}
+
+ip=$(kubectl -n reticulum get pod -l role=ledger \
+  -o jsonpath='{.items[?(@.status.phase=="Running")].status.podIP}' 2>/dev/null | awk '{print $1}')
+[ -n "$ip" ] || {
+  echo "no running ledger Pod to test against"
+  show_actual text "$(kubectl -n reticulum get pod --show-labels 2>/dev/null)"
+  show_why "There is no Running Pod labelled role=ledger to send a request to, so the policies' effect cannot be observed either way. The three Deployments the question describes are seeded and were not yours to change."
+  exit 1
+}
+
+# A denied packet is dropped rather than refused, so the client waits for a
+# handshake that never comes. The timeout is what keeps the denied direction
+# well inside the check's own deadline.
+reaches() {
+  kubectl -n reticulum exec "deploy/$1" -- \
+    curl -s -m 3 -o /dev/null "http://${ip}:80" 2>/dev/null
+}
+
+crit 2 "teller still reaches ledger on port 80" \
+  "teller cannot reach ledger on port 80, but the pair should allow it" \
+  "The path the question asks to keep open is closed. An ingress rule allows a source only when BOTH halves match — the peer's labels and the destination port — so a rule naming the wrong label, or restricted to the wrong port, denies teller exactly as completely as no rule at all. Check the labels the Pods actually carry against the ones the policy asks for." \
+  -- reaches teller
+
+crit 2 "auditor is denied" \
+  "auditor reached ledger on port 80 — the Namespace is not denying by default" \
+  "Everything the pair does not explicitly allow has to be denied, and auditor got through. Either the default-deny selects nothing — an empty podSelector selects every Pod, while a selector matching none leaves those Pods unrestricted rather than protected — or it carries a rule that allows something, which an empty rule entry does. A policy that protects nothing is not a policy that denies nothing; it simply never applies." \
+  -- negate reaches auditor
+
+crit_all_passed || evidence "$(crit_why)"
+report "enforced: teller allowed, auditor denied"

--- a/banks/ckad-mock-01/q38/validate.d/30_enforced.sh
+++ b/banks/ckad-mock-01/q38/validate.d/30_enforced.sh
@@ -8,14 +8,58 @@ evidence() {
   show_why "$1"
 }
 
-ip=$(kubectl -n reticulum get pod -l role=ledger \
-  -o jsonpath='{.items[?(@.status.phase=="Running")].status.podIP}' 2>/dev/null | awk '{print $1}')
+pod=$(kubectl -n reticulum get pod -l role=ledger -o json 2>/dev/null \
+  | jq -r 'first(.items[]
+             | select(.status.phase == "Running" and (.status.podIP // "") != "")
+             | "\(.metadata.name) \(.status.podIP)")')
+ledger_pod=${pod%% *}
+ip=${pod##* }
 [ -n "$ip" ] || {
   echo "no running ledger Pod to test against"
   show_actual text "$(kubectl -n reticulum get pod --show-labels 2>/dev/null)"
   show_why "There is no Running Pod labelled role=ledger to send a request to, so the policies' effect cannot be observed either way. The three Deployments the question describes are seeded and were not yours to change."
   exit 1
 }
+
+deny=$(kubectl -n reticulum get netpol default-deny-ingress -o json 2>/dev/null)
+
+# A podSelector written the way kubectl takes a selector, so the Pods it really
+# picks can be listed rather than guessed at. An empty podSelector prints
+# nothing, which is also how it selects every Pod in the Namespace.
+selector_of() {
+  printf '%s' "$1" | jq -r '
+    (.spec.podSelector // {}) as $s
+    | (($s.matchLabels // {}) | to_entries | map("\(.key)=\(.value)"))
+      + (($s.matchExpressions // []) | map(
+          if .operator == "In" then "\(.key) in (\(.values | join(",")))"
+          elif .operator == "NotIn" then "\(.key) notin (\(.values | join(",")))"
+          elif .operator == "Exists" then .key
+          else "!\(.key)" end))
+    | join(",")' 2>/dev/null
+}
+
+covers_the_ledger_pod() {
+  local sel
+  sel=$(selector_of "$deny")
+  [ -n "$sel" ] || {
+    has_name "$(kubectl -n reticulum get pod -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)" "$ledger_pod"
+    return
+  }
+  has_name "$(kubectl -n reticulum get pod -l "$sel" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)" "$ledger_pod"
+}
+
+# Every check runs on its own, so this re-reads what 10_default-deny.sh scores.
+# The question's own first line is that nothing restricts traffic here today, so
+# until the default closes the Namespace over the ledger Pods, teller reaching
+# them is the state the question starts in rather than anything allow-teller
+# did. A rule with no 'from' does not close it either: that allows every source.
+closed=false
+if [ -n "$deny" ] \
+  && printf '%s' "$deny" | jq -e '[.spec.policyTypes[]?] | index("Ingress")' >/dev/null 2>&1 \
+  && printf '%s' "$deny" | jq -e '[.spec.ingress[]? | select(((.from // []) | length) == 0)] | length == 0' >/dev/null 2>&1 \
+  && covers_the_ledger_pod; then
+  closed=true
+fi
 
 # A denied packet is dropped rather than refused, so the client waits for a
 # handshake that never comes. The timeout is what keeps the denied direction
@@ -25,15 +69,32 @@ reaches() {
     curl -s -m 3 -o /dev/null "http://${ip}:80" 2>/dev/null
 }
 
-crit 2 "teller still reaches ledger on port 80" \
-  "teller cannot reach ledger on port 80, but the pair should allow it" \
-  "The path the question asks to keep open is closed. An ingress rule allows a source only when BOTH halves match — the peer's labels and the destination port — so a rule naming the wrong label, or restricted to the wrong port, denies teller exactly as completely as no rule at all. Check the labels the Pods actually carry against the ones the policy asks for." \
-  -- reaches teller
+opened_through_the_default() { [ "$closed" = true ] && reaches teller; }
+
+if [ "$closed" = true ]; then
+  allowed_msg="teller cannot reach ledger on port 80, but the pair should allow it"
+else
+  allowed_msg="the ledger Pods are not denied by default, so teller reaching them counts for nothing yet — default-deny-ingress has to select them, list Ingress, and not carry a rule that lets everyone in"
+fi
+
+# A request that never leaves is not a denial. exec into a Deployment with no
+# ready Pod fails exactly like a dropped packet, so deleting auditor would
+# otherwise score the denial it was seeded to demonstrate.
+live() {
+  n=$(kubectl -n reticulum get deploy "$1" -o jsonpath='{.status.readyReplicas}' 2>/dev/null)
+  [ -n "$n" ] && [ "$n" -ge 1 ] 2>/dev/null
+}
+denied_from_a_live_source() { live auditor && negate reaches auditor; }
+
+crit 2 "default-deny-ingress is in force and teller still reaches ledger on port 80" \
+  "$allowed_msg" \
+  "The path is only open because a policy opens it once the Namespace is shut, which is why the two are scored as one thing. Before the default exists every Pod here reaches every other one — the question says so in its first line — so a successful request on its own is the starting state, not a result. Once the default is in force, an ingress rule allows a source only when BOTH halves match — the peer's labels and the destination port — so a rule naming the wrong label, or restricted to the wrong port, denies teller exactly as completely as no rule at all. Check the labels the Pods actually carry against the ones the policy asks for." \
+  -- opened_through_the_default
 
 crit 2 "auditor is denied" \
-  "auditor reached ledger on port 80 — the Namespace is not denying by default" \
+  "auditor reached ledger on port 80 — the Namespace is not denying by default, or auditor has no ready Pod to send one from" \
   "Everything the pair does not explicitly allow has to be denied, and auditor got through. Either the default-deny selects nothing — an empty podSelector selects every Pod, while a selector matching none leaves those Pods unrestricted rather than protected — or it carries a rule that allows something, which an empty rule entry does. A policy that protects nothing is not a policy that denies nothing; it simply never applies." \
-  -- negate reaches auditor
+  -- denied_from_a_live_source
 
 crit_all_passed || evidence "$(crit_why)"
 report "enforced: teller allowed, auditor denied"

--- a/banks/ckad-mock-01/q39/hints.md
+++ b/banks/ckad-mock-01/q39/hints.md
@@ -16,8 +16,9 @@ than an empty one. `kubectl create service clusterip --clusterip=None`
 writes it, or `kubectl expose --cluster-ip=None`; either way check the
 selector afterwards, since `expose` copies it from whatever you exposed.
 
-To read the addresses back, ask DNS from inside a Pod with `nslookup`, or
-read them off the EndpointSlice the Service owns:
+The file wants one name per Pod, not one address: a Pod's own name is
+`<pod>.<service>.<namespace>.svc.cluster.local`. Which Pods the Service
+publishes is on the EndpointSlice it owns, one `targetRef` per endpoint:
 
 ```bash
 k -n telescopium get endpointslice -l kubernetes.io/service-name=shard

--- a/banks/ckad-mock-01/q39/hints.md
+++ b/banks/ckad-mock-01/q39/hints.md
@@ -1,0 +1,24 @@
+## Hint 1
+
+"Headless" is one field on an otherwise ordinary Service, and setting it
+changes what DNS answers rather than what the Service does. Nothing is
+load balanced and no virtual address is allocated: the name resolves
+straight to the Pods behind it.
+
+That is also what gives the members of a StatefulSet their individual
+names. An ordinary Service publishes only its own name, however carefully
+its Pods are numbered.
+
+## Hint 2
+
+The field is `spec.clusterIP`, and the value is the string `None` rather
+than an empty one. `kubectl create service clusterip --clusterip=None`
+writes it, or `kubectl expose --cluster-ip=None`; either way check the
+selector afterwards, since `expose` copies it from whatever you exposed.
+
+To read the addresses back, ask DNS from inside a Pod with `nslookup`, or
+read them off the EndpointSlice the Service owns:
+
+```bash
+k -n telescopium get endpointslice -l kubernetes.io/service-name=shard
+```

--- a/banks/ckad-mock-01/q39/question.md
+++ b/banks/ckad-mock-01/q39/question.md
@@ -1,0 +1,18 @@
+Namespace `telescopium` runs StatefulSet `shard` with 3 replicas. Its
+Pods carry the label `app=shard` and each serves HTTP on port `80`. The
+StatefulSet names `shard` as its governing Service, and that Service does
+not exist — so no Pod in the set has a DNS name of its own.
+
+1. Create the missing Service: name `shard`, Namespace `telescopium`,
+   **headless**, selecting `app=shard`, publishing port `80` with
+   `targetPort` `80`. Do not change the StatefulSet.
+2. Record the Pod addresses that `shard.telescopium.svc.cluster.local`
+   resolves to in `/opt/course/39/shard-addresses` on `instance-1` — one
+   IP address per line, and nothing else in the file.
+
+Each Pod answers with its own name, so once the Service exists you can
+tell `shard-0` from `shard-2` from inside the cluster:
+
+```bash
+k -n telescopium exec shard-0 -- curl -s http://shard-2.shard.telescopium.svc.cluster.local/
+```

--- a/banks/ckad-mock-01/q39/question.md
+++ b/banks/ckad-mock-01/q39/question.md
@@ -6,9 +6,10 @@ not exist — so no Pod in the set has a DNS name of its own.
 1. Create the missing Service: name `shard`, Namespace `telescopium`,
    **headless**, selecting `app=shard`, publishing port `80` with
    `targetPort` `80`. Do not change the StatefulSet.
-2. Record the Pod addresses that `shard.telescopium.svc.cluster.local`
-   resolves to in `/opt/course/39/shard-addresses` on `instance-1` — one
-   IP address per line, and nothing else in the file.
+2. Record the per-Pod DNS name of each of the three Pods in
+   `/opt/course/39/shard-names` on `instance-1` — one fully qualified
+   name per line, ending `.svc.cluster.local`, and nothing else in the
+   file.
 
 Each Pod answers with its own name, so once the Service exists you can
 tell `shard-0` from `shard-2` from inside the cluster:

--- a/banks/ckad-mock-01/q39/setup.sh
+++ b/banks/ckad-mock-01/q39/setup.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl create ns telescopium --dry-run=client -o yaml | kubectl apply -f -
+
+# $hostname is nginx's own variable, not the shell's: each Pod answers with the
+# name the StatefulSet gave it, so a per-Pod DNS name can be told apart from the
+# Service's.
+kubectl -n telescopium apply -f - <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shard-conf
+  namespace: telescopium
+data:
+  default.conf: |
+    server {
+      listen 80;
+      location / {
+        add_header Content-Type text/plain;
+        return 200 '$hostname\n';
+      }
+    }
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: shard
+  namespace: telescopium
+spec:
+  serviceName: shard
+  replicas: 3
+  selector:
+    matchLabels: {app: shard}
+  template:
+    metadata:
+      labels: {app: shard}
+    spec:
+      volumes:
+        - name: conf
+          configMap:
+            name: shard-conf
+      containers:
+        - name: web
+          image: nginx:1.29-alpine
+          ports: [{containerPort: 80}]
+          volumeMounts:
+            - name: conf
+              mountPath: /etc/nginx/conf.d
+EOF
+
+# The governing Service is the candidate's to create; one left behind by an
+# earlier attempt would hand them the answer.
+kubectl -n telescopium delete svc shard --ignore-not-found >/dev/null
+
+kubectl -n telescopium rollout status statefulset/shard --timeout=300s

--- a/banks/ckad-mock-01/q39/solution.md
+++ b/banks/ckad-mock-01/q39/solution.md
@@ -75,19 +75,32 @@ as a name **only for a headless Service**. Point the same StatefulSet at
 an ordinary ClusterIP Service and the per-Pod names silently stop
 resolving while everything else keeps working.
 
-## Record the addresses
+## Record the names
+
+Each endpoint on the EndpointSlice carries a `targetRef` naming the Pod
+it publishes, so the per-Pod names can be built straight from it:
 
 ```bash
 k -n telescopium get endpointslice -l kubernetes.io/service-name=shard \
-  -o jsonpath='{range .items[*].endpoints[*]}{.addresses[0]}{"\n"}{end}' \
-  > /opt/course/39/shard-addresses
-cat /opt/course/39/shard-addresses
+  -o jsonpath='{range .items[*].endpoints[*]}{.targetRef.name}{".shard.telescopium.svc.cluster.local"}{"\n"}{end}' \
+  > /opt/course/39/shard-names
+cat /opt/course/39/shard-names
+# shard-0.shard.telescopium.svc.cluster.local
+# shard-1.shard.telescopium.svc.cluster.local
+# shard-2.shard.telescopium.svc.cluster.local
 ```
 
-The EndpointSlice is where the addresses come from in the first place —
-the DNS answer is generated from it, so the two always agree. Reading it
-avoids parsing `nslookup` output, which mixes the resolver's own address
-in with the answers.
+Then prove one of them rather than trusting the string:
+
+```bash
+k -n telescopium exec shard-0 -- nslookup shard-1.shard.telescopium.svc.cluster.local
+```
+
+The addresses were the easier thing to write down and the wrong thing to
+keep. Delete `shard-1` and the StatefulSet brings it back under the same
+name at a different address; the name is what a peer, a connection string
+or a config file can hold on to, and publishing it is the entire job of
+the headless Service you just created.
 
 ## What headless actually changes
 

--- a/banks/ckad-mock-01/q39/solution.md
+++ b/banks/ckad-mock-01/q39/solution.md
@@ -1,0 +1,114 @@
+# Solution 39
+
+Look at what is already there before writing anything — the StatefulSet
+tells you the Service's name and the label to select:
+
+```bash
+k -n telescopium get sts shard -o jsonpath='{.spec.serviceName}{"\n"}'
+# shard
+k -n telescopium get pod --show-labels
+# shard-0  ...  app=shard,...
+```
+
+## The Service
+
+```bash
+k -n telescopium apply -f - <<'EOF'
+apiVersion: v1
+kind: Service
+metadata:
+  name: shard
+  namespace: telescopium
+spec:
+  clusterIP: None
+  selector:
+    app: shard
+  ports:
+    - port: 80
+      targetPort: 80
+EOF
+```
+
+Or with the generator:
+
+```bash
+k -n telescopium create service clusterip shard --clusterip=None --tcp=80:80
+```
+
+`create service clusterip` does not set a selector matching these Pods —
+it labels the Service `app=shard` and selects the same — which happens to
+be right here. Check it either way:
+
+```bash
+k -n telescopium get svc shard
+# NAME    TYPE        CLUSTER-IP   PORT(S)   AGE
+# shard   ClusterIP   None         80/TCP    4s
+```
+
+`None` in the `CLUSTER-IP` column is the whole answer. The type still
+reads `ClusterIP`; headless is not a fourth Service type.
+
+## The names it publishes
+
+```bash
+k -n telescopium exec shard-0 -- nslookup shard.telescopium.svc.cluster.local
+# Name:    shard.telescopium.svc.cluster.local
+# Address: 10.244.1.12
+# Address: 10.244.2.9
+# Address: 10.244.1.13
+
+k -n telescopium exec shard-0 -- curl -s http://shard-2.shard.telescopium.svc.cluster.local/
+# shard-2
+```
+
+Two kinds of record appear at once:
+
+| Name | Answers with |
+|---|---|
+| `shard.telescopium.svc.cluster.local` | every ready Pod address, all three |
+| `shard-N.shard.telescopium.svc.cluster.local` | that one Pod's address |
+
+The per-Pod names are the reason a StatefulSet wants a headless Service.
+The controller gives each Pod a stable `hostname` and sets its
+`subdomain` to `spec.serviceName`; the cluster's DNS publishes that pair
+as a name **only for a headless Service**. Point the same StatefulSet at
+an ordinary ClusterIP Service and the per-Pod names silently stop
+resolving while everything else keeps working.
+
+## Record the addresses
+
+```bash
+k -n telescopium get endpointslice -l kubernetes.io/service-name=shard \
+  -o jsonpath='{range .items[*].endpoints[*]}{.addresses[0]}{"\n"}{end}' \
+  > /opt/course/39/shard-addresses
+cat /opt/course/39/shard-addresses
+```
+
+The EndpointSlice is where the addresses come from in the first place —
+the DNS answer is generated from it, so the two always agree. Reading it
+avoids parsing `nslookup` output, which mixes the resolver's own address
+in with the answers.
+
+## What headless actually changes
+
+- **No virtual IP is allocated**, so kube-proxy programs nothing and
+  there is no load balancing, no `sessionAffinity` and no NAT. Clients
+  get addresses and choose for themselves.
+- **The name resolves to the Pods.** A client that resolves once and
+  holds the connection is talking to one specific Pod, not to a Service
+  that may move it.
+- **`port` and `targetPort` stop renumbering anything** for those direct
+  connections; they still describe the Service and appear in its SRV
+  records.
+
+Reach for it when the caller has to address individual members — a
+database with a primary, a quorum that gossips, a client library that
+does its own connection pooling. Everything else wants an ordinary
+ClusterIP.
+
+## A headless Service with no selector
+
+Leave the selector out as well and nothing is published at all until you
+write the EndpointSlice yourself. That is how a name inside the cluster
+is pointed at addresses Kubernetes does not manage — the sibling of the
+`ExternalName` trick, for when you have addresses rather than a name.

--- a/banks/ckad-mock-01/q39/validate.d/10_headless.sh
+++ b/banks/ckad-mock-01/q39/validate.d/10_headless.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# points: 3
+# desc: Service shard is headless, selects app=shard and publishes port 80
+set -uo pipefail
+. /banks/_lib/checks.sh
+evidence() {
+  show_actual yaml "$(kubectl -n telescopium get svc shard -o yaml 2>/dev/null | k8s_clean)"
+  show_why "$1"
+}
+
+kubectl -n telescopium get svc shard >/dev/null 2>&1 || {
+  echo "no Service named shard in Namespace telescopium"
+  show_actual text "$(kubectl -n telescopium get svc 2>/dev/null)"
+  show_why "The StatefulSet names shard as its governing Service and nothing by that name exists. Its Pods run regardless — a StatefulSet does not wait for the Service — but neither the set's own name nor any per-Pod name resolves until the Service is there."
+  exit 1
+}
+
+cip=$(kubectl -n telescopium get svc shard -o jsonpath='{.spec.clusterIP}' 2>/dev/null)
+sel=$(kubectl -n telescopium get svc shard -o json 2>/dev/null \
+  | jq -r '.spec.selector // {} | to_entries | map("\(.key)=\(.value)") | sort | join(",")')
+target=$(kubectl -n telescopium get svc shard \
+  -o jsonpath='{.spec.ports[?(@.port==80)].targetPort}' 2>/dev/null)
+
+crit 2 "no cluster IP is allocated" \
+  "clusterIP is '$cip', want None" \
+  "clusterIP: None is the whole of 'headless', and the value is the literal string None rather than an empty one — omit the field and the API allocates an address as usual. With no virtual address there is nothing for kube-proxy to program, so the name resolves to the Pod addresses themselves instead of to one address in front of them, and it is that shape which lets the cluster's DNS publish a name per Pod. The type still reads ClusterIP; headless is not a fourth Service type." \
+  -- [ "$cip" = "None" ]
+
+crit 1 "selects the StatefulSet's Pods" \
+  "selector is '$sel', want app=shard" \
+  "A Service finds its Pods by label, never by name and never through the StatefulSet that owns them. Naming the set in spec.serviceName does not connect the two — the Service's own selector does, and while it matches nothing the name resolves to nothing at all." \
+  -- [ "$sel" = "app=shard" ]
+
+crit 1 "publishes port 80" \
+  "targetPort for port 80 is '$target', want 80" \
+  "A headless Service still declares its ports: they describe the endpoints and they are what its SRV records answer with. Nothing is renumbered for a direct connection to a Pod address, but a Service that publishes no port 80 does not publish the port the question asked for." \
+  -- [ "$target" = "80" ]
+
+crit_all_passed || evidence "$(crit_why)"
+report "headless service ok"

--- a/banks/ckad-mock-01/q39/validate.d/20_names.sh
+++ b/banks/ckad-mock-01/q39/validate.d/20_names.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# points: 4
+# desc: all three Pods are ready endpoints and each answers on its own DNS name
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+view='.items[] | del(.metadata.ownerReferences, .metadata.generateName,
+                     .metadata.annotations, .metadata.labels)'
+evidence() {
+  show_actual yaml "$(kubectl -n telescopium get endpointslice -l kubernetes.io/service-name=shard -o yaml 2>/dev/null | k8s_clean | yq "$view")"
+  show_why "$1"
+}
+
+count=$(kubectl -n telescopium get endpointslice -l kubernetes.io/service-name=shard -o json 2>/dev/null \
+  | jq '[.items[].endpoints[]? | select(.conditions.ready == true)] | length')
+count=${count:-0}
+
+out=$(kubectl -n telescopium exec shard-0 -- sh -c \
+  'for h in shard-1 shard-2; do
+     curl -s -m 4 "http://${h}.shard.telescopium.svc.cluster.local/"
+   done' 2>/dev/null)
+
+named() { printf '%s' "$out" | grep -q "$1"; }
+per_pod_names() { named 'shard-1' && named 'shard-2'; }
+
+crit 2 "all three Pods appear as ready endpoints" \
+  "the Service has $count ready endpoints, want 3" \
+  "An endpoint list that is short or empty means the Service is selecting fewer Pods than the set runs. Compare spec.selector on the Service with the labels on the StatefulSet's Pod template — and remember a headless Service publishes its endpoints as DNS answers, so the address list IS what the name resolves to." \
+  -- [ "$count" = "3" ]
+
+crit 2 "each Pod answers on its own DNS name" \
+  "shard-1 and shard-2 did not both answer on their per-Pod names (got: $(printf '%s' "$out" | tr '\n' ' ' | head -c 120))" \
+  "The name shard-N.shard.telescopium.svc.cluster.local exists because the StatefulSet gives each Pod a stable hostname and sets its subdomain to the governing Service's name — and because that Service is headless. Point the same set at an ordinary ClusterIP Service and the per-Pod names stop resolving while the Service's own name keeps working, which is exactly the failure this criterion catches." \
+  -- per_pod_names
+
+crit_all_passed || evidence "$(crit_why)"
+report "per-Pod names resolve"

--- a/banks/ckad-mock-01/q39/validate.d/30_recorded.sh
+++ b/banks/ckad-mock-01/q39/validate.d/30_recorded.sh
@@ -1,32 +1,47 @@
 #!/usr/bin/env bash
 # points: 2
-# desc: the recorded file holds the three Pod addresses the headless name resolves to
+# desc: the recorded file holds the per-Pod DNS name of each of the three Pods
 set -uo pipefail
 . /banks/_lib/checks.sh
 
+FILE=/opt/course/39/shard-names
+SUFFIX=.shard.telescopium.svc.cluster.local
+
+# The Pods the Service publishes, named rather than addressed. targetRef is the
+# Pod behind each endpoint, and <pod>.<service>.<namespace>.svc.cluster.local is
+# the name the cluster's DNS answers for it while the Service is headless.
 want=$(kubectl -n telescopium get endpointslice -l kubernetes.io/service-name=shard -o json 2>/dev/null \
-  | jq -r '[.items[].endpoints[]? | select(.conditions.ready == true) | .addresses[]?] | unique | .[]')
-got=$(file_lines_sorted /opt/course/39/shard-addresses | sort -u)
-n=$(printf '%s\n' "$got" | grep -c '[0-9]')
+  | jq -r --arg suffix "$SUFFIX" '[.items[].endpoints[]?
+      | select(.conditions.ready == true)
+      | .targetRef.name // empty
+      | . + $suffix] | unique | .[]')
+
+# A trailing dot is the DNS root, not a different name, so it is normalised away
+# rather than scored.
+got=$(file_lines_sorted "$FILE" | sed 's/\.$//' | sort -u)
+lines=$(printf '%s\n' "$got" | grep -c '.')
+named=$(printf '%s\n' "$got" | grep -c '^shard-[0-9][0-9]*\.shard\.telescopium\.svc\.cluster\.local$')
 
 evidence() {
-  show_actual text "$(cat /opt/course/39/shard-addresses 2>/dev/null)"
+  show_actual text "$(cat "$FILE" 2>/dev/null)"
   show_why "$1"
 }
 
+three_names() { [ "$lines" = "3" ] && [ "$named" = "3" ]; }
+
 # Two empty sets are equal, and that must not read as a match: with no Service
 # there is nothing to have recorded and nothing to compare it against.
-addresses_match() { [ -n "$want" ] && [ -n "$got" ] && same_set "$got" "$want"; }
+names_match() { [ -n "$want" ] && [ -n "$got" ] && same_set "$got" "$want"; }
 
-crit 1 "three distinct addresses recorded" \
-  "/opt/course/39/shard-addresses holds $n address line(s), want 3" \
-  "A headless name answers with one A record per ready endpoint, so this file should hold three addresses, one to a line and nothing else. Raw nslookup output does not qualify: it also carries the resolver's own address, which was never one of the answers." \
-  -- [ "$n" = "3" ]
+crit 1 "three distinct per-Pod names recorded" \
+  "$FILE holds $lines line(s), $named of them a per-Pod name of the form shard-N${SUFFIX}, want 3" \
+  "A headless Service publishes a name for every Pod in the set — <pod>.<service>.<namespace>.svc.cluster.local — and this set runs three Pods, so the file should hold three of those names fully qualified, one to a line and nothing else. The Pod addresses are not the answer here: a rescheduled Pod comes back with the same name at a different address, which is the whole reason a StatefulSet is given a headless Service to be reached through." \
+  -- three_names
 
 crit 1 "they are the Pods behind the headless Service" \
-  "the addresses recorded are not the ones the Service publishes" \
-  "The EndpointSlice the Service owns is where the DNS answer is generated from, so the two always agree and either is a fair way to read the addresses. Addresses that do not match are usually a different Service's, or the Pod names rather than their addresses." \
-  -- addresses_match
+  "the names recorded are not the ones the Service publishes" \
+  "These names exist only for the Pods the Service actually selects, so they are read off it rather than written from memory: each endpoint on the EndpointSlice the Service owns carries a targetRef naming its Pod, and the per-Pod name is that Pod's name in front of the Service's own DNS name. A name for a Pod the Service does not publish resolves to nothing, and while the Service does not exist at all neither does any of them." \
+  -- names_match
 
 crit_all_passed || evidence "$(crit_why)"
-report "addresses recorded"
+report "names recorded"

--- a/banks/ckad-mock-01/q39/validate.d/30_recorded.sh
+++ b/banks/ckad-mock-01/q39/validate.d/30_recorded.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: the recorded file holds the three Pod addresses the headless name resolves to
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+want=$(kubectl -n telescopium get endpointslice -l kubernetes.io/service-name=shard -o json 2>/dev/null \
+  | jq -r '[.items[].endpoints[]? | select(.conditions.ready == true) | .addresses[]?] | unique | .[]')
+got=$(file_lines_sorted /opt/course/39/shard-addresses | sort -u)
+n=$(printf '%s\n' "$got" | grep -c '[0-9]')
+
+evidence() {
+  show_actual text "$(cat /opt/course/39/shard-addresses 2>/dev/null)"
+  show_why "$1"
+}
+
+# Two empty sets are equal, and that must not read as a match: with no Service
+# there is nothing to have recorded and nothing to compare it against.
+addresses_match() { [ -n "$want" ] && [ -n "$got" ] && same_set "$got" "$want"; }
+
+crit 1 "three distinct addresses recorded" \
+  "/opt/course/39/shard-addresses holds $n address line(s), want 3" \
+  "A headless name answers with one A record per ready endpoint, so this file should hold three addresses, one to a line and nothing else. Raw nslookup output does not qualify: it also carries the resolver's own address, which was never one of the answers." \
+  -- [ "$n" = "3" ]
+
+crit 1 "they are the Pods behind the headless Service" \
+  "the addresses recorded are not the ones the Service publishes" \
+  "The EndpointSlice the Service owns is where the DNS answer is generated from, so the two always agree and either is a fair way to read the addresses. Addresses that do not match are usually a different Service's, or the Pod names rather than their addresses." \
+  -- addresses_match
+
+crit_all_passed || evidence "$(crit_why)"
+report "addresses recorded"

--- a/banks/ckad-mock-01/q40/hints.md
+++ b/banks/ckad-mock-01/q40/hints.md
@@ -1,0 +1,22 @@
+## Hint 1
+
+Replicas of a Deployment all reference the same claim, which is exactly
+what this question forbids. The workload you want takes a *template* for
+storage rather than a claim, and its controller stamps one claim out of
+that template per replica.
+
+It also insists on knowing which Service stands in front of it, and that
+Service has to be one with no address of its own.
+
+## Hint 2
+
+`spec.volumeClaimTemplates` is a sibling of `spec.template`, not
+something inside it, and each entry looks like the `spec` of a
+PersistentVolumeClaim. Mount it in the container under the template's
+`metadata.name`.
+
+`spec.serviceName` takes the name of the Service. A Service is headless
+when `clusterIP` is `None`.
+
+`kubectl -n cepheus get pvc` prints the claim names the controller
+generated; the pattern is `<template>-<workload>-<ordinal>`.

--- a/banks/ckad-mock-01/q40/question.md
+++ b/banks/ckad-mock-01/q40/question.md
@@ -1,0 +1,23 @@
+Team Cepheus keeps a ledger that no two replicas may share, in Namespace
+`cepheus`.
+
+1. Create a **headless** Service named `ledger` in Namespace `cepheus`,
+   selecting `app=ledger` on port `80`.
+2. Create a **StatefulSet** named `ledger` in the same Namespace:
+   - `2` replicas, governed by the Service `ledger`
+   - Pod label `app=ledger`
+   - one container named `ledger`, image `busybox:1.37`, command
+     `sh -c "sleep 86400"`
+   - a `volumeClaimTemplates` entry named `data` asking for `128Mi` with
+     access mode `ReadWriteOnce`, mounted at `/data` in the container
+
+   Name **no** storage class: the cluster's default one provisions these
+   volumes on demand.
+3. Both Pods must become `Ready`, and each must end up with a claim of
+   its own.
+4. Inside each Pod, write that Pod's own name into `/data/owner`, so
+   the file reads `ledger-0` in the first replica and `ledger-1` in the
+   second.
+5. Save the names of the two claims the StatefulSet created to
+   `/opt/course/40/claims` on `instance-2` — one name per line, nothing
+   else.

--- a/banks/ckad-mock-01/q40/setup.sh
+++ b/banks/ckad-mock-01/q40/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl create ns cepheus --dry-run=client -o yaml | kubectl apply -f -

--- a/banks/ckad-mock-01/q40/solution.md
+++ b/banks/ckad-mock-01/q40/solution.md
@@ -1,0 +1,123 @@
+# Solution 40
+
+Three things separate a StatefulSet from a Deployment, and this question
+uses all of them: Pod names that end in a stable ordinal, a governing
+Service named by `serviceName`, and `volumeClaimTemplates` — the field
+that hands every replica a PersistentVolumeClaim of its own instead of
+pointing them all at one.
+
+```bash
+k apply -f - <<'EOF'
+apiVersion: v1
+kind: Service
+metadata:
+  name: ledger
+  namespace: cepheus
+spec:
+  clusterIP: None
+  selector:
+    app: ledger
+  ports:
+    - port: 80
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ledger
+  namespace: cepheus
+spec:
+  serviceName: ledger
+  replicas: 2
+  selector:
+    matchLabels: {app: ledger}
+  template:
+    metadata:
+      labels: {app: ledger}
+    spec:
+      containers:
+        - name: ledger
+          image: busybox:1.37
+          command: ["sh", "-c", "sleep 86400"]
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 128Mi
+EOF
+```
+
+Note where `volumeClaimTemplates` sits: at the same level as
+`replicas` and `template`, not inside the Pod spec. Putting it one
+level too deep is the usual first attempt, and the API server rejects it
+rather than quietly ignoring it, which is the good outcome.
+
+Watch it come up. Replicas are created in order, so `ledger-1` does not
+start until `ledger-0` is Ready:
+
+```bash
+k -n cepheus rollout status statefulset ledger
+k -n cepheus get pod,pvc
+# NAME           READY   STATUS
+# pod/ledger-0   1/1     Running
+# pod/ledger-1   1/1     Running
+#
+# NAME                                     STATUS   VOLUME     CAPACITY
+# persistentvolumeclaim/data-ledger-0      Bound    pvc-…      128Mi
+# persistentvolumeclaim/data-ledger-1      Bound    pvc-…      128Mi
+```
+
+Then write each Pod's own name into its own volume and record the claim
+names:
+
+```bash
+for p in ledger-0 ledger-1; do
+  k -n cepheus exec "$p" -- sh -c "echo $p > /data/owner"
+done
+
+k -n cepheus get pvc -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+  > /opt/course/40/claims
+cat /opt/course/40/claims
+# data-ledger-0
+# data-ledger-1
+```
+
+## Where the claim names come from
+
+`<template name>-<statefulset name>-<ordinal>`. The controller derives
+them, which is why they are worth reading rather than inventing: they
+are how a replacement Pod finds the volume its predecessor was using.
+Delete `ledger-0` and the StatefulSet recreates a Pod with the same
+name, which claims `data-ledger-0` again and sees `/data/owner` exactly
+as it left it. That is the "storage that survives" part.
+
+Deleting the StatefulSet does **not** delete the claims. They outlive it
+on purpose, and cleaning them up is a separate, deliberate step.
+
+## Why no storage class
+
+The cluster has a default StorageClass with a dynamic provisioner, so a
+claim that names no class gets the default injected and a volume created
+for it on demand. That is what makes `volumeClaimTemplates` practical:
+two replicas today, ten tomorrow, and nobody creates ten
+PersistentVolumes by hand.
+
+Naming a class only matters when you want a *particular* one — or when
+you want to opt out of dynamic provisioning entirely and bind to a
+volume you made yourself, which needs a class name no provisioner
+answers for.
+
+## What a Deployment would have done instead
+
+A Deployment has no `volumeClaimTemplates`. To give its Pods persistent
+storage you write one PersistentVolumeClaim and reference it from the
+Pod template, so **every replica mounts the same volume** — fine for
+something read-only or genuinely shared, and wrong the moment each
+replica owns state. With a `ReadWriteOnce` claim it is worse than wrong:
+the second replica cannot mount at all if it lands on another node, and
+the rollout stalls with no obvious cause.

--- a/banks/ckad-mock-01/q40/validate.d/10_statefulset.sh
+++ b/banks/ckad-mock-01/q40/validate.d/10_statefulset.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: StatefulSet ledger runs 2 replicas governed by the headless Service ledger
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+sts=$(kubectl -n cepheus get statefulset ledger -o json 2>/dev/null \
+  | jq '{replicas: .spec.replicas, serviceName: .spec.serviceName, selector: .spec.selector.matchLabels}')
+svc=$(kubectl -n cepheus get svc ledger -o json 2>/dev/null \
+  | jq '{clusterIP: .spec.clusterIP, selector: .spec.selector}')
+
+evidence() {
+  show_actual json "$(jq -n --argjson sts "${sts:-null}" --argjson svc "${svc:-null}" \
+    '{"statefulset ledger": $sts, "service ledger": $svc}' 2>/dev/null)"
+  show_why "$1"
+}
+
+# The workload existing at all is the gate: a Deployment of the same name mounts
+# one shared claim, which is the answer this question exists to rule out.
+have=$(kubectl -n cepheus get statefulset ledger -o jsonpath='{.metadata.name}' 2>/dev/null)
+[ -n "$have" ] || {
+  echo "no StatefulSet named 'ledger' in namespace cepheus (statefulsets found: $(name_list "$(kubectl -n cepheus get statefulset -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)"))"
+  show_actual text "$(kubectl -n cepheus get statefulset,deploy,pod 2>&1)"
+  show_why "Only a StatefulSet gives each replica storage of its own. A Deployment points every replica at whichever claim its Pod template names, so scaling it hands the same volume to all of them — and with a ReadWriteOnce claim the extra replicas cannot even mount it."
+  exit 1
+}
+
+replicas=$(kubectl -n cepheus get statefulset ledger -o jsonpath='{.spec.replicas}' 2>/dev/null)
+svcname=$(kubectl -n cepheus get statefulset ledger -o jsonpath='{.spec.serviceName}' 2>/dev/null)
+clusterip=$(kubectl -n cepheus get svc ledger -o jsonpath='{.spec.clusterIP}' 2>/dev/null)
+
+crit 1 "2 replicas" \
+  "spec.replicas is '$replicas', want 2" \
+  "Two replicas is what makes the storage question visible: one claim would prove nothing, and the ordinals only start to matter once there is more than one of them." \
+  -- [ "$replicas" = "2" ]
+
+crit 1 "governed by Service ledger" \
+  "spec.serviceName is '$svcname', want ledger" \
+  "serviceName names the Service that governs the set. It is a required field on a StatefulSet and it is not a selector — the Service still finds Pods by label. Getting it wrong costs nothing at creation time and everything later, which is why it is worth checking rather than assuming." \
+  -- [ "$svcname" = "ledger" ]
+
+crit 1 "that Service is headless" \
+  "service ledger has clusterIP '$clusterip', want None" \
+  "A headless Service is one created with clusterIP: None. It allocates no virtual address and does no load balancing, which is the point when the replicas are not interchangeable. Leave the field out and the Service gets an address, and it stops being headless." \
+  -- [ "$clusterip" = "None" ]
+
+crit_all_passed || evidence "$(crit_why)"
+report "statefulset and its governing service ok"

--- a/banks/ckad-mock-01/q40/validate.d/20_claim-template.sh
+++ b/banks/ckad-mock-01/q40/validate.d/20_claim-template.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# points: 3
+# desc: volumeClaimTemplates entry data asks for 128Mi RWO and is mounted at /data
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+sts=$(kubectl -n cepheus get statefulset ledger -o json 2>/dev/null)
+
+evidence() {
+  show_actual json "$(printf '%s' "$sts" | jq '{
+    volumeClaimTemplates: [.spec.volumeClaimTemplates[]? | {
+      name: .metadata.name,
+      accessModes: .spec.accessModes,
+      storage: .spec.resources.requests.storage,
+      storageClassName: .spec.storageClassName}],
+    containers: [.spec.template.spec.containers[]? | {name, volumeMounts}]}' 2>/dev/null)"
+  show_why "$1"
+}
+
+tpl=$(printf '%s' "$sts" \
+  | jq -r '[.spec.volumeClaimTemplates[]? | select(.metadata.name == "data")] | first // {}' 2>/dev/null)
+name=$(printf '%s' "$tpl" | jq -r '.metadata.name // ""' 2>/dev/null)
+size=$(printf '%s' "$tpl" | jq -r '.spec.resources.requests.storage // ""' 2>/dev/null)
+modes=$(printf '%s' "$tpl" | jq -r '(.spec.accessModes // []) | join(" ")' 2>/dev/null)
+cnames=$(printf '%s' "$sts" | jq -r '[.spec.template.spec.containers[]?.name] | join(" ")' 2>/dev/null)
+mpath=$(printf '%s' "$sts" | jq -r '[.spec.template.spec.containers[]?
+  | select(.name == "ledger") | .volumeMounts[]?
+  | select(.name == "data") | .mountPath] | first // ""' 2>/dev/null)
+
+crit 1 "a volumeClaimTemplate named data" \
+  "no volumeClaimTemplates entry named 'data'" \
+  "volumeClaimTemplates is a sibling of spec.template, not a field inside the Pod spec, and each entry is shaped like a PersistentVolumeClaim. The controller stamps one real claim per replica out of it, which is the whole reason a StatefulSet is the right resource here." \
+  -- [ "$name" = "data" ]
+
+crit 1 "asking for 128Mi" \
+  "the template requests '$size', want 128Mi" \
+  "resources.requests.storage is the size each generated claim asks for. It is a minimum rather than a cap: the provisioner is free to hand back a larger volume, and the claim takes all of it." \
+  -- [ "$(mib "$size")" = "128" ]
+
+crit 1 "with access mode ReadWriteOnce" \
+  "the template's accessModes are '$modes', want ReadWriteOnce" \
+  "ReadWriteOnce means one node may mount the volume read-write at a time, which is exactly right when no two replicas share storage. It is also part of what a claim is matched on, so a mode the backing storage cannot offer leaves the claim Pending forever." \
+  -- same_set "$modes" "ReadWriteOnce"
+
+crit 2 "mounted at /data in container ledger" \
+  "container 'ledger' mounts 'data' at '$mpath', want /data (containers present: $(name_list "$cnames"))" \
+  "Declaring the template and mounting it are two separate steps. A template nobody mounts still creates claims and still binds volumes, and the container sees none of it — the mount is what puts the volume inside the process's filesystem, and it refers to the template by its metadata.name." \
+  -- [ "$mpath" = "/data" ]
+
+crit_all_passed || evidence "$(crit_why)"
+report "claim template and mount ok"

--- a/banks/ckad-mock-01/q40/validate.d/30_claims.sh
+++ b/banks/ckad-mock-01/q40/validate.d/30_claims.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: one Bound claim per ordinal, data-ledger-0 and data-ledger-1, both recorded
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+phase() { kubectl -n cepheus get pvc "$1" -o jsonpath='{.status.phase}' 2>/dev/null; }
+zero=$(phase data-ledger-0)
+one=$(phase data-ledger-1)
+recorded=$(file_lines_sorted /opt/course/40/claims)
+want=$(printf 'data-ledger-0\ndata-ledger-1')
+
+crit 1 "data-ledger-0 is Bound" \
+  "claim data-ledger-0 is '$zero', want Bound" \
+  "The controller names each generated claim <template>-<statefulset>-<ordinal>, so a claim under any other name means the template, the workload or the resource kind is not the one this question asked for. Bound is what proves a volume really was provisioned for it rather than merely requested." \
+  -- [ "$zero" = "Bound" ]
+
+crit 1 "data-ledger-1 is Bound" \
+  "claim data-ledger-1 is '$one', want Bound" \
+  "The second ordinal is the one that shows the storage is per replica. A single claim serving both Pods is what a Deployment would have given you; here each ordinal gets a claim of its own, created when that replica is first started." \
+  -- [ "$one" = "Bound" ]
+
+crit 1 "both claim names recorded on the instance" \
+  "/opt/course/40/claims does not list exactly those two names" \
+  "The names are the controller's, not yours, which is why the question asks you to read them back. Names only, one per line: a kubectl table, a resource-prefixed 'persistentvolumeclaim/...' form or a line of prose is not the name, even with the name inside it." \
+  -- [ "$recorded" = "$want" ]
+
+crit_all_passed || {
+  show_actual text "$(kubectl -n cepheus get pvc 2>&1; echo; echo '/opt/course/40/claims:'; cat /opt/course/40/claims 2>&1)"
+  show_why "$(crit_why)"
+}
+report "one bound claim per replica, recorded"

--- a/banks/ckad-mock-01/q40/validate.d/40_ready.sh
+++ b/banks/ckad-mock-01/q40/validate.d/40_ready.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# points: 1
+# desc: both StatefulSet replicas are Ready
+set -uo pipefail
+. /banks/_lib/checks.sh
+ready=$(kubectl -n cepheus get statefulset ledger -o jsonpath='{.status.readyReplicas}' 2>/dev/null)
+[ "$ready" = "2" ] && echo "2 ready replicas" || {
+  echo "readyReplicas is '$ready', want 2"
+  show_actual text "$(kubectl -n cepheus get pod 2>&1; echo; kubectl -n cepheus get pvc 2>&1)"
+  show_why "A StatefulSet starts its replicas in order and will not start ledger-1 until ledger-0 is Ready, so one Pod up and the other missing entirely is the normal shape of a stall rather than a second failure. A Pod stuck Pending is usually waiting on its claim: the default class provisions the volume only once the Pod has been scheduled, so a claim that never binds and a Pod that never schedules are the same problem seen from two sides."
+  exit 1
+}

--- a/banks/ckad-mock-01/q40/validate.d/50_owner.sh
+++ b/banks/ckad-mock-01/q40/validate.d/50_owner.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# points: 1
+# desc: each replica wrote its own name into its own volume at /data/owner
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+owner() { kubectl -n cepheus exec "$1" -- cat /data/owner 2>/dev/null | tr -d '[:space:]'; }
+zero=$(owner ledger-0)
+one=$(owner ledger-1)
+
+crit 1 "ledger-0 holds its own name" \
+  "/data/owner in ledger-0 reads '$zero', want ledger-0" \
+  "The file has to be written inside the Pod, on the mounted volume — writing it on the instance puts it somewhere no container can see. An empty reading means either no file at that path or nothing mounted there at all." \
+  -- [ "$zero" = "ledger-0" ]
+
+crit 1 "ledger-1 holds its own, different name" \
+  "/data/owner in ledger-1 reads '$one', want ledger-1" \
+  "Both replicas reading the same value would mean they share one volume, which is precisely what a StatefulSet is chosen to avoid. Each ordinal mounts the claim generated for it, so the two files are independent and a replacement Pod finds the value its predecessor left." \
+  -- [ "$one" = "ledger-1" ]
+
+crit_all_passed || {
+  show_actual text "$(kubectl -n cepheus get pod 2>&1; echo; printf 'ledger-0 /data/owner: %s\nledger-1 /data/owner: %s\n' "$zero" "$one")"
+  show_why "$(crit_why)"
+}
+report "each replica owns its own volume"

--- a/banks/ckad-mock-01/q41/hints.md
+++ b/banks/ckad-mock-01/q41/hints.md
@@ -1,0 +1,21 @@
+## Hint 1
+
+`Pending` is not an error state — it is the scheduler saying it has not
+found anywhere to put the Pod yet. Nothing in the container logs will
+tell you why, because no container was ever created. The reason is in
+the Pod's events instead.
+
+Every object carries its recent events, and there are two ways to reach
+them: the bottom of `kubectl describe`, or `kubectl get events` filtered
+down to the object you care about.
+
+## Hint 2
+
+Compare what the Pod asks for against what a node has. `requests` is what
+the scheduler does arithmetic with; `limits` it ignores entirely.
+
+For step 3, remember that `spec.containers[].resources` is fixed once the
+Pod exists. Save the Pod to a file, edit the request there, delete the
+Pod and apply the file — `kubectl get pod ... -o yaml` is the quickest
+way to get a starting manifest, and `--force` on `replace` will do the
+delete for you.

--- a/banks/ckad-mock-01/q41/question.md
+++ b/banks/ckad-mock-01/q41/question.md
@@ -1,0 +1,16 @@
+Namespace `columba` runs three Pods. Two are serving; one has been
+`Pending` since it was created and no container of it has ever started.
+
+1. Write the name of the Pod that will not schedule to
+   `/opt/course/41/pod-name` — the name only, nothing else.
+2. The scheduler has already said why. Save its message, **copied as it
+   appears**, to `/opt/course/41/reason`. Do not paraphrase it.
+3. Make that same Pod run. Keep its name, its container name and its
+   image exactly as they are, and give the container a memory request of
+   `64Mi` instead of the one it has.
+
+Leave the other two Pods alone.
+
+A Pod's resource requests cannot be edited in place, so step 3 needs the
+Pod replaced rather than patched — which is also why step 2 has to happen
+first.

--- a/banks/ckad-mock-01/q41/setup.sh
+++ b/banks/ckad-mock-01/q41/setup.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl create ns columba --dry-run=client -o yaml | kubectl apply -f -
+
+# A Pod's resources are immutable, so a re-seed cannot apply its way back over a
+# repaired archive-indexer — it has to take the object away first. The other two
+# Pods are unchanged by the exercise and apply cleanly whether they exist or not.
+kubectl -n columba delete pod archive-indexer \
+  --ignore-not-found --grace-period=1 --wait=true --timeout=90s
+
+kubectl -n columba apply -f - <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: price-feed
+  namespace: columba
+  labels: {app: price-feed}
+spec:
+  containers:
+    - name: feed
+      image: busybox:1.37
+      command: ["sh", "-c", "sleep 86400"]
+      resources:
+        requests: {memory: 16Mi, cpu: 10m}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: report-cache
+  namespace: columba
+  labels: {app: report-cache}
+spec:
+  containers:
+    - name: cache
+      image: nginx:1.29-alpine
+      resources:
+        requests: {memory: 16Mi, cpu: 10m}
+---
+# The fault: a request no node can satisfy. The scheduler never places the Pod
+# and says so in a FailedScheduling event, which is the whole exercise. 900Gi is
+# far beyond any machine this runs on, so the outcome does not depend on the
+# host's size the way an absurd CPU request would.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: archive-indexer
+  namespace: columba
+  labels: {app: archive-indexer}
+spec:
+  containers:
+    - name: indexer
+      image: busybox:1.37
+      command: ["sh", "-c", "sleep 86400"]
+      resources:
+        requests: {memory: 900Gi}
+EOF
+
+kubectl -n columba wait --for=condition=Ready pod/price-feed pod/report-cache --timeout=120s || true

--- a/banks/ckad-mock-01/q41/solution.md
+++ b/banks/ckad-mock-01/q41/solution.md
@@ -1,0 +1,137 @@
+# Solution 41
+
+Start with the listing. `Pending` with `0/1` containers ready and an age
+that keeps growing is the shape to recognise:
+
+```bash
+k -n columba get pod
+# NAME              READY   STATUS    RESTARTS   AGE
+# archive-indexer   0/1     Pending   0          3m
+# price-feed        1/1     Running   0          3m
+# report-cache      1/1     Running   0          3m
+```
+
+```bash
+echo archive-indexer > /opt/course/41/pod-name
+```
+
+There is nothing to read in the logs, and saying so is worth doing once:
+
+```bash
+k -n columba logs archive-indexer
+# Error from server (BadRequest): container "indexer" in pod "archive-indexer" is
+# waiting to start: ContainerCreating
+```
+
+No container ever started, so there is no log stream. The scheduler
+records its verdict as an event on the Pod instead:
+
+```bash
+k -n columba describe pod archive-indexer | tail -6
+# Events:
+#   Type     Reason            Age   From               Message
+#   ----     ------            ----  ----               -------
+#   Warning  FailedScheduling  3m    default-scheduler  0/2 nodes are available:
+#     2 Insufficient memory. preemption: 0/2 nodes are available: 2 No preemption
+#     victims found for incoming pod.
+```
+
+Save it exactly as it came out:
+
+```bash
+k -n columba get events \
+  --field-selector involvedObject.name=archive-indexer \
+  -o jsonpath='{range .items[*]}{.reason}{": "}{.message}{"\n"}{end}' \
+  > /opt/course/41/reason
+```
+
+`Insufficient memory` is the whole answer. Confirm it against the
+arithmetic the scheduler was doing:
+
+```bash
+k -n columba get pod archive-indexer \
+  -o jsonpath='{.spec.containers[*].resources.requests}'
+# {"memory":"900Gi"}
+```
+
+## Replacing the Pod
+
+`resources` is immutable on a running Pod, so an edit is refused:
+
+```bash
+k -n columba edit pod archive-indexer
+# error: pods "archive-indexer" was not valid:
+# spec: Forbidden: pod updates may not change fields other than ...
+```
+
+Take the object, change the one field, and replace it:
+
+```bash
+k -n columba get pod archive-indexer -o yaml > /tmp/indexer.yaml
+vim /tmp/indexer.yaml     # memory: 900Gi -> memory: 64Mi
+k -n columba replace --force -f /tmp/indexer.yaml
+```
+
+`--force` deletes the existing object and creates the file's version in
+its place. Writing it out by hand is just as good:
+
+```bash
+k -n columba delete pod archive-indexer
+k -n columba apply -f - <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: archive-indexer
+  namespace: columba
+  labels: {app: archive-indexer}
+spec:
+  containers:
+    - name: indexer
+      image: busybox:1.37
+      command: ["sh", "-c", "sleep 86400"]
+      resources:
+        requests:
+          memory: 64Mi
+EOF
+k -n columba get pod archive-indexer -w
+```
+
+## Why the events and not the logs
+
+The three places a Pod can be stuck each leave their trace somewhere
+else, and reaching for the wrong one wastes most of the time this
+question is worth:
+
+| Stuck at | Status | Where the reason is |
+|---|---|---|
+| Scheduling | `Pending` | Events on the Pod, from `default-scheduler` |
+| Fetching the image | `ImagePullBackOff` | Events on the Pod, from `kubelet` |
+| Running | `CrashLoopBackOff` | The container's log, including the previous one |
+
+The first two have no container, so no log stream exists and `kubectl
+logs` can only tell you that. Only the third has anything to read.
+
+## What the scheduler was comparing
+
+Scheduling is arithmetic over `requests`, never over `limits` and never
+over what a Pod is really using:
+
+- A node's allocatable capacity is its capacity minus what the kubelet
+  and the system reserve.
+- From that, the scheduler subtracts the sum of the **requests** of every
+  Pod already assigned to the node — whether or not those Pods are using
+  any of it.
+- A Pod fits only if every one of its requests still fits in what is
+  left.
+
+So a Pod requesting more memory than any single node has can never be
+scheduled, no matter how idle the cluster is, and it stays `Pending`
+forever rather than failing. `0/2 nodes are available` counts every node
+in the cluster and then says, per node, which predicate rejected it —
+`Insufficient memory` here, and typically `untolerated taint` for the
+control-plane node.
+
+Requests are also what the QoS class is derived from, which is what
+decides the eviction order under memory pressure: a container with equal
+requests and limits is `Guaranteed`, one with requests below its limits
+is `Burstable`, and one with neither is `BestEffort` and dies first.

--- a/banks/ckad-mock-01/q41/validate.d/10_identified.sh
+++ b/banks/ckad-mock-01/q41/validate.d/10_identified.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: the Pod that cannot be scheduled was identified by name
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+got=$(file_text /opt/course/41/pod-name)
+[ "$got" = "archive-indexer" ] && { echo "identified"; exit 0; }
+
+echo "/opt/course/41/pod-name contains '$got', want archive-indexer"
+show_actual text "$(kubectl -n columba get pod -o wide 2>/dev/null)"
+show_why "Pending means the scheduler has not placed the Pod on a node, so its READY column reads 0/1 and it has no node and no IP. The other two Pods here are Running and are not the subject. Only the Pod's own name belongs in the file — not the Namespace, not the status."
+exit 1

--- a/banks/ckad-mock-01/q41/validate.d/20_reason.sh
+++ b/banks/ckad-mock-01/q41/validate.d/20_reason.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: the scheduler's own message about the Pod was captured verbatim
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+# Match one stable fragment rather than the whole sentence. The scheduler
+# rewords the surrounding text between releases — how the node tally is
+# phrased, whether preemption is mentioned — but the predicate that rejected
+# the node is always named this way.
+grep -qi 'insufficient memory' /opt/course/41/reason 2>/dev/null && { echo "reason recorded"; exit 0; }
+
+echo "/opt/course/41/reason does not carry the scheduler's message"
+show_actual text "$(head -20 /opt/course/41/reason 2>/dev/null)"
+show_why "A Pod with no container has no log to read, so the reason lives in its events, written by default-scheduler with reason FailedScheduling. The message names the predicate that rejected each node, and here that is memory: the Pod asks for more than any node has left. Describing the Pod shows the same event at the bottom of the output. A file holding a paraphrase, or the Pod's own spec, is not the message the scheduler wrote."
+exit 1

--- a/banks/ckad-mock-01/q41/validate.d/30_scheduled.sh
+++ b/banks/ckad-mock-01/q41/validate.d/30_scheduled.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# points: 3
+# desc: archive-indexer was replaced with a request the cluster can satisfy and is Running
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+evidence() {
+  show_actual json "$(kubectl -n columba get pod archive-indexer -o json 2>/dev/null \
+    | jq '{phase: .status.phase, node: .spec.nodeName,
+           containers: [.spec.containers[] | {name, image, requests: .resources.requests}]}')"
+  show_why "$1"
+}
+
+# The other two Pods were the control: the Namespace's healthy workloads are
+# not collateral, and clearing them out is not a step towards anything.
+others=$(kubectl -n columba get pod -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)
+for p in price-feed report-cache; do
+  has_name "$others" "$p" || {
+    echo "Pod ${p} is gone; the other two Pods were to be left alone (found: $(name_list "$others"))"
+    show_actual text "$(kubectl -n columba get pod -o wide 2>/dev/null)"
+    show_why "Two of the three Pods here were serving and one was not, and telling them apart before changing anything is most of the exercise. Replacing the Pending one does not require touching either of the others."
+    exit 1
+  }
+done
+
+phase=$(kubectl -n columba get pod archive-indexer -o jsonpath='{.status.phase}' 2>/dev/null)
+[ -n "$phase" ] || {
+  echo "there is no Pod archive-indexer in columba"
+  show_actual text "$(kubectl -n columba get pod -o wide 2>/dev/null)"
+  show_why "The Pod had to come back under the same name after being replaced. Deleting it is half of the fix — a bare Pod has no controller behind it, so nothing recreates it and nothing rolls it out again."
+  exit 1
+}
+
+img=$(kubectl -n columba get pod archive-indexer \
+  -o jsonpath='{.spec.containers[?(@.name=="indexer")].image}' 2>/dev/null)
+mem=$(kubectl -n columba get pod archive-indexer \
+  -o jsonpath='{.spec.containers[?(@.name=="indexer")].resources.requests.memory}' 2>/dev/null)
+
+crit 1 "still the container and image it had" \
+  "the indexer container runs '$img', want busybox:1.37" \
+  "Replacing a Pod is not the same as writing a new one. The question fixes the name, the container name and the image so that only the request changes; an empty value here also means the container was renamed, since it is looked up by name." \
+  -- [ "$img" = "busybox:1.37" ]
+
+crit 1 "asks for 64Mi of memory" \
+  "the indexer container requests '$mem' of memory, want 64Mi" \
+  "requests is the number the scheduler subtracts from a node's allocatable capacity, and the old value was larger than any node has. Any spelling of the same quantity is accepted — 64Mi and 65536Ki are the same amount of memory — but the amount itself is what the question pins." \
+  -- [ "$(mib "$mem")" = "64" ]
+
+crit 1 "is scheduled and running" \
+  "archive-indexer is '$phase', want Running" \
+  "Pending is the scheduler still looking; Running is it having found a node and the kubelet having started the container. If the phase is still Pending after the request came down, read the events again — the message names whichever predicate rejected the nodes this time." \
+  -- [ "$phase" = "Running" ]
+
+crit_all_passed || evidence "$(crit_why)"
+report "archive-indexer scheduled"

--- a/banks/ckad-mock-01/q41/validate.d/30_scheduled.sh
+++ b/banks/ckad-mock-01/q41/validate.d/30_scheduled.sh
@@ -36,10 +36,20 @@ img=$(kubectl -n columba get pod archive-indexer \
 mem=$(kubectl -n columba get pod archive-indexer \
   -o jsonpath='{.spec.containers[?(@.name=="indexer")].resources.requests.memory}' 2>/dev/null)
 
-crit 1 "still the container and image it had" \
-  "the indexer container runs '$img', want busybox:1.37" \
-  "Replacing a Pod is not the same as writing a new one. The question fixes the name, the container name and the image so that only the request changes; an empty value here also means the container was renamed, since it is looked up by name." \
-  -- [ "$img" = "busybox:1.37" ]
+# The seeded Pod already runs that container on that image — the exercise
+# changes nothing but the request — so "it still does" is true of a Namespace
+# nobody has touched. What survived the replacement only counts once there has
+# been a replacement, which is visible as the request that could not be
+# scheduled being gone.
+seeded_request=$(mib 900Gi)
+survived_the_replacement() {
+  [ "$img" = "busybox:1.37" ] && [ "$(mib "$mem")" != "$seeded_request" ]
+}
+
+crit 1 "replaced, and still the container and image it had" \
+  "the indexer container runs '$img' asking for '$mem'; want busybox:1.37 on a Pod that no longer carries the 900Gi request it was created with" \
+  "Replacing a Pod is not the same as writing a new one. The question fixes the name, the container name and the image so that only the request changes; an empty value here also means the container was renamed, since it is looked up by name. Keeping them is not work on its own — the Pod that is there already has them — so this counts once the original request has actually been replaced." \
+  -- survived_the_replacement
 
 crit 1 "asks for 64Mi of memory" \
   "the indexer container requests '$mem' of memory, want 64Mi" \

--- a/banks/ckad-mock-01/q42/hints.md
+++ b/banks/ckad-mock-01/q42/hints.md
@@ -1,0 +1,22 @@
+## Hint 1
+
+Two flags do the whole job. One replaces the default column set with
+columns you name yourself; the other reorders the rows before anything is
+printed. Neither of them needs a pipe into `awk`.
+
+`kubectl get --help` lists both, and the first of the two is one of the
+output formats rather than a flag of its own.
+
+## Hint 2
+
+The column format is a comma-separated list of `HEADING:<field path>`
+pairs, and the heading is printed exactly as you type it. The field
+paths are the same ones `kubectl explain` walks — the desired count lives
+on the spec, and the container list is under the Pod template.
+
+The ordering flag takes a single field path with a leading dot and no
+braces around it. It sorts a numeric field numerically, so no padding is
+needed.
+
+Redirect the command's output straight into the file; every column and
+the order are already the command's job.

--- a/banks/ckad-mock-01/q42/question.md
+++ b/banks/ckad-mock-01/q42/question.md
@@ -1,0 +1,19 @@
+Namespace `antlia` holds four Deployments. Platform wants a plain-text
+inventory of them.
+
+Write a report of every Deployment in `antlia` to `/opt/course/42/report`
+with exactly three columns, in this order and under exactly these
+headings:
+
+| Heading | Value |
+|---|---|
+| `NAME` | the Deployment's name |
+| `REPLICAS` | its **desired** replica count, not how many are ready |
+| `IMAGE` | the image of the first container in its Pod template |
+
+The rows must be sorted by replica count, **smallest first**. The file
+must hold the header line and one line per Deployment and nothing else —
+no counts, no blank banner, no Namespace column.
+
+`kubectl` can produce this whole file on its own. Build the columns and
+the ordering with flags rather than editing the output afterwards.

--- a/banks/ckad-mock-01/q42/setup.sh
+++ b/banks/ckad-mock-01/q42/setup.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl create ns antlia --dry-run=client -o yaml | kubectl apply -f -
+
+# Four distinct replica counts, so the sort order the report asks for has
+# exactly one correct answer and no ties to argue about.
+kubectl -n antlia apply -f - <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: search-indexer
+  namespace: antlia
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: search-indexer}
+  template:
+    metadata:
+      labels: {app: search-indexer}
+    spec:
+      containers:
+        - name: indexer
+          image: busybox:1.37
+          command: ["sh", "-c", "sleep 86400"]
+          resources:
+            requests: {memory: 16Mi, cpu: 10m}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: audit-writer
+  namespace: antlia
+spec:
+  replicas: 2
+  selector:
+    matchLabels: {app: audit-writer}
+  template:
+    metadata:
+      labels: {app: audit-writer}
+    spec:
+      containers:
+        - name: writer
+          image: busybox:1.37
+          command: ["sh", "-c", "sleep 86400"]
+          resources:
+            requests: {memory: 16Mi, cpu: 10m}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: image-resizer
+  namespace: antlia
+spec:
+  replicas: 3
+  selector:
+    matchLabels: {app: image-resizer}
+  template:
+    metadata:
+      labels: {app: image-resizer}
+    spec:
+      containers:
+        - name: resizer
+          image: nginx:1.27-alpine
+          resources:
+            requests: {memory: 16Mi, cpu: 10m}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: billing-api
+  namespace: antlia
+spec:
+  replicas: 4
+  selector:
+    matchLabels: {app: billing-api}
+  template:
+    metadata:
+      labels: {app: billing-api}
+    spec:
+      containers:
+        - name: api
+          image: nginx:1.29-alpine
+          resources:
+            requests: {memory: 16Mi, cpu: 10m}
+EOF
+
+for d in search-indexer audit-writer image-resizer billing-api; do
+  kubectl -n antlia rollout status "deploy/$d" --timeout=180s
+done

--- a/banks/ckad-mock-01/q42/solution.md
+++ b/banks/ckad-mock-01/q42/solution.md
@@ -1,0 +1,87 @@
+# Solution 42
+
+One command writes the file:
+
+```bash
+k -n antlia get deploy \
+  --sort-by=.spec.replicas \
+  -o custom-columns='NAME:.metadata.name,REPLICAS:.spec.replicas,IMAGE:.spec.template.spec.containers[0].image' \
+  > /opt/course/42/report
+
+cat /opt/course/42/report
+# NAME             REPLICAS   IMAGE
+# search-indexer   1          busybox:1.37
+# audit-writer     2          busybox:1.37
+# image-resizer    3          nginx:1.27-alpine
+# billing-api      4          nginx:1.29-alpine
+```
+
+Quote the `custom-columns` argument. It contains `[0]`, and an unquoted
+bracket is glob syntax the shell will try to expand before `kubectl` ever
+sees it.
+
+## custom-columns
+
+The format is a comma-separated list of `HEADING:<path>` pairs, and both
+halves matter:
+
+- The heading is printed **verbatim**. `name:` gives you a lowercase
+  `name` column, so the capitals in the report are yours to type.
+- The path is a JSONPath expression with no braces around it — the
+  braces belong to `-o jsonpath`, not here. It is the same walk
+  `kubectl explain deployment.spec.replicas` describes.
+
+A path that matches nothing prints `<none>` rather than failing, which
+is how a typo shows up: a column of `<none>` down the whole report.
+
+There is a file-backed form of the same thing for a report you run
+often, where the columns are whitespace-separated on their own lines:
+
+```bash
+k -n antlia get deploy -o custom-columns-file=/opt/course/42/cols.txt
+```
+
+## Sorting
+
+`--sort-by` takes one JSONPath expression, also unbraced, and reorders
+the list server-side output before printing. It is independent of the
+output format, so it works with `custom-columns`, with `wide`, and with
+the default columns:
+
+```bash
+k -n antlia get deploy --sort-by=.spec.replicas          # ascending
+k -n antlia get deploy --sort-by=.metadata.creationTimestamp
+```
+
+Two things about it are worth knowing under a clock:
+
+- **It sorts by type.** An integer field sorts numerically, so `10`
+  comes after `4` rather than before it as a lexical sort would put it.
+- **There is no descending flag.** To reverse it, pipe through `tac`, and
+  keep the header where it belongs:
+
+```bash
+k -n antlia get deploy --sort-by=.spec.replicas \
+  -o custom-columns='NAME:.metadata.name,REPLICAS:.spec.replicas' \
+  | (read -r h; echo "$h"; tac)
+```
+
+## Why not jsonpath
+
+`-o jsonpath` can produce the same three fields, and it is the wrong tool
+for a report:
+
+```bash
+k -n antlia get deploy \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.replicas}{"\n"}{end}'
+```
+
+That gives you no header, no column alignment, and tabs you then have to
+think about. `jsonpath` is for extracting **one value** to feed to
+something else — an image to record, a nodePort to curl. `custom-columns`
+is for output a person reads.
+
+The same split shows up in what each one does with a missing field.
+`jsonpath` fails the whole command; `custom-columns` prints `<none>` in
+that cell and carries on, which is what you want across a list of
+objects that are not all identical.

--- a/banks/ckad-mock-01/q42/validate.d/10_report.sh
+++ b/banks/ckad-mock-01/q42/validate.d/10_report.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# points: 4
+# desc: the report carries the three named columns and a correct line per Deployment
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+# Column widths are kubectl's padding, not the candidate's answer, so every
+# comparison below is made against whitespace-collapsed lines.
+squeeze() {
+  tr -d '\r' < "$1" 2>/dev/null \
+    | sed -e 's/[[:space:]][[:space:]]*/ /g' -e 's/^ //' -e 's/ $//' \
+    | grep -v '^$'
+}
+
+lines=$(squeeze /opt/course/42/report)
+[ -n "$lines" ] || {
+  echo "/opt/course/42/report is missing or empty"
+  show_actual text "$(kubectl -n antlia get deploy 2>/dev/null)"
+  show_why "The report is a file on the instance, written from the output of one kubectl command. Above is the default listing of the same Deployments — the task is to reshape it into the three named columns and redirect it."
+  exit 1
+}
+
+head_line=$(printf '%s\n' "$lines" | head -1 | tr '[:lower:]' '[:upper:]')
+body=$(printf '%s\n' "$lines" | tail -n +2)
+
+evidence() {
+  show_actual text "$(cat /opt/course/42/report 2>/dev/null)"
+  show_why "$1"
+}
+
+row_present() {
+  local want=$1 line
+  while IFS= read -r line; do
+    [ "$line" = "$want" ] && return 0
+  done <<EOF
+$body
+EOF
+  return 1
+}
+
+crit 1 "the header names the three columns in order" \
+  "the first line reads '$head_line', want 'NAME REPLICAS IMAGE'" \
+  "A custom-columns argument is a list of HEADING:path pairs, and the heading half is printed exactly as it was typed — so the header line is a direct readout of the column list, in the order it was written. A header of NAMESPACE NAME READY is the default listing, which means the output format never changed at all." \
+  -- [ "$head_line" = "NAME REPLICAS IMAGE" ]
+
+crit 1 "search-indexer, 1 replica" \
+  "no line reads 'search-indexer 1 busybox:1.37'" \
+  "REPLICAS is the desired count on the spec, which is the number the Deployment was created with. status.replicas and status.readyReplicas are what is actually there at this instant and are a different column." \
+  -- row_present "search-indexer 1 busybox:1.37"
+
+crit 1 "audit-writer, 2 replicas" \
+  "no line reads 'audit-writer 2 busybox:1.37'" \
+  "Two of these four Deployments share an image, so the IMAGE column is not a second copy of the name. It comes from the first container of the Pod template, not from any running Pod." \
+  -- row_present "audit-writer 2 busybox:1.37"
+
+crit 1 "image-resizer, 3 replicas" \
+  "no line reads 'image-resizer 3 nginx:1.27-alpine'" \
+  "The image column wants the whole reference including the tag, exactly as the Pod template carries it. Two of these Deployments run nginx on different tags, so a column built from the repository alone cannot tell them apart." \
+  -- row_present "image-resizer 3 nginx:1.27-alpine"
+
+crit 1 "billing-api, 4 replicas" \
+  "no line reads 'billing-api 4 nginx:1.29-alpine'" \
+  "A field path that matches nothing prints <none> in that cell rather than failing the command, so a column of <none> down the report is a typo in the path and not an empty cluster." \
+  -- row_present "billing-api 4 nginx:1.29-alpine"
+
+crit_all_passed || evidence "$(crit_why)"
+report "report columns ok"

--- a/banks/ckad-mock-01/q42/validate.d/20_order.sh
+++ b/banks/ckad-mock-01/q42/validate.d/20_order.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# points: 3
+# desc: the report holds one row per Deployment, ordered by ascending replica count
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+squeeze() {
+  tr -d '\r' < "$1" 2>/dev/null \
+    | sed -e 's/[[:space:]][[:space:]]*/ /g' -e 's/^ //' -e 's/ $//' \
+    | grep -v '^$'
+}
+
+lines=$(squeeze /opt/course/42/report)
+[ -n "$lines" ] || {
+  echo "/opt/course/42/report is missing or empty"
+  show_why "There is nothing to order yet. The report has to exist before its row order can be graded."
+  exit 1
+}
+
+names=$(printf '%s\n' "$lines" | tail -n +2 | cut -d' ' -f1 | tr '\n' ' ' | sed -e 's/ $//')
+count=$(printf '%s\n' "$lines" | tail -n +2 | grep -c .)
+want='search-indexer audit-writer image-resizer billing-api'
+
+evidence() {
+  show_actual text "$(cat /opt/course/42/report 2>/dev/null)"
+  show_why "$1"
+}
+
+crit 1 "one row per Deployment and no extras" \
+  "the report has $count rows below the header, want 4" \
+  "There are four Deployments in this Namespace and the file was to hold the header and one line each. A fifth line is usually a blank one at the end of a heredoc or an echoed total; a missing line is a filter that was never asked for." \
+  -- [ "$count" = "4" ]
+
+crit 2 "rows ascend by replica count" \
+  "the rows read '$names', want '$want'" \
+  "Sorting is a flag on the get, applied to the object list before a single line is printed, so it needs no pipe and no second pass over the output. It sorts by the field's own type: an integer field ascends numerically, which is why 4 lands last here rather than between 3 and anything beginning with a smaller digit. Untouched, the list comes back in name order, which puts audit-writer first." \
+  -- [ "$names" = "$want" ]
+
+crit_all_passed || evidence "$(crit_why)"
+report "report ordered"

--- a/banks/ckad-mock-01/q43/hints.md
+++ b/banks/ckad-mock-01/q43/hints.md
@@ -1,0 +1,24 @@
+## Hint 1
+
+A container that restarts on a schedule, with nothing wrong in its log,
+is almost always being killed from outside rather than exiting on its
+own. Whatever kills it says so in the Pod's events, naming the check that
+failed and the address it tried.
+
+Read the events before you change anything: repairing the Deployment
+rolls out fresh Pods and takes their event history with them.
+
+## Hint 2
+
+Compare the address in the event against the port the container is
+declared to serve on. They are not the same number, and only one of them
+has anything listening on it.
+
+The probe lives on the Pod template, so the fix is an edit to the
+Deployment rather than to a Pod — `spec.template.spec.containers[]`, the
+`httpGet` block. Watch the rollout finish before you judge whether it
+worked:
+
+```bash
+k -n horologium rollout status deploy/session-store
+```

--- a/banks/ckad-mock-01/q43/question.md
+++ b/banks/ckad-mock-01/q43/question.md
@@ -1,0 +1,14 @@
+Deployment `session-store` in Namespace `horologium` runs 2 replicas.
+Its container serves fine when you reach it, and the kubelet keeps
+killing it anyway — the `RESTARTS` column climbs and never stops.
+
+1. Find out why from the Pods' events and save the evidence to
+   `/opt/course/43/evidence`. The kubelet's own message about the failing
+   check must be in that file, **copied as it appears**, and so must the
+   port it names.
+2. Correct the fault. The container must still be liveness-checked by an
+   HTTP GET of `/` — do not remove the probe and do not change its
+   timings. Only the thing it is aimed at is wrong.
+
+When you are done both replicas must be ready, and the Pods that are
+running must show **0** restarts.

--- a/banks/ckad-mock-01/q43/question.md
+++ b/banks/ckad-mock-01/q43/question.md
@@ -10,5 +10,6 @@ killing it anyway — the `RESTARTS` column climbs and never stops.
    HTTP GET of `/` — do not remove the probe and do not change its
    timings. Only the thing it is aimed at is wrong.
 
-When you are done both replicas must be ready, and the Pods that are
-running must show **0** restarts.
+When you are done both replicas must be ready and must have stopped
+restarting — a freshly rolled-out replica starts at **0** and stays
+there.

--- a/banks/ckad-mock-01/q43/setup.sh
+++ b/banks/ckad-mock-01/q43/setup.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl create ns horologium --dry-run=client -o yaml | kubectl apply -f -
+
+# One fault only: the probe is aimed at 8080 and the container serves on 80.
+# The timings are deliberately unhurried — a 5s delay and two failures at 3s
+# apart — so that correcting the port alone is enough for the container to pass
+# on its first attempt and never restart again. A tighter budget here would
+# make a correct answer look wrong on a slow node.
+kubectl -n horologium apply -f - <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: session-store
+  namespace: horologium
+spec:
+  replicas: 2
+  selector:
+    matchLabels: {app: session-store}
+  template:
+    metadata:
+      labels: {app: session-store}
+    spec:
+      containers:
+        - name: store
+          image: nginx:1.29-alpine
+          ports: [{containerPort: 80}]
+          resources:
+            requests: {memory: 24Mi, cpu: 10m}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            failureThreshold: 2
+EOF
+
+# Hand the candidate a Namespace whose restart counts are already climbing,
+# rather than one that looks healthy for the first quarter minute. Bounded, and
+# never fatal: the first kill lands around 11s and the loop gives up at 45s.
+for _ in $(seq 1 15); do
+  restarts=$(kubectl -n horologium get pod -l app=session-store \
+    -o jsonpath='{.items[*].status.containerStatuses[*].restartCount}' 2>/dev/null \
+    | tr ' ' '\n' | sort -n | tail -1)
+  if [ "${restarts:-0}" -ge 1 ] 2>/dev/null; then break; fi
+  sleep 3
+done

--- a/banks/ckad-mock-01/q43/solution.md
+++ b/banks/ckad-mock-01/q43/solution.md
@@ -1,0 +1,133 @@
+# Solution 43
+
+The symptom is in the listing, and it is the `RESTARTS` column rather
+than the status:
+
+```bash
+k -n horologium get pod
+# NAME                             READY   STATUS    RESTARTS      AGE
+# session-store-6c9f8d5b7c-2xk4m   1/1     Running   4 (21s ago)   2m
+# session-store-6c9f8d5b7c-r7ptn   1/1     Running   4 (18s ago)   2m
+```
+
+`Running` and `1/1`, restarting every twenty seconds or so. The container
+is not exiting — something is stopping it. The log says nothing useful,
+because there is nothing wrong with the application:
+
+```bash
+k -n horologium logs session-store-6c9f8d5b7c-2xk4m --previous
+# ... /docker-entrypoint.sh: Configuration complete; ready for start up
+```
+
+The events name the killer:
+
+```bash
+k -n horologium describe pod -l app=session-store | tail -8
+# Events:
+#   Type     Reason     Age                 From     Message
+#   ----     ------     ----                ----     -------
+#   Warning  Unhealthy  25s (x8 over 2m)    kubelet  Liveness probe failed: Get
+#     "http://10.244.1.9:8080/": dial tcp 10.244.1.9:8080: connect: connection refused
+#   Normal   Killing    25s (x4 over 2m)    kubelet  Container store failed liveness
+#     probe, will be restarted
+```
+
+Save that while it still exists:
+
+```bash
+k -n horologium describe pod -l app=session-store > /opt/course/43/evidence
+```
+
+`connection refused` on `8080`, from the kubelet, against the Pod's own
+address. Now look at what the container actually opens:
+
+```bash
+k -n horologium get deploy session-store \
+  -o jsonpath='{.spec.template.spec.containers[*].ports[*].containerPort}'
+# 80
+```
+
+Port `80` in the container, port `8080` in the probe.
+
+## The fix
+
+The probe is part of the Pod template, so it is edited on the Deployment:
+
+```bash
+k -n horologium edit deploy session-store
+```
+
+```yaml
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80        # was 8080
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            failureThreshold: 2
+```
+
+or as a patch, which is exact and does not open an editor:
+
+```bash
+k -n horologium patch deploy session-store -p '{
+  "spec": {"template": {"spec": {"containers": [
+    {"name": "store", "livenessProbe": {"httpGet": {"path": "/", "port": 80}}}
+  ]}}}
+}'
+```
+
+Editing the template starts a rollout, so the restarts do not "stop" —
+the Pods that were accumulating them are replaced by new ones that start
+at zero:
+
+```bash
+k -n horologium rollout status deploy/session-store --timeout=180s
+k -n horologium get pod
+# NAME                             READY   STATUS    RESTARTS   AGE
+# session-store-7d4b9c6f88-4tqvz   1/1     Running   0          32s
+# session-store-7d4b9c6f88-lm6hs   1/1     Running   0          30s
+```
+
+## Deleting the probe is not fixing it
+
+It makes the restarts stop, and it is the wrong answer for a reason
+worth stating plainly: a liveness probe is what turns a wedged process
+into a restarted one without anybody being paged. Removing it leaves a
+container that Kubernetes believes is healthy for as long as its PID 1 is
+alive — which a deadlocked server, an exhausted thread pool and a process
+stuck on a lost connection all are.
+
+The check here therefore looks for a probe that is present *and* correct.
+
+## Reading a probe failure
+
+The three things the event tells you, in the order they narrow it down:
+
+| In the message | Means |
+|---|---|
+| `Liveness probe failed` | Which probe. `Readiness probe failed` never restarts anything; it removes the Pod from its Services |
+| `Get "http://10.244.1.9:8080/"` | Where it went. The IP is the **Pod's**, never a Service's — the kubelet probes the container directly on the node |
+| `connection refused` | Nothing is bound to that port. Compare with a `404`, which means something answered and the *path* is wrong, and with a timeout, which means the process is alive and stuck |
+
+Those three failures need three different fixes, and the message is what
+separates them without any guessing.
+
+## The two clocks around a liveness probe
+
+The settings that were deliberately left alone here are the ones that
+decide how forgiving the probe is:
+
+| Field | Default | What it buys |
+|---|---|---|
+| `initialDelaySeconds` | 0 | Time before the first check, for a container that boots slowly |
+| `periodSeconds` | 10 | Gap between checks |
+| `failureThreshold` | 3 | Consecutive failures before the container is killed |
+| `timeoutSeconds` | 1 | How long one check may take before it counts as failed |
+
+A liveness probe that is too aggressive is its own outage: a container
+that is merely slow to start gets killed mid-boot, restarts, is slow
+again, and never converges. `startupProbe` exists exactly for that —
+while it is running the liveness probe is suspended entirely, so a slow
+boot and a hung process can have separate budgets instead of one shared
+compromise.

--- a/banks/ckad-mock-01/q43/validate.d/10_evidence.sh
+++ b/banks/ckad-mock-01/q43/validate.d/10_evidence.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: the kubelet's probe-failure message and the port it named were captured
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+evidence() {
+  show_actual text "$(head -30 /opt/course/43/evidence 2>/dev/null)"
+  show_why "$1"
+}
+
+# Two fragments, both stable across releases: the kubelet always names the probe
+# that failed this way, and the address it dialled always carries the port. The
+# wording between and around them is not matched, because it is not the answer.
+holds() { grep -qi -- "$1" /opt/course/43/evidence 2>/dev/null; }
+
+crit 1 "the kubelet's own message about the failing check" \
+  "/opt/course/43/evidence does not contain the kubelet's probe-failure message" \
+  "A container being killed from outside leaves nothing in its log — the log ends mid-sentence and the next one starts clean. The reason is an event on the Pod, reason Unhealthy, from the kubelet, and it names which of the three probes failed. Describing the Pod prints the same events under the spec." \
+  -- holds 'liveness probe failed'
+
+crit 1 "the port the check was aimed at" \
+  "/opt/course/43/evidence does not name the port the probe was dialling" \
+  "The event quotes the URL the kubelet requested, and the address in it is the Pod's own IP with the probe's port on the end — the kubelet reaches the container directly on the node and never through a Service. That port against the one the container is declared to serve on is the whole diagnosis, so the file has to carry it." \
+  -- holds '8080'
+
+crit_all_passed || evidence "$(crit_why)"
+report "probe failure recorded"

--- a/banks/ckad-mock-01/q43/validate.d/20_probe.sh
+++ b/banks/ckad-mock-01/q43/validate.d/20_probe.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# points: 3
+# desc: the liveness probe survives and now targets the port the container serves
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+evidence() {
+  show_actual json "$(kubectl -n horologium get deploy session-store -o json 2>/dev/null \
+    | jq --arg c store '
+      if any(.spec.template.spec.containers[]; .name == $c)
+      then first(.spec.template.spec.containers[] | select(.name == $c))
+           | {name, ports, livenessProbe}
+      else {"no such container": $c,
+            "containers that exist": [.spec.template.spec.containers[].name]}
+      end')"
+  show_why "$1"
+}
+
+names=$(kubectl -n horologium get deploy session-store \
+  -o jsonpath='{.spec.template.spec.containers[*].name}' 2>/dev/null)
+has_name "$names" store || {
+  echo "the Deployment has no container named store (found: $(name_list "$names"))"
+  evidence "The container was to keep its name; only the probe's target was wrong. Renaming or replacing it answers a different question and leaves the same fault in place."
+  exit 1
+}
+
+probe=$(kubectl -n horologium get deploy session-store -o json 2>/dev/null \
+  | jq -r --arg c store 'first(.spec.template.spec.containers[] | select(.name == $c)) | .livenessProbe // empty')
+[ -n "$probe" ] || {
+  echo "the store container has no livenessProbe at all"
+  evidence "Deleting the probe does stop the restarts, and it is the wrong repair. A liveness probe is what turns a wedged process into a restarted one with nobody being paged: without it Kubernetes calls the container healthy for as long as its first process is alive, which a deadlocked server and an exhausted thread pool both are. The question asks for a probe that is present AND correct."
+  exit 1
+}
+
+port=$(printf '%s' "$probe" | jq -r '.httpGet.port // "-"')
+path=$(printf '%s' "$probe" | jq -r '.httpGet.path // "-"')
+
+crit 2 "aimed at the port the container serves on" \
+  "livenessProbe.httpGet.port is '$port', want 80" \
+  "The container declares containerPort 80 and its server listens there; the probe was dialling 8080, where nothing is bound, so every check came back refused and the kubelet restarted the container on schedule. containerPort itself opens nothing — it is documentation — but it is the honest record of where the application serves." \
+  -- [ "$port" = "80" ]
+
+crit 1 "still an HTTP GET of /" \
+  "livenessProbe.httpGet.path is '$path', want /" \
+  "The probe had one fault and it was the port. Swapping the mechanism — an exec probe, a tcpSocket probe — or moving the path changes what is being checked rather than repairing it, and an HTTP GET of / against nginx is a real answer from the server rather than a socket that merely opens." \
+  -- [ "$path" = "/" ]
+
+crit_all_passed || evidence "$(crit_why)"
+report "probe repaired"

--- a/banks/ckad-mock-01/q43/validate.d/20_probe.sh
+++ b/banks/ckad-mock-01/q43/validate.d/20_probe.sh
@@ -35,15 +35,20 @@ probe=$(kubectl -n horologium get deploy session-store -o json 2>/dev/null \
 port=$(printf '%s' "$probe" | jq -r '.httpGet.port // "-"')
 path=$(printf '%s' "$probe" | jq -r '.httpGet.path // "-"')
 
+# The seeded probe is already an HTTP GET of / — its only fault is the port — so
+# "the path is untouched" is true before the candidate arrives. What was left
+# alone counts once the thing beside it has been repaired.
+path_kept_on_a_repaired_probe() { [ "$port" = "80" ] && [ "$path" = "/" ]; }
+
 crit 2 "aimed at the port the container serves on" \
   "livenessProbe.httpGet.port is '$port', want 80" \
   "The container declares containerPort 80 and its server listens there; the probe was dialling 8080, where nothing is bound, so every check came back refused and the kubelet restarted the container on schedule. containerPort itself opens nothing — it is documentation — but it is the honest record of where the application serves." \
   -- [ "$port" = "80" ]
 
-crit 1 "still an HTTP GET of /" \
-  "livenessProbe.httpGet.path is '$path', want /" \
-  "The probe had one fault and it was the port. Swapping the mechanism — an exec probe, a tcpSocket probe — or moving the path changes what is being checked rather than repairing it, and an HTTP GET of / against nginx is a real answer from the server rather than a socket that merely opens." \
-  -- [ "$path" = "/" ]
+crit 1 "still an HTTP GET of / on the repaired probe" \
+  "livenessProbe.httpGet.path is '$path' and .port is '$port'; the path must still be / on a probe whose port has been corrected to 80" \
+  "The probe had one fault and it was the port. Swapping the mechanism — an exec probe, a tcpSocket probe — or moving the path changes what is being checked rather than repairing it, and an HTTP GET of / against nginx is a real answer from the server rather than a socket that merely opens. The path was already / when you arrived, so leaving it there is not the answer on its own: it counts once the port beside it is right." \
+  -- path_kept_on_a_repaired_probe
 
 crit_all_passed || evidence "$(crit_why)"
 report "probe repaired"

--- a/banks/ckad-mock-01/q43/validate.d/30_settled.sh
+++ b/banks/ckad-mock-01/q43/validate.d/30_settled.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: the rollout finished and the Pods now serving have stopped restarting
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+# Restarts do not "stop" — the Pods carrying them are replaced. So this counts
+# only the Pods that already have the corrected probe, which is exactly the set
+# the new ReplicaSet owns. Anything still draining from the old one is excluded
+# rather than waited for, because a check has thirty seconds and no right to
+# spend them sleeping.
+repaired=$(kubectl -n horologium get pod -l app=session-store -o json 2>/dev/null | jq '
+  [.items[]
+   | select(.metadata.deletionTimestamp == null)
+   | select(any(.spec.containers[];
+       .name == "store" and (.livenessProbe.httpGet.port == 80 or .livenessProbe.httpGet.port == "80")))]')
+live=$(printf '%s' "$repaired" | jq 'length // 0')
+worst=$(printf '%s' "$repaired" | jq '[.[] | .status.containerStatuses[]? | .restartCount] | max // 0')
+
+ready=$(kubectl -n horologium get deploy session-store -o jsonpath='{.status.readyReplicas}' 2>/dev/null)
+want=$(kubectl -n horologium get deploy session-store -o jsonpath='{.spec.replicas}' 2>/dev/null)
+[ -n "$ready" ] || ready=0
+[ -n "$want" ] || want=0
+
+list_pane() {
+  show_actual text "$(kubectl -n horologium get pod -l app=session-store 2>/dev/null)"
+  show_why "$1"
+}
+detail_pane() {
+  show_actual json "$(printf '%s' "$repaired" | jq '[.[] | {name: .metadata.name,
+    phase: .status.phase,
+    restarts: [.status.containerStatuses[]? | .restartCount],
+    lastState: [.status.containerStatuses[]? | .lastState]}]')"
+  show_why "$1"
+}
+pane=''
+
+rolled_out() { [ "$want" = "2" ] && [ "$ready" = "2" ]; }
+quiet() { [ "${live:-0}" -ge 2 ] && [ "${worst:-1}" = "0" ]; }
+
+crit 1 "both replicas are ready" \
+  "${ready}/${want} replicas are ready" \
+  "A Pod being killed by its liveness probe still reports Ready between kills, so readiness alone was never the symptom here — the replica count is the other half of the pair. If this is short, the rollout has not finished or the new Pods are failing for a second reason." \
+  -- rolled_out || pane=${pane:-list_pane}
+
+crit 1 "the Pods now serving show no restarts" \
+  "${live} Pod(s) carry the corrected probe and the worst restart count among them is ${worst}, want 0" \
+  "Editing the Pod template starts a rollout, so the Pods whose restart counts were climbing are deleted rather than repaired, and their replacements begin at zero. A replacement that is itself restarting means the probe still cannot reach the container: read the new Pods' events the same way, since the address in the message is the fastest way to see what it is dialling now." \
+  -- quiet || pane=${pane:-detail_pane}
+
+crit_all_passed || "${pane:-list_pane}" "$(crit_why)"
+report "restarts stopped"

--- a/banks/ckad-mock-01/q43/validate.d/30_settled.sh
+++ b/banks/ckad-mock-01/q43/validate.d/30_settled.sh
@@ -35,12 +35,16 @@ detail_pane() {
 }
 pane=''
 
-rolled_out() { [ "$want" = "2" ] && [ "$ready" = "2" ]; }
+# A Pod being killed by liveness reports Ready between kills, so the seeded
+# Deployment is already 2/2 and a bare readiness count is true of a Namespace
+# nobody has touched. Both replicas being ready means something once the two
+# that are ready are the ones carrying the corrected probe.
+rolled_out() { [ "$want" = "2" ] && [ "$ready" = "2" ] && [ "${live:-0}" -ge 2 ]; }
 quiet() { [ "${live:-0}" -ge 2 ] && [ "${worst:-1}" = "0" ]; }
 
-crit 1 "both replicas are ready" \
-  "${ready}/${want} replicas are ready" \
-  "A Pod being killed by its liveness probe still reports Ready between kills, so readiness alone was never the symptom here — the replica count is the other half of the pair. If this is short, the rollout has not finished or the new Pods are failing for a second reason." \
+crit 1 "both replicas are ready on the corrected probe" \
+  "${ready}/${want} replicas are ready and ${live} Pod(s) carry the corrected probe, want 2 of each" \
+  "A Pod being killed by its liveness probe still reports Ready between kills, so readiness alone was never the symptom here and it was already 2/2 before you started — the replica count is only half of the pair, and the Pods being counted have to be the repaired ones. If this is short, the rollout has not finished or the new Pods are failing for a second reason." \
   -- rolled_out || pane=${pane:-list_pane}
 
 crit 1 "the Pods now serving show no restarts" \

--- a/banks/ckad-mock-01/q43/validate.d/30_settled.sh
+++ b/banks/ckad-mock-01/q43/validate.d/30_settled.sh
@@ -15,12 +15,41 @@ repaired=$(kubectl -n horologium get pod -l app=session-store -o json 2>/dev/nul
    | select(any(.spec.containers[];
        .name == "store" and (.livenessProbe.httpGet.port == 80 or .livenessProbe.httpGet.port == "80")))]')
 live=$(printf '%s' "$repaired" | jq 'length // 0')
-worst=$(printf '%s' "$repaired" | jq '[.[] | .status.containerStatuses[]? | .restartCount] | max // 0')
+
+# A restart count is not the signal it looks like: stopping and starting the
+# whole stack restarts every container in the cluster once, and a candidate who
+# repaired this probe an hour ago must not lose the points for it. What the
+# seeded fault actually looks like is a container that never gets to run: the
+# broken probe starts checking at five seconds and kills on its second failure
+# three seconds later, so a container it is still failing never runs for more
+# than about eleven seconds at a stretch, over and over. QUIET_FOR is nearly
+# three times that, and no wait is involved — a Pod either already has a long
+# run behind it or it does not.
+QUIET_FOR=30
+churning=$(printf '%s' "$repaired" | jq -r --argjson quiet "$QUIET_FOR" '
+  [ .[]
+    | {name: .metadata.name, cs: (.status.containerStatuses[]? | select(.name == "store"))}
+    | {name,
+       restarts: (.cs.restartCount // 0),
+       run: ([ (.cs.state.running.startedAt // empty | now - fromdateiso8601)?,
+               (.cs.lastState.terminated // empty
+                | select(.startedAt != null and .finishedAt != null)
+                | (.finishedAt | fromdateiso8601) - (.startedAt | fromdateiso8601))? ]
+              | max // 0 | floor)}
+    | select(.restarts > 0 and .run < $quiet)
+    | "\(.name) (\(.restarts) restart(s), longest run \(.run)s)" ]
+  | join(", ")')
 
 ready=$(kubectl -n horologium get deploy session-store -o jsonpath='{.status.readyReplicas}' 2>/dev/null)
 want=$(kubectl -n horologium get deploy session-store -o jsonpath='{.spec.replicas}' 2>/dev/null)
 [ -n "$ready" ] || ready=0
 [ -n "$want" ] || want=0
+
+if [ -n "$churning" ]; then
+  churn_msg="Pod(s) carrying the corrected probe are still being restarted: ${churning}"
+else
+  churn_msg="${live} Pod(s) carry the corrected probe, want 2"
+fi
 
 list_pane() {
   show_actual text "$(kubectl -n horologium get pod -l app=session-store 2>/dev/null)"
@@ -30,6 +59,7 @@ detail_pane() {
   show_actual json "$(printf '%s' "$repaired" | jq '[.[] | {name: .metadata.name,
     phase: .status.phase,
     restarts: [.status.containerStatuses[]? | .restartCount],
+    state: [.status.containerStatuses[]? | .state],
     lastState: [.status.containerStatuses[]? | .lastState]}]')"
   show_why "$1"
 }
@@ -40,16 +70,16 @@ pane=''
 # nobody has touched. Both replicas being ready means something once the two
 # that are ready are the ones carrying the corrected probe.
 rolled_out() { [ "$want" = "2" ] && [ "$ready" = "2" ] && [ "${live:-0}" -ge 2 ]; }
-quiet() { [ "${live:-0}" -ge 2 ] && [ "${worst:-1}" = "0" ]; }
+quiet() { [ "${live:-0}" -ge 2 ] && [ -z "$churning" ]; }
 
 crit 1 "both replicas are ready on the corrected probe" \
   "${ready}/${want} replicas are ready and ${live} Pod(s) carry the corrected probe, want 2 of each" \
   "A Pod being killed by its liveness probe still reports Ready between kills, so readiness alone was never the symptom here and it was already 2/2 before you started — the replica count is only half of the pair, and the Pods being counted have to be the repaired ones. If this is short, the rollout has not finished or the new Pods are failing for a second reason." \
   -- rolled_out || pane=${pane:-list_pane}
 
-crit 1 "the Pods now serving show no restarts" \
-  "${live} Pod(s) carry the corrected probe and the worst restart count among them is ${worst}, want 0" \
-  "Editing the Pod template starts a rollout, so the Pods whose restart counts were climbing are deleted rather than repaired, and their replacements begin at zero. A replacement that is itself restarting means the probe still cannot reach the container: read the new Pods' events the same way, since the address in the message is the fastest way to see what it is dialling now." \
+crit 1 "the Pods now serving are out of the restart loop" \
+  "${churn_msg}" \
+  "Editing the Pod template starts a rollout, so the Pods whose restart counts were climbing are deleted rather than repaired and their replacements begin at zero. This criterion does not demand that zero, because a restart count no longer tells a kill from a reboot: stopping and starting the whole environment restarts every container in the cluster once, through nobody's fault. What it asks instead is that no Pod carrying the corrected probe is still in the loop the broken one was in — that it has either never been restarted, or has a run behind it, the one it is in now or the one before it, longer than this probe would ever have allowed. A replacement that IS still being killed cannot have one: the probe cuts every run short at about eleven seconds. That also means this proves the probe is no longer failing, not that the container has never been restarted, and it cannot see a Pod that has only just been created either — nothing has had time to happen to it yet." \
   -- quiet || pane=${pane:-detail_pane}
 
 crit_all_passed || "${pane:-list_pane}" "$(crit_why)"

--- a/banks/ckad-mock-01/q44/hints.md
+++ b/banks/ckad-mock-01/q44/hints.md
@@ -1,0 +1,27 @@
+## Hint 1
+
+A Job that has finished — either way — records that as a condition on its
+status, and the condition carries a machine-readable reason as well as a
+sentence. `kubectl describe` prints it; `-o jsonpath` gets you the one
+word on its own.
+
+The Pods it left behind are still there, in a terminal phase rather than
+deleted. That is where the container's output is, and a label selector
+reaches all of them at once without you naming any.
+
+## Hint 2
+
+Almost nothing in a Job's spec can be edited after it exists — the
+completion count and the whole Pod template are rejected — so step 3
+means deleting and creating, not patching.
+
+Four fields carry the requirements: two of them are siblings of each
+other under `spec` and describe how much work there is and how much runs
+concurrently; the third caps failures; the fourth is a wall clock over
+the entire Job and lives beside them rather than inside the template.
+
+The last requirement is about the Pod, not the Job: `restartPolicy` on
+`spec.template.spec`, and the value that keeps the same Pod and restarts
+its container.
+
+`kubectl explain job.spec` lists all of them with their defaults.

--- a/banks/ckad-mock-01/q44/question.md
+++ b/banks/ckad-mock-01/q44/question.md
@@ -1,0 +1,25 @@
+Job `ledger-reconcile` in Namespace `eridanus` has stopped trying. It
+never produced a single successful Pod, and it is not going to start
+again on its own.
+
+1. Ask the Job why it gave up and write the **reason** it reports —
+   that one word, nothing else — to `/opt/course/44/reason`.
+2. Save the output the container itself printed before it died to
+   `/opt/course/44/failure.log`. The message explaining the failure must
+   be in that file.
+3. Then replace the Job with one that works. Keep the name
+   `ledger-reconcile`, the Namespace, the container name `reconcile` and
+   the image `busybox:1.37`, and give the container the command
+   `sh -c "echo reconciled"`. The new Job must:
+
+   - run **4 completions**, at most **2 at a time**
+   - allow up to **4** failed Pods before giving up
+   - abandon the whole run after **120 seconds**, however many attempts
+     are left
+   - restart a failed container in place rather than replacing its Pod
+
+Wait for it to finish. When you are done the Job must report **4**
+successful Pods.
+
+Steps 1 and 2 have to come first: removing the Job removes its Pods, and
+their output with them.

--- a/banks/ckad-mock-01/q44/setup.sh
+++ b/banks/ckad-mock-01/q44/setup.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl create ns eridanus --dry-run=client -o yaml | kubectl apply -f -
+
+# The Job can never succeed, and backoffLimit decides how long it keeps trying:
+# 2 retries on top of the first attempt is three Pods, each left behind in
+# Failed because restartPolicy is Never. It reaches its terminal Failed
+# condition in well under a minute and then never changes again, which is what
+# makes it safe to grade.
+#
+# Almost everything in a Job's spec is immutable, so a re-seed cannot apply its
+# way back over a rewritten one: the object has to go first.
+kubectl -n eridanus delete job ledger-reconcile \
+  --ignore-not-found --wait=true --timeout=90s
+
+kubectl -n eridanus apply -f - <<'EOF'
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ledger-reconcile
+  namespace: eridanus
+spec:
+  backoffLimit: 2
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: reconcile
+          image: busybox:1.37
+          command: ["sh", "-c", "echo 'reconcile aborted: ledger checksum mismatch'; exit 1"]
+          resources:
+            requests: {memory: 16Mi, cpu: 10m}
+EOF
+
+# Hand the candidate a Job that has already given up rather than one still
+# counting. Bounded at 60s and never fatal: the third Pod normally fails around
+# the 35 second mark, and if this cluster is slower the Job reaches the same
+# state a few seconds into the attempt instead.
+for _ in $(seq 1 20); do
+  state=$(kubectl -n eridanus get job ledger-reconcile \
+    -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null)
+  if [ "${state:-}" = "True" ]; then break; fi
+  sleep 3
+done

--- a/banks/ckad-mock-01/q44/solution.md
+++ b/banks/ckad-mock-01/q44/solution.md
@@ -1,0 +1,140 @@
+# Solution 44
+
+The listing says it is over, and the Pods say how it got there:
+
+```bash
+k -n eridanus get job
+# NAME               STATUS   COMPLETIONS   DURATION   AGE
+# ledger-reconcile   Failed   0/1           38s        4m
+
+k -n eridanus get pod
+# NAME                     READY   STATUS   RESTARTS   AGE
+# ledger-reconcile-8bqzv   0/1     Error    0          4m
+# ledger-reconcile-nk4tp   0/1     Error    0          3m
+# ledger-reconcile-wr2c9   0/1     Error    0          3m
+```
+
+Three Pods, all `Error`, none of them restarted. That combination is the
+signature of `restartPolicy: Never`: a failed container is never retried
+inside its Pod, so each attempt is a whole new Pod and the dead ones stay
+where they are.
+
+## The reason
+
+```bash
+k -n eridanus describe job ledger-reconcile | grep -A3 Conditions
+# Conditions:
+#   Type    Status  Reason
+#   ----    ------  ------
+#   Failed  True    BackoffLimitExceeded
+```
+
+```bash
+k -n eridanus get job ledger-reconcile \
+  -o jsonpath='{.status.conditions[?(@.type=="Failed")].reason}' \
+  > /opt/course/44/reason
+cat /opt/course/44/reason
+# BackoffLimitExceeded
+```
+
+## The container's own words
+
+The Pods are still there, so their logs are still readable. Select them
+all at once rather than naming one:
+
+```bash
+k -n eridanus logs -l batch.kubernetes.io/job-name=ledger-reconcile --tail=-1 \
+  > /opt/course/44/failure.log
+cat /opt/course/44/failure.log
+# reconcile aborted: ledger checksum mismatch
+# reconcile aborted: ledger checksum mismatch
+# reconcile aborted: ledger checksum mismatch
+```
+
+`--tail=-1` is worth knowing: with a selector, `kubectl logs` tails only
+the last 10 lines per Pod by default, and silently.
+
+`kubectl logs job/ledger-reconcile` also works and picks one of the Pods.
+
+## Replacing it
+
+`spec.completions`, `spec.template` and `spec.backoffLimit` are all
+immutable, so an edit gets you a wall of `field is immutable`. Delete and
+create:
+
+```bash
+k -n eridanus delete job ledger-reconcile
+
+k -n eridanus apply -f - <<'EOF'
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ledger-reconcile
+  namespace: eridanus
+spec:
+  completions: 4
+  parallelism: 2
+  backoffLimit: 4
+  activeDeadlineSeconds: 120
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: reconcile
+          image: busybox:1.37
+          command: ["sh", "-c", "echo reconciled"]
+EOF
+
+k -n eridanus wait --for=condition=Complete job/ledger-reconcile --timeout=180s
+k -n eridanus get job ledger-reconcile
+# NAME               STATUS     COMPLETIONS   DURATION   AGE
+# ledger-reconcile   Complete   4/4           9s         12s
+```
+
+Deleting the Job takes its Pods with it, which is why the log had to be
+saved first.
+
+## The four fields, and what each one actually stops
+
+| Field | Default | Counts |
+|---|---|---|
+| `completions` | 1 | How many Pods must **succeed** before the Job is done |
+| `parallelism` | 1 | How many Pods may be running at once |
+| `backoffLimit` | 6 | How many **failures** are tolerated before the Job is failed |
+| `activeDeadlineSeconds` | none | Wall-clock seconds from the Job starting |
+
+`backoffLimit` is a count of failures, not of attempts, and the Job stops
+when that count is *exceeded* — so a limit of 2 produces three failed
+Pods, which is exactly what was sitting in this Namespace. Between
+attempts the controller waits 10s, then 20s, then 40s, doubling to a
+six-minute cap, which is why a Job that cannot succeed takes minutes to
+admit it rather than seconds.
+
+`activeDeadlineSeconds` is the other kind of give-up, and it **outranks**
+`backoffLimit`: when the deadline passes, every running Pod is
+terminated and the Job is failed with reason `DeadlineExceeded` however
+many retries were still available. It is the field for work that is
+worthless once it is late — a nightly reconciliation that must not still
+be going when the morning batch starts.
+
+## Never versus OnFailure
+
+`restartPolicy` on a Job's Pod template takes only those two values;
+`Always` is rejected, because a Pod that always restarts can never
+complete.
+
+| Value | On a failed container |
+|---|---|
+| `Never` | The Pod goes to `Failed` and stays. The Job creates a **new Pod** for the next attempt |
+| `OnFailure` | The **same Pod** restarts the container in place, and its `RESTARTS` column climbs |
+
+`Never` leaves you one Pod per attempt to read afterwards, which is the
+better default when you expect to be debugging — it is why the failed
+Job here still had three sets of logs to show. `OnFailure` is cheaper: no
+new Pod, no rescheduling, no image lookup. The cost is that each restart
+overwrites what the last container was doing, so `--previous` reaches
+back exactly one attempt and no further.
+
+Under `OnFailure`, container restarts also count towards `backoffLimit`
+just as replaced Pods do — the limit is about failures, not about how the
+failure was retried.

--- a/banks/ckad-mock-01/q44/validate.d/10_reason.sh
+++ b/banks/ckad-mock-01/q44/validate.d/10_reason.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# points: 2
+# desc: the reason the original Job reported for giving up was recorded
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+got=$(file_text /opt/course/44/reason)
+lower=$(printf '%s' "$got" | tr '[:upper:]' '[:lower:]')
+[ "$lower" = "backofflimitexceeded" ] && { echo "reason recorded"; exit 0; }
+
+echo "/opt/course/44/reason contains '$got', want BackoffLimitExceeded"
+show_actual text "$(cat /opt/course/44/reason 2>/dev/null)"
+show_why "A finished Job records how it finished as a condition on its status, and the condition carries a short machine-readable reason beside the human sentence. BackoffLimitExceeded means the Job ran out of tolerated failures; DeadlineExceeded would mean activeDeadlineSeconds expired first, and the two are different problems with different fixes. The file wants that single word — not the condition type, not the message, and not the whole block."
+exit 1

--- a/banks/ckad-mock-01/q44/validate.d/20_failure-log.sh
+++ b/banks/ckad-mock-01/q44/validate.d/20_failure-log.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# points: 1
+# desc: the failing container's own output was captured before the Job was removed
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+grep -q 'ledger checksum mismatch' /opt/course/44/failure.log 2>/dev/null \
+  && { echo "failure log captured"; exit 0; }
+
+echo "/opt/course/44/failure.log does not contain the container's failure message"
+show_actual text "$(head -20 /opt/course/44/failure.log 2>/dev/null)"
+show_why "The Job's Pods were left behind in a terminal phase rather than deleted, so their logs were still readable — a Job with restartPolicy Never creates a fresh Pod per attempt and keeps every one of them. A label selector reads all of them at once, and with a selector kubectl prints only the last ten lines per Pod unless asked for more. Once the Job is deleted its Pods go with it, which is why this had to be saved before the rewrite."
+exit 1

--- a/banks/ckad-mock-01/q44/validate.d/30_job-spec.sh
+++ b/banks/ckad-mock-01/q44/validate.d/30_job-spec.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# points: 3
+# desc: the rewritten Job carries the completion, concurrency and give-up settings
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+spec=$(kubectl -n eridanus get job ledger-reconcile -o json 2>/dev/null | jq '.spec')
+[ -n "$spec" ] && [ "$spec" != "null" ] || {
+  echo "there is no Job ledger-reconcile in eridanus"
+  show_actual text "$(kubectl -n eridanus get job 2>/dev/null; echo; kubectl -n eridanus get pod 2>/dev/null)"
+  show_why "The rewrite keeps the original name. Deleting the broken Job is the first half of it — almost every field the question asks for is immutable once a Job exists, so there is no editing your way from one to the other — but the Namespace has to end up with a Job under that name again."
+  exit 1
+}
+
+evidence() {
+  show_actual json "$(printf '%s' "$spec" | jq '{completions, parallelism, backoffLimit,
+    activeDeadlineSeconds,
+    restartPolicy: .template.spec.restartPolicy,
+    containers: [.template.spec.containers[] | {name, image, command}]}')"
+  show_why "$1"
+}
+
+field() { printf '%s' "$spec" | jq -r "$1 // \"-\""; }
+
+completions=$(field '.completions')
+parallelism=$(field '.parallelism')
+backoff=$(field '.backoffLimit')
+deadline=$(field '.activeDeadlineSeconds')
+policy=$(field '.template.spec.restartPolicy')
+names=$(printf '%s' "$spec" | jq -r '[.template.spec.containers[].name] | join(" ")')
+img=$(printf '%s' "$spec" | jq -r 'first(.template.spec.containers[] | select(.name == "reconcile") | .image) // "-"')
+
+crit 1 "4 completions" \
+  "completions is '$completions', want 4" \
+  "completions is how many Pods must SUCCEED before the Job is finished, and it defaults to 1. It is not a count of attempts: failures do not consume it, they consume backoffLimit." \
+  -- [ "$completions" = "4" ]
+
+crit 1 "2 at a time" \
+  "parallelism is '$parallelism', want 2" \
+  "parallelism caps how many Pods may exist at once, and defaults to 1 — which turns a multi-completion Job into a strictly serial one. Set above completions it is simply clamped down to what is left to do." \
+  -- [ "$parallelism" = "2" ]
+
+crit 1 "gives up after 4 failures" \
+  "backoffLimit is '$backoff', want 4" \
+  "backoffLimit counts failed Pods, not attempts remaining, and the Job fails once that count is EXCEEDED — which is why the broken Job here, at a limit of 2, left three dead Pods behind. Its default is 6." \
+  -- [ "$backoff" = "4" ]
+
+crit 1 "abandons the whole thing after 120 seconds" \
+  "activeDeadlineSeconds is '$deadline', want 120" \
+  "activeDeadlineSeconds is a wall clock over the entire Job rather than over one Pod, and it OUTRANKS backoffLimit: when it expires every live Pod is terminated and the Job is failed with reason DeadlineExceeded, however many retries were still owed. It belongs beside completions under spec — there is a field of the same name on the Pod template with a narrower meaning, which is the usual place to put it by mistake." \
+  -- [ "$deadline" = "120" ]
+
+crit 1 "restarts the container in place" \
+  "restartPolicy is '$policy', want OnFailure" \
+  "A Job's Pod template takes only Never or OnFailure; Always is rejected outright, because a Pod that always restarts can never be counted as complete. OnFailure keeps the same Pod and restarts its container, so the restart count climbs and no new Pod is scheduled. Never is the opposite bargain and is what the broken Job used: one Pod per attempt, all of them left behind to read." \
+  -- [ "$policy" = "OnFailure" ]
+
+crit 1 "still the container and image it had" \
+  "the container list is '$(name_list "$names")' with reconcile on image '$img', want one named reconcile on busybox:1.37" \
+  "The rewrite was to change the Job's settings, not the work it does. The container is looked up by name, so an empty image here means it was renamed rather than that the image is missing." \
+  -- [ "$img" = "busybox:1.37" ]
+
+crit_all_passed || evidence "$(crit_why)"
+report "job spec ok"

--- a/banks/ckad-mock-01/q44/validate.d/30_job-spec.sh
+++ b/banks/ckad-mock-01/q44/validate.d/30_job-spec.sh
@@ -55,10 +55,21 @@ crit 1 "restarts the container in place" \
   "A Job's Pod template takes only Never or OnFailure; Always is rejected outright, because a Pod that always restarts can never be counted as complete. OnFailure keeps the same Pod and restarts its container, so the restart count climbs and no new Pod is scheduled. Never is the opposite bargain and is what the broken Job used: one Pod per attempt, all of them left behind to read." \
   -- [ "$policy" = "OnFailure" ]
 
-crit 1 "still the container and image it had" \
-  "the container list is '$(name_list "$names")' with reconcile on image '$img', want one named reconcile on busybox:1.37" \
-  "The rewrite was to change the Job's settings, not the work it does. The container is looked up by name, so an empty image here means it was renamed rather than that the image is missing." \
-  -- [ "$img" = "busybox:1.37" ]
+# The Job that gave up already runs a container named reconcile on busybox:1.37
+# — the rewrite was never meant to change either — so "it still does" is true of
+# an untouched Namespace. What survived the rewrite counts once there has been a
+# rewrite: at least one of the settings above has to have landed, or the Job
+# sitting there is still the one that failed.
+rewritten() {
+  [ "$completions" = "4" ] || [ "$parallelism" = "2" ] || [ "$backoff" = "4" ] \
+    || [ "$deadline" = "120" ] || [ "$policy" = "OnFailure" ]
+}
+survived_the_rewrite() { rewritten && [ "$img" = "busybox:1.37" ]; }
+
+crit 1 "rewritten, and still the container and image it had" \
+  "the container list is '$(name_list "$names")' with reconcile on image '$img', want one named reconcile on busybox:1.37 in a Job that carries at least one of the settings above" \
+  "The rewrite was to change the Job's settings, not the work it does. The container is looked up by name, so an empty image here means it was renamed rather than that the image is missing. Keeping them is not work on its own — the Job that gave up already has them — so this counts once something about the Job has actually changed." \
+  -- survived_the_rewrite
 
 crit_all_passed || evidence "$(crit_why)"
 report "job spec ok"

--- a/banks/ckad-mock-01/q44/validate.d/40_complete.sh
+++ b/banks/ckad-mock-01/q44/validate.d/40_complete.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# points: 1
+# desc: the rewritten Job reached 4 successful Pods and reports Complete
+set -uo pipefail
+. /banks/_lib/checks.sh
+
+status=$(kubectl -n eridanus get job ledger-reconcile -o json 2>/dev/null | jq '.status')
+[ -n "$status" ] && [ "$status" != "null" ] || {
+  echo "there is no Job ledger-reconcile in eridanus to have completed"
+  show_actual text "$(kubectl -n eridanus get job 2>/dev/null)"
+  show_why "The Job that had given up was to be replaced by one under the same name that finishes. Nothing is there under that name now."
+  exit 1
+}
+
+succeeded=$(printf '%s' "$status" | jq -r '.succeeded // 0')
+complete=$(printf '%s' "$status" | jq -r 'first(.conditions[]? | select(.type == "Complete") | .status) // "-"')
+
+[ "$succeeded" = "4" ] && [ "$complete" = "True" ] && { echo "job complete"; exit 0; }
+
+echo "the Job reports $succeeded successful Pods and Complete='$complete', want 4 and True"
+show_actual json "$(printf '%s' "$status" | jq '{succeeded, failed, active,
+  conditions: [.conditions[]? | {type, status, reason}]}')"
+show_why "status.succeeded counts Pods that exited zero, and a Job is marked Complete only once that number reaches spec.completions. A Job still counting means this was graded before it finished; a Job with a Failed condition instead means the work itself is still exiting non-zero, or that activeDeadlineSeconds ran out before the last completion landed."
+exit 1

--- a/docs/api.md
+++ b/docs/api.md
@@ -766,7 +766,7 @@ weighting existed. Both floor rather than round.
 
 Weighting happens at scoring time rather than being baked into a bank's
 point budget, because **a bank's points are fixed and a draw is not**.
-`tests/bank-weights.sh` can promise ckad-mock-01's 180 points sit in the
+`tests/bank-weights.sh` can promise ckad-mock-01's 217 points sit in the
 curriculum's ratios, but not that a filtered or partial draw out of it
 does.
 
@@ -1298,7 +1298,7 @@ The exam catalog the exam selector renders. Always 200.
 {
   "active": "ckad-mock-01",
   "banks": [
-    {"id": "ckad-mock-01", "title": "CKAD Mock Exam 01", "certification": "CKAD", "description": "Developer-track exercises...", "examType": "hands-on", "durationSeconds": 7200, "passingScore": 66, "kubernetesVersion": "1.35", "questionCount": 22, "poolCount": 26, "available": true},
+    {"id": "ckad-mock-01", "title": "CKAD Mock Exam", "certification": "CKAD", "description": "Developer-track exercises...", "examType": "hands-on", "durationSeconds": 7200, "passingScore": 66, "kubernetesVersion": "1.35", "questionCount": 17, "poolCount": 26, "available": true},
     {"id": "kcna-mock", "title": "KCNA Mock Exam", "certification": "KCNA", "description": "65 questions drawn each attempt...", "examType": "mcq", "durationSeconds": 5400, "passingScore": 75, "questionCount": 65, "poolCount": 97, "available": true},
     {"id": "cks-mock", "title": "CKS Mock Exam", "certification": "CKS", "examType": "hands-on", "available": false, "comingSoon": true, "note": "Requires security add-ons not in the kind environment yet"}
   ]
@@ -1311,7 +1311,7 @@ The exam catalog the exam selector renders. Always 200.
 | `poolCount` | How many the bank authors |
 
 - They differ only for a pooled bank, and the exam card prints them as a
-  pair (`65 / 97`) only when they do. A card reading `22 / 22` would
+  pair (`65 / 97`) only when they do. A card reading `26 / 26` would
   advertise a pool that is not one.
 - The facilitator knows both for the *active* bank, but the catalog is
   the only place that knows them for the others — and the exam selector

--- a/docs/api.md
+++ b/docs/api.md
@@ -146,7 +146,7 @@ fields.
   "state": "booting",
   "phase": "seed",
   "label": "Setting up the exam questions",
-  "detail": "question 11 of 22",
+  "detail": "question 11 of 17",
   "error": "",
   "step": 7,
   "totalSteps": 8,
@@ -170,14 +170,15 @@ and the three selectable modes. Always 200.
 ```json
 {
   "name": "ckad-mock-01",
-  "title": "CKAD Mock Exam 01",
+  "title": "CKAD Mock Exam",
   "certification": "CKAD",
   "examType": "hands-on",
   "durationSeconds": 7200,
   "passingScore": 66,
   "kubernetesVersion": "1.35",
-  "questionCount": 22,
+  "questionCount": 17,
   "hasTips": true,
+  "levelMixed": true,
   "questions": [
     {"id": "q01", "instance": "instance-1", "domain": "Application Environment, Configuration and Security", "weight": 9, "totalPoints": 9, "hintCount": 2, "targetSeconds": 360, "targetDerived": true}
   ],
@@ -218,7 +219,7 @@ user-facing copy and lives in `ui/src/strings.ts`; its permissions are
 facts only the server knows.
 
 `certification` names the exam this bank rehearses ("CKAD"), where
-`title` names the bank ("CKAD Mock Exam 01"). Omitted when the bank
+`title` names the bank ("CKAD Mock Exam"). Omitted when the bank
 declares none. The mode screen and its header read it from here rather
 than from the conductor's catalog, so a deep link into that screen
 needs no prior call to `GET /api/control/banks`.
@@ -275,6 +276,12 @@ if they were the whole curriculum. `questionCount` is the exam's declared
 length — `spec.examLength` for a pooled bank, otherwise the pool size —
 and is what any display of "how many questions" must read, since
 `questions` still lists the whole pool before an attempt has drawn.
+
+`levelMixed` says the bank declares a `spec.difficultyMix`, so its draw is
+stratified by level as well as by domain. It is a property of the bank, not
+of the attempt, and the per-question tier is deliberately not here — see
+[GET /api/results](#get-apiresults), which carries it once the attempt is
+over.
 
 `hasTips` says the bank ships a `tips.md`, i.e. that
 [`GET /api/exam/tips`](#get-apiexamtips) has something to serve. Omitted
@@ -735,6 +742,7 @@ The graded scoreboard for the ended attempt.
       "id": "q01",
       "instance": "instance-1",
       "domain": "Application Environment, Configuration and Security",
+      "difficulty": "core",
       "earned": 3,
       "total": 9,
       "weightPct": 5,
@@ -749,12 +757,28 @@ The graded scoreboard for the ended attempt.
   ],
   "domains": [
     {"domain": "Application Environment, Configuration and Security", "earned": 30, "total": 45, "weightPct": 25, "questionCount": 5}
+  ],
+  "levels": [
+    {"level": "quick", "earned": 18, "total": 18, "questionCount": 2},
+    {"level": "core", "earned": 45, "total": 45, "questionCount": 5},
+    {"level": "deep", "earned": 0, "total": 27, "questionCount": 3}
   ]
 }
 ```
 
 Abridged: `questions` carries every question the attempt was graded on
 and `checks` every check in each. `passed` is `percent >= passingScore`.
+
+`levels` is the same score cut by `spec.questions[].difficulty`, and
+`questions[].difficulty` is the per-question tier. **Both appear only
+here** — the tier is deliberately absent from `GET /api/exam` during an
+attempt, where it would only tell a candidate to brace. A bank that
+declares no tiers, which is every mcq bank, omits both fields entirely.
+
+The rows stay in tier order — `quick`, `core`, `deep` — rather than being
+sorted by score, because what the candidate is meant to read is the shape:
+a score that holds on short tasks and falls away on long ones is a pacing
+problem, and a flat low score is a knowledge problem.
 
 ### Weighting and the two percentages
 
@@ -967,7 +991,7 @@ Every attempt, most recent first, plus the cross-exam summary. Always
       "id": "9f2c41ab30de5517",
       "bank": "ckad-mock-01",
       "certification": "CKAD",
-      "examTitle": "CKAD Mock Exam 01",
+      "examTitle": "CKAD Mock Exam",
       "examType": "hands-on",
       "mode": "exam",
       "startedAt": "2026-07-30T09:20:11Z",
@@ -975,7 +999,7 @@ Every attempt, most recent first, plus the cross-exam summary. Always
       "seed": "a1b2c3",
       "durationSeconds": 7200,
       "elapsedSeconds": 7233,
-      "questionCount": 22,
+      "questionCount": 17,
       "earned": 41,
       "total": 60,
       "percent": 68,
@@ -1085,13 +1109,13 @@ history still has a bank list).
   "exams": [
     {
       "id": "ckad-mock-01",
-      "title": "CKAD Mock Exam 01",
+      "title": "CKAD Mock Exam",
       "certification": "CKAD",
       "examType": "hands-on",
       "durationSeconds": 7200,
       "passingScore": 66,
-      "questionCount": 22,
-      "poolCount": 26,
+      "questionCount": 17,
+      "poolCount": 44,
       "available": true,
       "progress": {
         "attempts": 3,
@@ -1298,7 +1322,7 @@ The exam catalog the exam selector renders. Always 200.
 {
   "active": "ckad-mock-01",
   "banks": [
-    {"id": "ckad-mock-01", "title": "CKAD Mock Exam", "certification": "CKAD", "description": "Developer-track exercises...", "examType": "hands-on", "durationSeconds": 7200, "passingScore": 66, "kubernetesVersion": "1.35", "questionCount": 17, "poolCount": 26, "available": true},
+    {"id": "ckad-mock-01", "title": "CKAD Mock Exam", "certification": "CKAD", "description": "Developer-track exercises...", "examType": "hands-on", "durationSeconds": 7200, "passingScore": 66, "kubernetesVersion": "1.35", "questionCount": 17, "poolCount": 44, "available": true},
     {"id": "kcna-mock", "title": "KCNA Mock Exam", "certification": "KCNA", "description": "65 questions drawn each attempt...", "examType": "mcq", "durationSeconds": 5400, "passingScore": 75, "questionCount": 65, "poolCount": 97, "available": true},
     {"id": "cks-mock", "title": "CKS Mock Exam", "certification": "CKS", "examType": "hands-on", "available": false, "comingSoon": true, "note": "Requires security add-ons not in the kind environment yet"}
   ]

--- a/docs/bank-spec.md
+++ b/docs/bank-spec.md
@@ -278,17 +278,21 @@ clock and one nobody finishes are both miscalibrated. `ckad-mock-01`
 currently draws 4 quick, 9 core and 4 deep for 115 minutes of task time
 against 120.
 
-The tier never reaches the candidate mid-attempt. It shapes the draw and
-it is gate input; a question labelled `deep` on screen would only tell
-someone to brace.
+The tier never reaches the candidate **mid-attempt**: a question labelled
+`deep` on screen would only tell someone to brace. It arrives once the
+attempt is over, on `GET /api/results`, where the same score is also cut
+by level — see [api.md](api.md). That cut is the reason the axis is worth
+having beyond comfort: a score that holds up on short tasks and falls
+away on long ones is a pacing problem, and a flat low score is a
+knowledge problem, and the two want different practice.
 
 ### Points in a pooled bank
 
 Derive them against the **pool**, exactly as an unpooled bank does:
 `domain budget / questions in that domain`, counting every authored
-question. `ckad-mock-01`'s 26 questions total 217 points that way, and
-every domain's share of them lands within one percentage point of its
-curriculum weight.
+question. `ckad-mock-01`'s 44 questions total 360 points that way — flat per
+domain, 9 or 7 — and every domain's share of them lands within one
+percentage point of its curriculum weight.
 
 What that does *not* give you is a drawn attempt whose raw points divide
 in the curriculum's ratios, and it cannot: a domain that contributes 4 of

--- a/docs/bank-spec.md
+++ b/docs/bank-spec.md
@@ -92,6 +92,7 @@ Where the optional keys go:
 |---|---|
 | `title:` | *Inside* the run, directly after `id:`. Nowhere else |
 | `targetSeconds:` | *After* the run, below `weight:` (hands-on) or `correct:` (mcq) |
+| `difficulty:` | Same as `targetSeconds:` |
 | `docs:` | Same as `targetSeconds:` |
 
 | Field | Meaning and status |
@@ -105,6 +106,7 @@ Where the optional keys go:
 | `spec.passingScore` | Percent. Enforced by the facilitator's `Results.Passed` |
 | `spec.kubernetesVersion` | Informational; shown on the catalog card |
 | `spec.domainWeights` | The certification's published weights, and a runtime value in three places: `exam.Load` builds `Exam.Domains` from it, `exam.Draw` stratifies a pooled or filtered draw by it, and both graders weight the final score by it. [bank-weights.sh](../tests/bank-weights.sh) still gates it too. Getting it wrong now moves real scores, not just a build check |
+| `spec.difficultyMix` | Optional, hands-on. Opts a **pooled** bank into a second stratification: the percentage of a drawn attempt that should be `quick`, `core` and `deep`. Must sum to 100, must name only those three tiers, and every question in the bank must then declare a `difficulty` and a `targetSeconds`. Absent — every bank in this repo but `ckad-mock-01` — the draw is stratified by domain alone and nothing changes. See [Mixing a draw by level](#mixing-a-draw-by-level-specdifficultymix) |
 | `spec.examLength` | Optional, **both engines**. Pools the bank: author more questions than one attempt should ask, set this to the smaller per-attempt count, and `exam.Draw` takes a fresh domain-stratified subset every start. Must be positive and no larger than the pool — `exam.Load` rejects both, because an `examLength` typo that silently turns pooling *off* is worse than one that fails the boot. A pooled bank must declare `spec.domainWeights`; the draw stratifies against them and errors without. Absent or `>=` the pool means no pooling, which is every bank in this repo. **A pooled hands-on bank also changes when its cluster is seeded** — see below |
 | `spec.environment.nodes` | **The size of this exam's cluster.** [bootstrap.sh](../images/k8s-env/bootstrap.sh) copies `kind-config.yaml` — which holds the control-plane node and nothing else — and appends one `- role: worker` per extra node before `kind create cluster`. Absent means 2; anything that is not a positive integer fails the boot rather than falling back, because a cluster silently the wrong size is discovered by a drain question grading zero. Also served on `GET /api/exam` so the screens that describe the environment while it builds describe the one being built |
 | `spec.environment.provider` | Informational; `kind` is the only one that exists. Served on `GET /api/exam` beside `nodes` |
@@ -114,7 +116,8 @@ Where the optional keys go:
 | `spec.questions[].title` | Optional short label shown in the question navigator, the jump grid and the score review. Absent, the UI falls back to the id (hands-on) or the attempt position (mcq) |
 | `spec.questions[].domain` | Must match a `domainWeights` key |
 | `spec.questions[].weight` | Must equal the sum of this question's `# points:` headers |
-| `spec.questions[].targetSeconds` | Optional pacing budget, in seconds, shown on the task chip. Absent, the facilitator derives one from the question's weight's share of the exam clock ([exam.go](../facilitator/internal/exam/exam.go), `TargetSeconds`) and flags it `targetDerived` on `GET /api/exam`, so a derived figure is never presented as the author's judgement — neither shipped bank sets it. It is a budget, never a limit: nothing enforces it and running over costs no points. Write it below `weight:` (hands-on) or `correct:` (mcq); both gate regexes end there, and a `targetSeconds:` line above them hides the question from the gate |
+| `spec.questions[].targetSeconds` | Optional pacing budget, in seconds, shown on the task chip. Absent, the facilitator derives one from the question's weight's share of the exam clock ([exam.go](../facilitator/internal/exam/exam.go), `TargetSeconds`) and flags it `targetDerived` on `GET /api/exam`, so a derived figure is never presented as the author's judgement. `ckad-mock-01` sets it on every question because its `spec.difficultyMix` requires one; `kcna-mock` sets none. It is a budget, never a limit: nothing enforces it and running over costs no points. Write it below `weight:` (hands-on) or `correct:` (mcq); both gate regexes end there, and a `targetSeconds:` line above them hides the question from the gate |
+| `spec.questions[].difficulty` | `quick`, `core` or `deep`. Required on every question of a bank declaring `spec.difficultyMix`, and rejected on a bank that does not — a label nothing draws on is cruft. **The tier is its `targetSeconds` band, not a judgement**: `quick` is at most 240s, `core` 241-540, `deep` 541-840, and [exam.go](../facilitator/internal/exam/exam.go) refuses a bank whose label and budget disagree. Never sent to the client during an attempt: a question labelled `deep` on screen is a spoiler and an anxiety source |
 | `spec.questions[].docs` | Optional upstream reading: a list of `{label, url}`. Shown in the post-attempt deep dive — see [Documentation links](#documentation-links-specquestionsdocs). Write it below `weight:`/`correct:` for the same reason `targetSeconds` goes there |
 
 ## Documentation links: `spec.questions[].docs`
@@ -191,19 +194,93 @@ For an author:
   moved four minutes of seeding from the boot screen to the moment the
   candidate presses Start, and gained almost no variety for it.
 
-`ckad-mock-01` pools 26 down to 22 for the other reason: **holding the
-sitting to the right length.** The real CKAD is around twenty tasks in
-two hours.
+`ckad-mock-01` pools 26 down to 17 for both reasons. **Holding the sitting
+to the right length** comes first: the real CKAD is 15-20 tasks in two
+hours, and 17 is its midpoint.
 
-The variety that comes with it is modest, and worth stating plainly:
+The variety is worth stating plainly, because a draw that barely shrinks
+the pool is pooling in name only:
 
-| Domain | Rotation |
-|---|---|
-| Three of the five | Asked in full every time |
-| Application Design and Build | 4 of 7 |
-| Application Observability and Maintenance | 3 of 4 |
+| Domain | Pool | Rotation |
+|---|---|---|
+| Application Environment, Configuration and Security | 6 | 4 of 6 |
+| Application Deployment | 5 | 4 of 5 |
+| Services and Networking | 4 | 3 of 4 |
+| Application Design and Build | 7 | 3 of 7 |
+| Application Observability and Maintenance | 4 | 3 of 4 |
 
-Deepening a domain widens its rotation.
+Deepening a domain widens its rotation. The gate prints this table, so the
+thinnest domain is always the one to write into next.
+
+## Mixing a draw by level: `spec.difficultyMix`
+
+Domain stratification says *what* an attempt asks about. It says nothing
+about how tiring the attempt is, and a draw of four multi-step questions
+in a row teaches less than a mixed one — the fatigue costs more than the
+extra difficulty buys.
+
+A pooled bank can declare the shape it wants:
+
+```yaml
+spec:
+  examLength: 17
+  difficultyMix:
+    quick: 30
+    core: 45
+    deep: 25
+```
+
+and every question then declares where it sits:
+
+```yaml
+    - id: q23
+      title: Blue/green cutover
+      instance: instance-2
+      domain: Application Deployment
+      weight: 9
+      targetSeconds: 150
+      difficulty: quick
+```
+
+**A tier is a time band, not an opinion.** That is the whole point of
+writing it this way: a subjective label rots, a budget does not.
+
+| Tier | `targetSeconds` | Shape |
+|---|---|---|
+| `quick` | up to 240 | One object, one or two non-default fields. Not a bare `kubectl get` — the floor is still a real object with a field you have to know |
+| `core` | 241-540 | The real exam's median task: a manifest with a few non-obvious fields, or two chained steps |
+| `deep` | 541-840 | Multi-step, ordering matters, or diagnosis before the fix |
+
+[exam.go](../facilitator/internal/exam/exam.go) refuses to load a bank
+whose label and budget disagree, so the two cannot drift apart.
+
+### What the draw guarantees, and what it does not
+
+**The domain split is a hard constraint and the mix a soft one.** Each
+domain takes its exact allocation and spends it on whichever tier is
+furthest behind; a domain that cannot supply that tier supplies the next
+best, and the shortfall carries to the following domain rather than
+bending the domain split. `spec.domainWeights` is the promise the graders
+weight a final score by (`evaluate.Results.Finalize`), and a comfort
+preference does not get to move a score.
+
+One consequence is worth knowing: **the tier composition of a draw does
+not depend on the seed.** Only the deficit and what each domain holds
+decide which tier is spent next, so every attempt of a given bank holds
+the same counts — the seed decides only *which* question fills each slot.
+The mix is guaranteed, not likely.
+
+[bank-weights.sh](../tests/bank-weights.sh) replays that walk and fails
+the bank when a tier lands more than one question from its share, prints
+a domain-by-tier depth table, and checks the drawn sitting against the
+clock: 0.85 to 1.05 of `spec.duration`, because a bank that wastes the
+clock and one nobody finishes are both miscalibrated. `ckad-mock-01`
+currently draws 4 quick, 9 core and 4 deep for 115 minutes of task time
+against 120.
+
+The tier never reaches the candidate mid-attempt. It shapes the draw and
+it is gate input; a question labelled `deep` on screen would only tell
+someone to brace.
 
 ### Points in a pooled bank
 

--- a/facilitator/internal/api/api.go
+++ b/facilitator/internal/api/api.go
@@ -123,6 +123,11 @@ type examResponse struct {
 	Domains []domainInfo `json:"domains"`
 
 	HasTips bool `json:"hasTips,omitempty"`
+
+	// Whether the draw is stratified by level as well as by domain. The
+	// per-question tier deliberately stays server-side: it shapes the
+	// draw, it is not something to brace a candidate with mid-attempt.
+	LevelMixed bool `json:"levelMixed,omitempty"`
 }
 
 type environmentInfo struct {
@@ -179,6 +184,7 @@ func (s *server) handleExam(w http.ResponseWriter, r *http.Request) {
 		KubernetesVersion: s.ex.KubernetesVersion,
 		QuestionCount:     s.declaredQuestionCount(),
 		HasTips:           s.ex.HasTips,
+		LevelMixed:        len(s.ex.DifficultyMix) > 0,
 
 		Questions: make([]examQuestionInfo, 0, len(pool)),
 	}

--- a/facilitator/internal/evaluate/evaluate.go
+++ b/facilitator/internal/evaluate/evaluate.go
@@ -67,6 +67,8 @@ type Results struct {
 
 	Domains []DomainResult `json:"domains,omitempty"`
 
+	Levels []LevelResult `json:"levels,omitempty"`
+
 	Mode string `json:"mode,omitempty"`
 	Seed string `json:"seed,omitempty"`
 
@@ -114,6 +116,16 @@ type DomainResult struct {
 	QuestionCount int     `json:"questionCount"`
 }
 
+// The same attempt cut by how long each task was meant to take. A score that
+// falls away as the tasks get longer is a different problem from one that is
+// flat and low, and only the candidate can act on the difference.
+type LevelResult struct {
+	Level         string `json:"level"`
+	Earned        int    `json:"earned"`
+	Total         int    `json:"total"`
+	QuestionCount int    `json:"questionCount"`
+}
+
 type QuestionResult struct {
 	ID       string        `json:"id"`
 	Title    string        `json:"title,omitempty"`
@@ -122,6 +134,10 @@ type QuestionResult struct {
 	Earned   int           `json:"earned"`
 	Total    int           `json:"total"`
 	Checks   []CheckResult `json:"checks"`
+
+	// Only ever sent once the attempt is over. During one it would just tell
+	// a candidate to brace.
+	Difficulty string `json:"difficulty,omitempty"`
 
 	WeightPct float64 `json:"weightPct"`
 
@@ -167,7 +183,8 @@ func Grade(ex *exam.Exam, bank string, r Runner, checkTimeout time.Duration, que
 	}
 
 	for _, q := range exam.Subset(ex, questionIDs) {
-		qr := QuestionResult{ID: q.ID, Title: q.Title, Instance: q.Instance, Domain: q.Domain}
+		qr := QuestionResult{ID: q.ID, Title: q.Title, Instance: q.Instance, Domain: q.Domain,
+			Difficulty: q.Difficulty}
 
 		for _, c := range q.Checks {
 			if c.Skip {
@@ -238,6 +255,8 @@ func (r *Results) Finalize(domains []exam.Domain) {
 		r.Domains = nil
 	}
 
+	r.rollUpLevels()
+
 	if r.Total > 0 {
 		r.PointsPercent = r.Earned * 100 / r.Total
 	} else {
@@ -301,6 +320,33 @@ func (r *Results) weight(declared map[string]int) {
 		}
 		qShare := new(big.Rat).Mul(shares[i], big.NewRat(int64(q.Total), int64(r.Domains[i].Total)))
 		r.Questions[j].WeightPct, _ = qShare.Float64()
+	}
+}
+
+// Levels stay in tier order rather than being sorted by score: the point of
+// reading them is the shape as the tasks get longer, which a sort destroys.
+// A bank that declares no tiers — every mcq bank — gets no breakdown at all.
+func (r *Results) rollUpLevels() {
+	by := map[string]*LevelResult{}
+	for _, q := range r.Questions {
+		if q.Difficulty == "" {
+			continue
+		}
+		l, ok := by[q.Difficulty]
+		if !ok {
+			l = &LevelResult{Level: q.Difficulty}
+			by[q.Difficulty] = l
+		}
+		l.Earned += q.Earned
+		l.Total += q.Total
+		l.QuestionCount++
+	}
+
+	r.Levels = nil
+	for _, tier := range exam.Tiers() {
+		if l, ok := by[tier]; ok {
+			r.Levels = append(r.Levels, *l)
+		}
 	}
 }
 

--- a/facilitator/internal/evaluate/levels_test.go
+++ b/facilitator/internal/evaluate/levels_test.go
@@ -1,0 +1,88 @@
+package evaluate
+
+import (
+	"testing"
+
+	"kubestronaut-sim/facilitator/internal/exam"
+)
+
+func levelResults(qs ...QuestionResult) *Results {
+	r := &Results{Questions: qs}
+	r.Finalize(nil)
+	return r
+}
+
+func q(id, domain, tier string, earned, total int) QuestionResult {
+	return QuestionResult{ID: id, Domain: domain, Difficulty: tier, Earned: earned, Total: total}
+}
+
+func TestLevelsReadShortestFirstWhateverOrderTheQuestionsCame(t *testing.T) {
+	r := levelResults(
+		q("q1", "A", exam.TierDeep, 2, 10),
+		q("q2", "A", exam.TierQuick, 5, 5),
+		q("q3", "B", exam.TierCore, 4, 8),
+		q("q4", "B", exam.TierQuick, 4, 5),
+	)
+
+	want := []LevelResult{
+		{Level: exam.TierQuick, Earned: 9, Total: 10, QuestionCount: 2},
+		{Level: exam.TierCore, Earned: 4, Total: 8, QuestionCount: 1},
+		{Level: exam.TierDeep, Earned: 2, Total: 10, QuestionCount: 1},
+	}
+	if len(r.Levels) != len(want) {
+		t.Fatalf("Levels = %+v, want %d entries", r.Levels, len(want))
+	}
+	for i, w := range want {
+		if r.Levels[i] != w {
+			t.Errorf("Levels[%d] = %+v, want %+v", i, r.Levels[i], w)
+		}
+	}
+}
+
+// The shape is the whole point: a score that falls away as tasks get longer is
+// a different problem from one that is flat and low.
+func TestLevelsKeepTierOrderRatherThanScoreOrder(t *testing.T) {
+	r := levelResults(
+		q("q1", "A", exam.TierQuick, 0, 10),
+		q("q2", "A", exam.TierDeep, 10, 10),
+	)
+	if len(r.Levels) != 2 || r.Levels[0].Level != exam.TierQuick || r.Levels[1].Level != exam.TierDeep {
+		t.Fatalf("Levels = %+v, want quick before deep even when quick scored worse", r.Levels)
+	}
+}
+
+// kcna-mock and the smoke banks declare no tiers; they must get no breakdown
+// rather than one bucket labelled with the empty string.
+func TestLevelsAbsentWhenTheBankDeclaresNoTiers(t *testing.T) {
+	r := levelResults(
+		QuestionResult{ID: "q1", Domain: "A", Earned: 1, Total: 1},
+		QuestionResult{ID: "q2", Domain: "A", Earned: 0, Total: 1},
+	)
+	if r.Levels != nil {
+		t.Errorf("Levels = %+v, want nil for a bank that declares no tiers", r.Levels)
+	}
+}
+
+func TestLevelsCoverOnlyTheTiersTheAttemptDrew(t *testing.T) {
+	r := levelResults(q("q1", "A", exam.TierCore, 3, 6))
+	if len(r.Levels) != 1 || r.Levels[0].Level != exam.TierCore {
+		t.Fatalf("Levels = %+v, want only the core tier", r.Levels)
+	}
+}
+
+func TestLevelTotalsAgreeWithTheAttemptTotal(t *testing.T) {
+	r := levelResults(
+		q("q1", "A", exam.TierQuick, 3, 5),
+		q("q2", "B", exam.TierCore, 6, 9),
+		q("q3", "B", exam.TierDeep, 1, 7),
+	)
+	earned, total := 0, 0
+	for _, l := range r.Levels {
+		earned += l.Earned
+		total += l.Total
+	}
+	if earned != r.Earned || total != r.Total {
+		t.Errorf("levels sum to %d/%d, attempt is %d/%d — a breakdown that does not add up is worse than none",
+			earned, total, r.Earned, r.Total)
+	}
+}

--- a/facilitator/internal/exam/draw_levels_test.go
+++ b/facilitator/internal/exam/draw_levels_test.go
@@ -1,0 +1,256 @@
+package exam
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var ckadDomainOrder = []string{
+	"Application Environment, Configuration and Security",
+	"Application Deployment",
+	"Services and Networking",
+	"Application Design and Build",
+	"Application Observability and Maintenance",
+}
+
+var ckadWeights = map[string]int{
+	"Application Environment, Configuration and Security": 25,
+	"Application Deployment":                              20,
+	"Services and Networking":                             20,
+	"Application Design and Build":                        20,
+	"Application Observability and Maintenance":           15,
+}
+
+var ckadMix = map[string]int{TierQuick: 30, TierCore: 45, TierDeep: 25}
+
+// The shape branch 2+ is authoring towards: 44 questions drawing 17.
+var ckadTierPools = map[string]map[string]int{
+	"Application Environment, Configuration and Security": {TierQuick: 3, TierCore: 4, TierDeep: 3},
+	"Application Deployment":                              {TierQuick: 3, TierCore: 4, TierDeep: 3},
+	"Services and Networking":                             {TierQuick: 2, TierCore: 4, TierDeep: 2},
+	"Application Design and Build":                        {TierQuick: 2, TierCore: 4, TierDeep: 2},
+	"Application Observability and Maintenance":           {TierQuick: 2, TierCore: 4, TierDeep: 2},
+}
+
+func levelFixture(t *testing.T, tierPools map[string]map[string]int, mix map[string]int, examLength int) *Exam {
+	t.Helper()
+	e := &Exam{
+		Type:          TypeMCQ,
+		DomainWeights: ckadWeights,
+		DifficultyMix: mix,
+		ExamLength:    examLength,
+	}
+	for _, d := range ckadDomainOrder {
+		for _, tier := range tierOrder {
+			for i := 1; i <= tierPools[d][tier]; i++ {
+				e.Questions = append(e.Questions, Question{
+					ID:            fmt.Sprintf("%s-%s-%d", d, tier, i),
+					Domain:        d,
+					Difficulty:    tier,
+					TargetSeconds: tierBounds[tier][1],
+					Weight:        1,
+				})
+			}
+		}
+	}
+	return e
+}
+
+func tallyBy(e *Exam, ids []string, key func(Question) string) map[string]int {
+	byID := map[string]Question{}
+	for _, q := range e.Questions {
+		byID[q.ID] = q
+	}
+	out := map[string]int{}
+	for _, id := range ids {
+		out[key(byID[id])]++
+	}
+	return out
+}
+
+// The mix is a soft constraint, so this asserts the property that matters:
+// no tier ever lands more than one question away from its share.
+func TestDrawHoldsTheDeclaredLevelMixAcrossSeeds(t *testing.T) {
+	e := levelFixture(t, ckadTierPools, ckadMix, 17)
+	want := largestRemainder(ckadMix, tierOrder, 17, 100)
+
+	for i := 0; i < 256; i++ {
+		seed := fmt.Sprintf("%06x", i*7919)
+		res, err := Draw(e, DrawOptions{Seed: seed})
+		if err != nil {
+			t.Fatalf("Draw(seed %s): %v", seed, err)
+		}
+		if len(res.IDs) != 17 {
+			t.Fatalf("seed %s drew %d questions, want 17", seed, len(res.IDs))
+		}
+		got := tallyBy(e, res.IDs, func(q Question) string { return q.Difficulty })
+		for _, tier := range tierOrder {
+			if drift := got[tier] - want[tier]; drift < -1 || drift > 1 {
+				t.Fatalf("seed %s drew %d %s questions, want %d (drift %+d, tolerance 1)",
+					seed, got[tier], tier, want[tier], drift)
+			}
+		}
+	}
+}
+
+func TestDrawMixedIsExactOnDomainsAndReplaysBySeed(t *testing.T) {
+	e := levelFixture(t, ckadTierPools, ckadMix, 17)
+	want, err := domainTargets(ckadWeights, ckadDomainOrder, 17)
+	if err != nil {
+		t.Fatalf("domainTargets: %v", err)
+	}
+
+	first, err := Draw(e, DrawOptions{Seed: "a1b2c3"})
+	if err != nil {
+		t.Fatalf("Draw (first): %v", err)
+	}
+	second, err := Draw(e, DrawOptions{Seed: "a1b2c3"})
+	if err != nil {
+		t.Fatalf("Draw (second): %v", err)
+	}
+	if !equalIDs(first.IDs, second.IDs) {
+		t.Errorf("same seed drew different sets:\n first  = %v\n second = %v", first.IDs, second.IDs)
+	}
+
+	got := tallyBy(e, first.IDs, func(q Question) string { return q.Domain })
+	for _, d := range ckadDomainOrder {
+		if got[d] != want[d] {
+			t.Errorf("domain %q drew %d, want exactly %d — the domain split is the hard constraint", d, got[d], want[d])
+		}
+	}
+}
+
+// A domain that holds only one tier cannot help the mix. The split it
+// owes is still exact, and the shortfall carries rather than compounding.
+func TestDrawMixedKeepsDomainsExactWhenATierIsUnavailable(t *testing.T) {
+	pools := map[string]map[string]int{}
+	for d, tiers := range ckadTierPools {
+		pools[d] = map[string]int{TierQuick: tiers[TierQuick], TierCore: tiers[TierCore], TierDeep: tiers[TierDeep]}
+	}
+	lopsided := "Application Observability and Maintenance"
+	pools[lopsided] = map[string]int{TierDeep: 8}
+
+	e := levelFixture(t, pools, ckadMix, 17)
+	want, err := domainTargets(ckadWeights, ckadDomainOrder, 17)
+	if err != nil {
+		t.Fatalf("domainTargets: %v", err)
+	}
+
+	res, err := Draw(e, DrawOptions{Seed: "beef01"})
+	if err != nil {
+		t.Fatalf("Draw: %v", err)
+	}
+	got := tallyBy(e, res.IDs, func(q Question) string { return q.Domain })
+	for _, d := range ckadDomainOrder {
+		if got[d] != want[d] {
+			t.Errorf("domain %q drew %d, want exactly %d", d, got[d], want[d])
+		}
+	}
+	byTier := tallyBy(e, res.IDs, func(q Question) string { return q.Difficulty })
+	if byTier[TierDeep] < want[lopsided] {
+		t.Errorf("drew %d deep questions, want at least the %d that only-deep domain owes", byTier[TierDeep], want[lopsided])
+	}
+}
+
+// Guards kcna-mock and the smoke banks: with no mix declared the draw must
+// still be the plain per-domain shuffle it has always been.
+func TestDrawWithoutAMixIsTheDomainOnlyShuffle(t *testing.T) {
+	e := levelFixture(t, ckadTierPools, nil, 17)
+	targets, err := domainTargets(ckadWeights, ckadDomainOrder, 17)
+	if err != nil {
+		t.Fatalf("domainTargets: %v", err)
+	}
+
+	res, err := Draw(e, DrawOptions{Seed: "a1b2c3"})
+	if err != nil {
+		t.Fatalf("Draw: %v", err)
+	}
+
+	var want []string
+	for _, d := range ckadDomainOrder {
+		var pool []string
+		for _, q := range e.Questions {
+			if q.Domain == d {
+				pool = append(pool, q.ID)
+			}
+		}
+		want = append(want, shuffle(pool, "a1b2c3", d)[:targets[d]]...)
+	}
+	if !equalIDs(res.IDs, want) {
+		t.Errorf("a mixless bank no longer draws the legacy per-domain shuffle:\n got  = %v\n want = %v", res.IDs, want)
+	}
+}
+
+func levelQuestion(id, tier string, targetSeconds int) string {
+	return fmt.Sprintf(
+		`{"id": %q, "domain": "d", "multi": false, "options": ["A", "B", "C"], "correct": [0], "targetSeconds": %d, "difficulty": %q}`,
+		id, targetSeconds, tier)
+}
+
+func TestLoadDifficultyValidation(t *testing.T) {
+	mix := func(body string) string { return fmt.Sprintf(`"examType": "mcq", "difficultyMix": {%s},`, body) }
+	good := `"quick": 30, "core": 45, "deep": 25`
+
+	cases := []struct {
+		name     string
+		spec     string
+		question string
+		wantErr  string
+	}{
+		{"mix does not sum to 100", mix(`"quick": 30, "core": 45, "deep": 20`),
+			levelQuestion("q01", TierQuick, 200), "sums to 95"},
+		{"unknown tier", mix(`"quick": 30, "core": 45, "brutal": 25`),
+			levelQuestion("q01", TierQuick, 200), "unknown tier"},
+		{"negative share", mix(`"quick": 130, "core": 0, "deep": -30`),
+			levelQuestion("q01", TierQuick, 200), "negative share"},
+		{"question has no tier", mix(good),
+			`{"id": "q01", "domain": "d", "multi": false, "options": ["A", "B", "C"], "correct": [0], "targetSeconds": 200}`,
+			"declares a tier on every question"},
+		{"question has an unknown tier", mix(good),
+			levelQuestion("q01", "brutal", 200), "declares a tier on every question"},
+		{"tier contradicts targetSeconds", mix(good),
+			levelQuestion("q01", TierQuick, 600), "outside that tier's 1-240 band"},
+		{"targetSeconds beyond the deepest band", mix(good),
+			levelQuestion("q01", TierDeep, 1200), "outside that tier's 541-840 band"},
+		{"no targetSeconds to place the tier", mix(good),
+			`{"id": "q01", "domain": "d", "multi": false, "options": ["A", "B", "C"], "correct": [0], "difficulty": "quick"}`,
+			"sets no targetSeconds"},
+		{"a tier the bank cannot supply", mix(good),
+			levelQuestion("q01", TierQuick, 200), "asks for 45% core questions and the bank holds none"},
+		{"a tier without a mix to draw against", `"examType": "mcq",`,
+			levelQuestion("q01", TierQuick, 200), "declares no spec.difficultyMix"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := loadMCQDoc(t, c.spec, c.question)
+			if err == nil {
+				t.Fatalf("Load: got nil error, want one containing %q", c.wantErr)
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Errorf("error = %v, want it to contain %q", err, c.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoadAcceptsAWellFormedMix(t *testing.T) {
+	e, err := loadMCQDoc(t,
+		`"examType": "mcq", "difficultyMix": {"quick": 30, "core": 45, "deep": 25},`,
+		levelQuestion("q01", TierQuick, 240),
+		levelQuestion("q02", TierCore, 241),
+		levelQuestion("q03", TierDeep, 541),
+	)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := e.DifficultyMix[TierCore]; got != 45 {
+		t.Errorf("DifficultyMix[core] = %d, want 45", got)
+	}
+	for i, want := range []string{TierQuick, TierCore, TierDeep} {
+		if got := e.Questions[i].Difficulty; got != want {
+			t.Errorf("Questions[%d].Difficulty = %q, want %q", i, got, want)
+		}
+	}
+}

--- a/facilitator/internal/exam/exam.go
+++ b/facilitator/internal/exam/exam.go
@@ -25,6 +25,22 @@ const (
 	TypeMCQ     = "mcq"
 )
 
+const (
+	TierQuick = "quick"
+	TierCore  = "core"
+	TierDeep  = "deep"
+)
+
+var tierOrder = []string{TierQuick, TierCore, TierDeep}
+
+// A tier is the time band, not a judgement: the gate checks the label
+// against targetSeconds so it cannot drift into an opinion.
+var tierBounds = map[string][2]int{
+	TierQuick: {1, 240},
+	TierCore:  {241, 540},
+	TierDeep:  {541, 840},
+}
+
 type Exam struct {
 	Name  string
 	Title string
@@ -42,6 +58,8 @@ type Exam struct {
 	Questions   []Question
 
 	DomainWeights map[string]int
+
+	DifficultyMix map[string]int
 
 	Domains []Domain
 
@@ -76,6 +94,8 @@ type Question struct {
 
 	TargetSeconds int
 
+	Difficulty string
+
 	Docs []Doc
 
 	Options []string
@@ -108,6 +128,7 @@ type examDoc struct {
 		PassingScore      int            `json:"passingScore"`
 		KubernetesVersion string         `json:"kubernetesVersion"`
 		DomainWeights     map[string]int `json:"domainWeights"`
+		DifficultyMix     map[string]int `json:"difficultyMix"`
 		ExamLength        int            `json:"examLength"`
 		Environment       struct {
 			Provider string `json:"provider"`
@@ -120,6 +141,7 @@ type examDoc struct {
 			Domain        string        `json:"domain"`
 			Weight        int           `json:"weight"`
 			TargetSeconds int           `json:"targetSeconds"`
+			Difficulty    string        `json:"difficulty"`
 			Options       []string      `json:"options"`
 			Correct       []int         `json:"correct"`
 			Multi         bool          `json:"multi"`
@@ -175,6 +197,7 @@ func Load(examJSONPath, bankDir string) (*Exam, error) {
 		PassingScore:      doc.Spec.PassingScore,
 		KubernetesVersion: doc.Spec.KubernetesVersion,
 		DomainWeights:     doc.Spec.DomainWeights,
+		DifficultyMix:     doc.Spec.DifficultyMix,
 		ExamLength:        doc.Spec.ExamLength,
 		Environment: Environment{
 			Provider: doc.Spec.Environment.Provider,
@@ -194,6 +217,7 @@ func Load(examJSONPath, bankDir string) (*Exam, error) {
 			Domain:        q.Domain,
 			Weight:        q.Weight,
 			TargetSeconds: q.TargetSeconds,
+			Difficulty:    q.Difficulty,
 			HintCount:     countHints(bankDir, q.ID),
 			Docs:          loadDocs(q.ID, q.Docs),
 		}
@@ -226,11 +250,64 @@ func Load(examJSONPath, bankDir string) (*Exam, error) {
 		return nil, fmt.Errorf("exam: spec.examLength %d exceeds the pool of %d questions", e.ExamLength, len(e.Questions))
 	}
 
+	if err := validateDifficulty(e); err != nil {
+		return nil, err
+	}
+
 	for _, name := range domainOrder(e.Questions) {
 		e.Domains = append(e.Domains, Domain{Name: name, WeightPct: e.DomainWeights[name]})
 	}
 
 	return e, nil
+}
+
+func validateDifficulty(e *Exam) error {
+	if len(e.DifficultyMix) == 0 {
+		for _, q := range e.Questions {
+			if q.Difficulty != "" {
+				return fmt.Errorf("exam: question %s declares difficulty %q, but the bank declares no spec.difficultyMix to draw against", q.ID, q.Difficulty)
+			}
+		}
+		return nil
+	}
+
+	total := 0
+	for tier, share := range e.DifficultyMix {
+		if _, ok := tierBounds[tier]; !ok {
+			return fmt.Errorf("exam: spec.difficultyMix names an unknown tier %q, want one of %s", tier, strings.Join(tierOrder, ", "))
+		}
+		if share < 0 {
+			return fmt.Errorf("exam: spec.difficultyMix gives %s a negative share %d", tier, share)
+		}
+		total += share
+	}
+	if total != 100 {
+		return fmt.Errorf("exam: spec.difficultyMix sums to %d, want 100", total)
+	}
+
+	for _, q := range e.Questions {
+		bounds, ok := tierBounds[q.Difficulty]
+		if !ok {
+			return fmt.Errorf("exam: question %s has difficulty %q, want one of %s — a bank declaring spec.difficultyMix declares a tier on every question", q.ID, q.Difficulty, strings.Join(tierOrder, ", "))
+		}
+		if q.TargetSeconds == 0 {
+			return fmt.Errorf("exam: question %s is %s but sets no targetSeconds; the tier is the time band, so it cannot be derived from the question's share of the points", q.ID, q.Difficulty)
+		}
+		if q.TargetSeconds < bounds[0] || q.TargetSeconds > bounds[1] {
+			return fmt.Errorf("exam: question %s is %s with targetSeconds %d, outside that tier's %d-%d band", q.ID, q.Difficulty, q.TargetSeconds, bounds[0], bounds[1])
+		}
+	}
+
+	held := map[string]bool{}
+	for _, q := range e.Questions {
+		held[q.Difficulty] = true
+	}
+	for _, tier := range tierOrder {
+		if e.DifficultyMix[tier] > 0 && !held[tier] {
+			return fmt.Errorf("exam: spec.difficultyMix asks for %d%% %s questions and the bank holds none", e.DifficultyMix[tier], tier)
+		}
+	}
+	return nil
 }
 
 func domainOrder(questions []Question) []string {
@@ -502,6 +579,15 @@ func Draw(ex *Exam, opts DrawOptions) (DrawResult, error) {
 		return DrawResult{}, err
 	}
 
+	if len(ex.DifficultyMix) > 0 {
+		ids, err := drawMixed(ex, inScope, order, targets, length, seed)
+		if err != nil {
+			return DrawResult{}, err
+		}
+		res.IDs = ids
+		return res, nil
+	}
+
 	drawn := make([]string, 0, length)
 	for _, d := range order {
 		k := targets[d]
@@ -514,6 +600,61 @@ func Draw(ex *Exam, opts DrawOptions) (DrawResult, error) {
 	}
 	res.IDs = drawn
 	return res, nil
+}
+
+// The domain targets are a hard constraint and the tier mix a soft one:
+// spec.domainWeights is the promise the graders weight a score by, while
+// the mix only shapes how tiring the sitting is. So each domain takes its
+// exact count and spends it on whichever tier is furthest behind, and any
+// shortfall carries to the next domain rather than bending the split.
+func drawMixed(ex *Exam, inScope []Question, order []string, targets map[string]int, length int, seed string) ([]string, error) {
+	byDomainTier := map[string]map[string][]string{}
+	for _, q := range inScope {
+		if byDomainTier[q.Domain] == nil {
+			byDomainTier[q.Domain] = map[string][]string{}
+		}
+		byDomainTier[q.Domain][q.Difficulty] = append(byDomainTier[q.Domain][q.Difficulty], q.ID)
+	}
+
+	totalShare := 0
+	for _, t := range tierOrder {
+		totalShare += ex.DifficultyMix[t]
+	}
+	deficit := largestRemainder(ex.DifficultyMix, tierOrder, length, totalShare)
+
+	drawn := make([]string, 0, length)
+	for _, d := range order {
+		k := targets[d]
+		queues := make(map[string][]string, len(tierOrder))
+		held := 0
+		for _, t := range tierOrder {
+			queues[t] = shuffle(byDomainTier[d][t], seed, d+"\x00"+t)
+			held += len(queues[t])
+		}
+		if k > held {
+			return nil, fmt.Errorf("exam: domain %q needs %d questions for a %d-question draw, pool has only %d", d, k, length, held)
+		}
+		for i := 0; i < k; i++ {
+			t := neediestTier(deficit, queues)
+			drawn = append(drawn, queues[t][0])
+			queues[t] = queues[t][1:]
+			deficit[t]--
+		}
+	}
+	return drawn, nil
+}
+
+func neediestTier(deficit map[string]int, queues map[string][]string) string {
+	best := ""
+	for _, t := range tierOrder {
+		if len(queues[t]) == 0 {
+			continue
+		}
+		if best == "" || deficit[t] > deficit[best] {
+			best = t
+		}
+	}
+	return best
 }
 
 func questionIDs(questions []Question) []string {
@@ -626,12 +767,6 @@ func domainTargets(domainWeights map[string]int, order []string, n int) (map[str
 		return nil, fmt.Errorf("exam: spec.domainWeights is required to draw a %d-question subset", n)
 	}
 
-	type remainder struct {
-		domain string
-		frac   float64
-		index  int
-	}
-
 	totalWeight := 0
 	for _, d := range order {
 		w, ok := domainWeights[d]
@@ -644,20 +779,33 @@ func domainTargets(domainWeights map[string]int, order []string, n int) (map[str
 		return nil, fmt.Errorf("exam: the domains of a %d-question draw declare no weight between them", n)
 	}
 
+	targets := largestRemainder(domainWeights, order, n, totalWeight)
+	assigned := 0
+	for _, d := range order {
+		assigned += targets[d]
+	}
+	if assigned != n {
+		return nil, fmt.Errorf("exam: domainWeights do not add up cleanly for a %d-question draw", n)
+	}
+	return targets, nil
+}
+
+func largestRemainder(weights map[string]int, order []string, n, totalWeight int) map[string]int {
+	type remainder struct {
+		key   string
+		frac  float64
+		index int
+	}
+
 	targets := make(map[string]int, len(order))
 	remainders := make([]remainder, 0, len(order))
 	assigned := 0
-	for i, d := range order {
-		raw := float64(domainWeights[d]) * float64(n) / float64(totalWeight)
+	for i, k := range order {
+		raw := float64(weights[k]) * float64(n) / float64(totalWeight)
 		floor := int(raw)
-		targets[d] = floor
+		targets[k] = floor
 		assigned += floor
-		remainders = append(remainders, remainder{domain: d, frac: raw - float64(floor), index: i})
-	}
-
-	leftover := n - assigned
-	if leftover < 0 || leftover > len(order) {
-		return nil, fmt.Errorf("exam: domainWeights do not add up cleanly for a %d-question draw", n)
+		remainders = append(remainders, remainder{key: k, frac: raw - float64(floor), index: i})
 	}
 
 	sort.Slice(remainders, func(i, j int) bool {
@@ -666,10 +814,10 @@ func domainTargets(domainWeights map[string]int, order []string, n int) (map[str
 		}
 		return remainders[i].index < remainders[j].index
 	})
-	for i := 0; i < leftover; i++ {
-		targets[remainders[i].domain]++
+	for i := 0; i < n-assigned && i < len(remainders); i++ {
+		targets[remainders[i].key]++
 	}
-	return targets, nil
+	return targets
 }
 
 func shuffle(ids []string, seed, label string) []string {

--- a/facilitator/internal/exam/exam.go
+++ b/facilitator/internal/exam/exam.go
@@ -33,6 +33,9 @@ const (
 
 var tierOrder = []string{TierQuick, TierCore, TierDeep}
 
+// Tiers in the order a breakdown should read: shortest task first.
+func Tiers() []string { return append([]string(nil), tierOrder...) }
+
 // A tier is the time band, not a judgement: the gate checks the label
 // against targetSeconds so it cannot drift into an opinion.
 var tierBounds = map[string][2]int{

--- a/site/index.html
+++ b/site/index.html
@@ -272,7 +272,7 @@
             <div class="exam-card-head">
               <span class="exam-avatar" aria-hidden="true"><svg class="cert-mark" data-cert="CKAD" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M12 3.4l8.2 4.4L12 12.2 3.8 7.8z"/><path d="M3.8 12l8.2 4.4L20.2 12"/><path d="M3.8 16.2l8.2 4.4 8.2-4.4"/></svg></span>
               <div class="exam-card-name">
-                <h4>CKAD Mock Exam 01</h4>
+                <h4>CKAD Mock Exam</h4>
                 <p>Certified Kubernetes Application Developer</p>
               </div>
               <span class="exam-badge exam-badge-live">Live</span>
@@ -282,18 +282,20 @@
               <div><dt>Duration</dt><dd>2h</dd></div>
               <div>
                 <dt>Drawn / pool</dt>
-                <dd>22 <span class="exam-stat-of">/ 26</span></dd>
+                <dd>17 <span class="exam-stat-of">/ 26</span></dd>
               </div>
               <div><dt>To pass</dt><dd>66%</dd></div>
               <div><dt>Engine</dt><dd class="exam-stat-engine">Practical</dd></div>
             </dl>
 
             <p class="exam-desc">
-              22 tasks drawn each attempt from a 26-task pool, across the
+              17 tasks drawn each attempt from a 26-task pool, across the
               full CKAD curriculum: workloads and multi-container design,
               deployments and configuration, security contexts,
-              observability, and services, ingress and network policy. Two
-              instances, kind-backed cluster, Kubernetes 1.35.
+              observability, and services, ingress and network policy. The
+              draw is mixed across three levels, so a sitting is not a wall
+              of long multi-step tasks. Two instances, kind-backed cluster,
+              Kubernetes 1.35.
             </p>
 
             <div class="domains">

--- a/site/index.html
+++ b/site/index.html
@@ -222,10 +222,10 @@
         <h2 id="stats-title" class="sr-only">The numbers behind it</h2>
         <ul class="stat-grid">
           <li class="stat">
-            <p class="stat-figure">123</p>
+            <p class="stat-figure">141</p>
             <h3 class="stat-label">Questions written</h3>
             <p class="stat-note">
-              26 hands-on for CKAD and 97 multiple-choice for KCNA, counted from
+              44 hands-on for CKAD and 97 multiple-choice for KCNA, counted from
               the <code>spec.questions</code> list in each bank's
               <code>exam.yaml</code> file. All original: no third-party exam
               dump may be committed here, because CC BY-SA 4.0 requires the

--- a/tests/bank-weights.sh
+++ b/tests/bank-weights.sh
@@ -7,6 +7,20 @@ import os, re, sys, glob
 
 TOLERANCE = 2.0
 
+# Mirrors facilitator/internal/exam/exam.go tierOrder and tierBounds. A
+# tier is its time band, so the label cannot drift into an opinion.
+TIER_ORDER = ["quick", "core", "deep"]
+TIER_BOUNDS = {"quick": (1, 240), "core": (241, 540), "deep": (541, 840)}
+
+# How far a drawn tier count may sit from its share. The draw spends a
+# domain's exact allocation on whichever tier is furthest behind, so a
+# thin pool shows up here rather than in a candidate's tired afternoon.
+TIER_TOLERANCE = 1
+
+# Bounds on the drawn sitting as a fraction of spec.duration. Under is a
+# bank that wastes the clock; over is one nobody finishes.
+TIME_BAND = (0.85, 1.05)
+
 Q_RE = re.compile(
     r"-\s+id:\s*(?P<id>\S+)\s*\n"
     r"(?:\s+title:\s*.+\n)?"
@@ -22,11 +36,11 @@ failures = []
 def fail(bank, msg):
     failures.append(f"{bank}: {msg}")
 
-def domain_weights(text):
-    """Parse the optional spec.domainWeights block: `  Name: 20` lines
-    under a `domainWeights:` key, ending at the next key at its own
-    indentation or shallower."""
-    m = re.search(r"^(\s*)domainWeights:\s*$", text, re.M)
+def nested_map(text, key):
+    """Parse a `key:` block of `  Name: 20` lines, ending at the next key
+    at its own indentation or shallower. A negative is matched so a typo
+    is caught rather than read as 'absent'."""
+    m = re.search(rf"^(\s*){key}:\s*$", text, re.M)
     if not m:
         return None
     indent = len(m.group(1))
@@ -37,10 +51,31 @@ def domain_weights(text):
         cur = len(line) - len(line.lstrip())
         if cur <= indent:
             break
-        em = re.match(r"\s*(.+?):\s*(\d+)\s*$", line)
+        em = re.match(r"\s*(.+?):\s*(-?\d+)\s*$", line)
         if em:
             out[em.group(1).strip()] = int(em.group(2))
     return out or None
+
+def domain_weights(text):
+    return nested_map(text, "domainWeights")
+
+def difficulty_mix(text):
+    return nested_map(text, "difficultyMix")
+
+def question_extras(text):
+    """The keys that sit below `weight:` — Q_RE stops there on purpose,
+    so read them per question chunk and order-independently."""
+    out = {}
+    chunks = re.split(r"^\s*-\s+id:\s*", text, flags=re.M)[1:]
+    for chunk in chunks:
+        qid = chunk.split("\n", 1)[0].strip()
+        secs = re.search(r"^\s*targetSeconds:\s*(-?\d+)\s*$", chunk, re.M)
+        tier = re.search(r"^\s*difficulty:\s*(\S+)\s*$", chunk, re.M)
+        out[qid] = {
+            "targetSeconds": int(secs.group(1)) if secs else None,
+            "difficulty": tier.group(1) if tier else None,
+        }
+    return out
 
 def exam_length(text):
     """Parse spec.examLength: N, or None when absent. Same parser as
@@ -56,7 +91,8 @@ def domain_targets(weights, order, n):
     checks pool depth against the same numbers a real draw will ask for.
     Copied from tests/bank-mcq.sh rather than shared: these two gates
     are standalone scripts on purpose, and the algorithm is eight lines
-    that the Go implementation is the authority for anyway."""
+    that the Go implementation is the authority for anyway. Also used for
+    spec.difficultyMix, which sums to 100 under the same rule."""
     raw = {d: weights[d] * n / 100 for d in order}
     targets = {d: int(raw[d]) for d in order}
     leftover = n - sum(targets.values())
@@ -64,6 +100,30 @@ def domain_targets(weights, order, n):
     for d in remainders[:leftover]:
         targets[d] += 1
     return targets
+
+def tier_draw(pool_by_domain_tier, order, dom_targets, tier_deficit):
+    """The tier half of exam.go's drawMixed. Each domain spends its exact
+    allocation on whichever tier is furthest behind, and a shortfall
+    carries to the next domain rather than bending the domain split.
+    Which question comes out is seeded; how many of each tier is not —
+    so simulating the counts needs no seed and covers every draw."""
+    got = {t: 0 for t in TIER_ORDER}
+    deficit = dict(tier_deficit)
+    for d in order:
+        left = {t: pool_by_domain_tier.get(d, {}).get(t, 0) for t in TIER_ORDER}
+        for _ in range(dom_targets[d]):
+            best = None
+            for t in TIER_ORDER:
+                if left[t] == 0:
+                    continue
+                if best is None or deficit[t] > deficit[best]:
+                    best = t
+            if best is None:
+                return None
+            left[best] -= 1
+            deficit[best] -= 1
+            got[best] += 1
+    return got
 
 def domain_order(questions):
     """Each distinct domain once, in first-appearance order — what
@@ -75,12 +135,77 @@ def domain_order(questions):
             order.append(q["domain"])
     return order
 
+def duration(text):
+    """spec.duration in seconds. Go duration strings, but banks only ever
+    write minutes or hours, so anything else is treated as unknown rather
+    than guessed at."""
+    m = re.search(r"^\s*duration:\s*(\d+)(m|h)\s*$", text, re.M)
+    if not m:
+        return None
+    return int(m.group(1)) * (60 if m.group(2) == "m" else 3600)
+
+def report_tiers(bank, questions, extras, mix, order, dom_targets, length, clock):
+    pool = {}
+    for q in questions:
+        tier = extras[q["id"]]["difficulty"]
+        pool.setdefault(q["domain"], {}).setdefault(tier, []).append(q["id"])
+
+    want = domain_targets(mix, TIER_ORDER, length)
+    print(f"  levels — {length} drawn as "
+          + ", ".join(f"{want[t]} {t}" for t in TIER_ORDER)
+          + f" (mix {'/'.join(str(mix.get(t, 0)) for t in TIER_ORDER)})")
+    head = "".join(f"{t:>7}" for t in TIER_ORDER)
+    print(f"        {head}   pool  draw  domain")
+    for d in order:
+        cells = "".join(f"{len(pool.get(d, {}).get(t, [])):>7}" for t in TIER_ORDER)
+        held = sum(len(v) for v in pool.get(d, {}).values())
+        print(f"        {cells}   {held:>4}  {dom_targets[d]:>4}  {d}")
+
+    counts = {d: {t: len(ids) for t, ids in tiers.items()} for d, tiers in pool.items()}
+    got = tier_draw(counts, order, dom_targets, want)
+    if got is None:
+        fail(bank, "the draw runs out of questions before it fills a domain — "
+                   "the pool-depth check above should have caught this")
+        return
+    for t in TIER_ORDER:
+        drift = got[t] - want[t]
+        if abs(drift) > TIER_TOLERANCE:
+            fail(bank, f"every draw holds {got[t]} {t} questions, want {want[t]} "
+                       f"(drift {drift:+d}, tolerance {TIER_TOLERANCE}) — "
+                       f"the pool is too thin in {t} for this mix")
+
+    if clock is None:
+        print("        (spec.duration not in minutes or hours — sitting length not checked)")
+        return
+
+    # Which question comes out is seeded, so the honest figure is the mean
+    # of each tier weighted by how many of it every draw takes.
+    spent = 0.0
+    for t in TIER_ORDER:
+        secs = [extras[q["id"]]["targetSeconds"] for q in questions
+                if extras[q["id"]]["difficulty"] == t]
+        if secs:
+            spent += got[t] * sum(secs) / len(secs)
+    ratio = spent / clock
+    lo, hi = TIME_BAND
+    mark = "ok " if lo <= ratio <= hi else "OFF"
+    print(f"  [{mark}] sitting {spent/60:5.1f} min of a {clock//60} min clock "
+          f"({ratio:.0%} — band {lo:.0%}-{hi:.0%})")
+    if not lo <= ratio <= hi:
+        fail(bank, f"a drawn sitting is {spent/60:.1f} min of task time against a "
+                   f"{clock//60} min clock ({ratio:.0%}), outside {lo:.0%}-{hi:.0%}")
+
 for exam_path in sorted(glob.glob("banks/*/exam.yaml")):
     bank_dir = os.path.dirname(exam_path)
     bank = os.path.basename(bank_dir)
     text = open(exam_path, encoding="utf-8").read()
 
     if re.search(r"^\s*examType:\s*mcq\s*$", text, re.M):
+        if difficulty_mix(text) is not None:
+
+            fail(bank, "an mcq bank declares spec.difficultyMix, and the tier gate "
+                       "below only runs for hands-on banks — teach tests/bank-mcq.sh "
+                       "the tiers before shipping this")
         print(f"{bank}: mcq — covered by tests/bank-mcq.sh")
         continue
 
@@ -151,6 +276,40 @@ for exam_path in sorted(glob.glob("banks/*/exam.yaml")):
     for d in sorted(missing):
         fail(bank, f"spec.domainWeights lists {d!r} but no question uses it")
 
+    extras = question_extras(text)
+    mix = difficulty_mix(text)
+
+    if mix is None:
+        for q in questions:
+            if extras.get(q["id"], {}).get("difficulty"):
+                fail(bank, f"{q['id']} declares a difficulty but the bank declares no "
+                           f"spec.difficultyMix to draw against")
+    else:
+        unknown_tiers = [t for t in mix if t not in TIER_BOUNDS]
+        for t in sorted(unknown_tiers):
+            fail(bank, f"spec.difficultyMix names an unknown tier {t!r}, "
+                       f"want one of {', '.join(TIER_ORDER)}")
+        if sum(mix.values()) != 100:
+            fail(bank, f"spec.difficultyMix sums to {sum(mix.values())}, want 100")
+        if not pooled:
+            fail(bank, "spec.difficultyMix is declared but the bank is not pooled, so "
+                       "every attempt asks every question and the mix decides nothing")
+        for q in questions:
+            e = extras.get(q["id"], {})
+            tier, secs = e.get("difficulty"), e.get("targetSeconds")
+            if tier not in TIER_BOUNDS:
+                fail(bank, f"{q['id']} has difficulty {tier!r}; a bank declaring "
+                           f"spec.difficultyMix declares a tier on every question")
+                continue
+            if secs is None:
+                fail(bank, f"{q['id']} is {tier} but sets no targetSeconds; the tier is "
+                           f"the time band, so it cannot be derived from the points")
+                continue
+            lo, hi = TIER_BOUNDS[tier]
+            if not lo <= secs <= hi:
+                fail(bank, f"{q['id']} is {tier} with targetSeconds {secs}, "
+                           f"outside that tier's {lo}-{hi} band")
+
     if pooled:
         order = domain_order(questions)
         targets = domain_targets(weights, order, length)
@@ -164,6 +323,9 @@ for exam_path in sorted(glob.glob("banks/*/exam.yaml")):
             if have < need:
                 fail(bank, f"{d} needs {need} questions for a {length}-question draw, "
                            f"pool has {have}")
+
+        if mix is not None and not [f for f in failures if f.startswith(f"{bank}: ")]:
+            report_tiers(bank, questions, extras, mix, order, targets, length, duration(text))
         continue
 
     print(f"{bank}: {len(questions)} questions, {grand} points")

--- a/tests/check-lint.sh
+++ b/tests/check-lint.sh
@@ -114,6 +114,24 @@ for path in scripts:
                                    f"'command not found', scored as a FAILED check, so a "
                                    f"correct answer loses the points"))
 
+    # evaluate.go awards a check its full points whenever it exits 0, and only
+    # consults the criterion tally when it does not. report() returns
+    # crit_all_passed, so anything after it becomes the script's exit status and
+    # a wholly failed check scores full marks in silence.
+    report_at = [i for i, line in enumerate(lines, 1)
+                 if re.match(r"\s*report\b", line)]
+    if report_at:
+        for i, line in enumerate(lines, 1):
+            if i <= report_at[-1] or not line.strip() or line.strip().startswith("#"):
+                continue
+            errors.append((path, i, "after-report",
+                           f"{line.strip()!r} runs after report(), so it — not report() — "
+                           f"sets the exit status. A check that exits 0 is scored full "
+                           f"marks without its criteria being read, so every criterion "
+                           f"could fail and the candidate would still get the points. "
+                           f"report() must be the last command in the script"))
+            break
+
     for i, line in enumerate(lines, 1):
         stripped = line.strip()
         if stripped.startswith("#"):

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -19,6 +19,19 @@ print(data.get(os.environ["FIELD"], ""))
 '
 }
 
+# A drawn question id from the attempt that is open now. The CKAD pool is deep
+# enough that no particular id is drawn every time, so an assertion that names
+# one by hand fails whenever the draw leaves it out.
+drawn_qid() {
+  req GET /api/exam >/dev/null
+  RESP="$RESP" python3 -c '
+import json, os
+with open(os.environ["RESP"]) as f:
+    qs = json.load(f).get("questions", [])
+print(qs[0]["id"] if qs else "")
+'
+}
+
 bash tests/bank-weights.sh || fail "bank weights are out of balance"
 bash tests/check-lint.sh || fail "validate.d checks have brittle idioms"
 bash tests/check-lib.sh || fail "banks/_lib/checks.sh helpers are broken"
@@ -308,7 +321,8 @@ rem2=$(json_field remainingSeconds)
 status=$(req GET /desktop/vnc.html)
 [ "$status" = "200" ] || fail "desktop should be 200 while running, got $status"
 
-status=$(req GET /api/questions/q01/solution)
+gated_qid=$(drawn_qid)
+status=$(req GET /api/questions/${gated_qid}/solution)
 [ "$status" = "403" ] || fail "solution should still be 403 while the session is running, got $status"
 
 ./sim grade | tee /tmp/grade0.txt
@@ -382,10 +396,6 @@ with open(os.environ["RESP"]) as f:
 drawn_n=$(printf '%s' "$drawn_ids" | wc -w | tr -d ' ')
 [ "$drawn_n" = "$declared" ] \
   || fail "a running attempt should ask the declared ${declared} of ${pool}, got ${drawn_n}"
-case " $drawn_ids " in
-  *" q01 "*) ;;
-  *) fail "q01 was not drawn; the gate assertions below name it by id" ;;
-esac
 
 solve_bank ckad-mock-01
 
@@ -430,7 +440,7 @@ for q in data.get("questions", []):
   [ "$passed" = "True" ] || fail "facilitator results: passed should be true, got ${passed}"
 fi
 
-status=$(req GET /api/questions/q01/solution)
+status=$(req GET /api/questions/${gated_qid}/solution)
 [ "$status" = "200" ] || fail "solution should be 200 once the session has ended, got $status"
 
 status=$(req GET /desktop/vnc.html)
@@ -747,11 +757,12 @@ status=$(start_session '{"mode":"training"}')
 training_seed=$(json_field seed)
 [ -n "$training_seed" ] || fail "training: the attempt reported no seed"
 
-[ "$(req GET /api/questions/q01/hints/1)" = "200" ] || fail "training: hint 1 not served"
+training_qid=$(drawn_qid)
+[ "$(req GET /api/questions/${training_qid}/hints/1)" = "200" ] || fail "training: hint 1 not served"
 [ -n "$(json_field markdown)" ] || fail "training: hint 1 is empty"
-[ "$(req GET /api/questions/q01/hints/99)" = "404" ] || fail "training: out-of-range hint should 404"
+[ "$(req GET /api/questions/${training_qid}/hints/99)" = "404" ] || fail "training: out-of-range hint should 404"
 
-[ "$(req GET /api/questions/q01/solution)" = "200" ] \
+[ "$(req GET /api/questions/${training_qid}/solution)" = "200" ] \
   || fail "training: solutions should be readable during a training attempt"
 
 [ "$(req POST /api/session/grade)" = "200" ] || fail "training: mid-attempt grade failed"
@@ -761,7 +772,7 @@ training_seed=$(json_field seed)
   || fail "training: a practice grade must not be recorded as a result"
 
 curl -s -o "$RESP" -w '%{http_code}' -X POST -H 'Content-Type: application/json' \
-  -d '{"question":"q01"}' "${BASE}/api/control/reseed" > /tmp/smoke-reseed.txt
+  -d "{\"question\":\"${training_qid}\"}" "${BASE}/api/control/reseed" > /tmp/smoke-reseed.txt
 [ "$(cat /tmp/smoke-reseed.txt)" = "200" ] \
   || fail "training: reseed expected 200, got $(cat /tmp/smoke-reseed.txt)"
 curl -s -o "$RESP" -w '%{http_code}' -X POST -H 'Content-Type: application/json' \
@@ -778,13 +789,14 @@ status=$(start_session "{\"seed\":\"${training_seed}\"}")
   || fail "exam-gate: replayed seed ${training_seed}, got '$(json_field seed)'"
 if [ "$status" = "200" ]; then
   [ "$(json_field mode)" = "exam" ] || fail "exam-gate: mode is '$(json_field mode)', want exam"
-  [ "$(req GET /api/questions/q01/hints/1)" = "403" ] || fail "exam-gate: hints must be 403 in an exam"
-  [ "$(req GET /api/questions/q01/solution)" = "403" ] || fail "exam-gate: solutions must be 403 mid-exam"
+  exam_qid=$(drawn_qid)
+  [ "$(req GET /api/questions/${exam_qid}/hints/1)" = "403" ] || fail "exam-gate: hints must be 403 in an exam"
+  [ "$(req GET /api/questions/${exam_qid}/solution)" = "403" ] || fail "exam-gate: solutions must be 403 mid-exam"
 
   [ "$(req GET /api/exam/tips)" = "200" ] || fail "exam-gate: tips must stay readable mid-exam"
   [ "$(req POST /api/session/grade)" = "403" ] || fail "exam-gate: mid-attempt scoring must be 403 in an exam"
   curl -s -o "$RESP" -w '%{http_code}' -X POST -H 'Content-Type: application/json' \
-    -d '{"question":"q01"}' "${BASE}/api/control/reseed" > /tmp/smoke-reseed-exam.txt
+    -d "{\"question\":\"${exam_qid}\"}" "${BASE}/api/control/reseed" > /tmp/smoke-reseed-exam.txt
   [ "$(cat /tmp/smoke-reseed-exam.txt)" = "403" ] \
     || fail "exam-gate: reseed must be 403 in an exam, got $(cat /tmp/smoke-reseed-exam.txt)"
 fi

--- a/tests/solutions/ckad-mock-01/q27.sh
+++ b/tests/solutions/ckad-mock-01/q27.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl apply -f - <<'EOF'
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: container-defaults
+  namespace: fornax
+spec:
+  limits:
+    - type: Container
+      defaultRequest:
+        cpu: 100m
+        memory: 128Mi
+      default:
+        cpu: 500m
+        memory: 256Mi
+EOF
+
+kubectl -n fornax delete pod unspecified --ignore-not-found >/dev/null
+kubectl apply -f - <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: unspecified
+  namespace: fornax
+spec:
+  containers:
+    - name: app
+      image: nginx:1.29-alpine
+EOF
+kubectl -n fornax wait --for=condition=Ready pod/unspecified --timeout=180s
+
+kubectl -n fornax get pod unspecified \
+  -o jsonpath='{.spec.containers[?(@.name=="app")].resources.requests.cpu}' \
+  > /opt/course/27/cpu-request

--- a/tests/solutions/ckad-mock-01/q28.sh
+++ b/tests/solutions/ckad-mock-01/q28.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl -n equuleus create secret docker-registry registry-cred \
+  --docker-server=registry:5000 \
+  --docker-username=pipeline \
+  --docker-password=s3cr3t-pull \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl apply -f - <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: puller
+  namespace: equuleus
+spec:
+  imagePullSecrets:
+    - name: registry-cred
+  containers:
+    - name: web
+      image: nginx:1.29-alpine
+EOF
+kubectl -n equuleus wait --for=condition=Ready pod/puller --timeout=180s

--- a/tests/solutions/ckad-mock-01/q29.sh
+++ b/tests/solutions/ckad-mock-01/q29.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+base=/apis/flags.kubestronaut.dev/v1alpha1/namespaces/sextans/featuretoggles
+
+kubectl get crd -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+  | grep '^featuretoggles\.' > /opt/course/29/crd-name
+
+kubectl get --raw "$base" \
+  | jq -r '[.items[].metadata.name] | map(select(. != "dark-mode")) | first' \
+  > /opt/course/29/existing-toggle
+
+kubectl apply -f - <<'EOF'
+apiVersion: flags.kubestronaut.dev/v1alpha1
+kind: FeatureToggle
+metadata:
+  name: dark-mode
+  namespace: sextans
+spec:
+  enabled: true
+  rollout: 25
+  owner: platform-team
+EOF
+kubectl get --raw "$base/dark-mode" >/dev/null

--- a/tests/solutions/ckad-mock-01/q30.sh
+++ b/tests/solutions/ckad-mock-01/q30.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl -n crater create serviceaccount report-reader \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n crater create role configmap-reader \
+  --verb=get --verb=list --verb=watch --resource=configmaps \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n crater create rolebinding report-reader-binding \
+  --role=configmap-reader --serviceaccount=crater:report-reader \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl delete clusterrolebinding report-reader-legacy --ignore-not-found

--- a/tests/solutions/ckad-mock-01/q31.sh
+++ b/tests/solutions/ckad-mock-01/q31.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl -n pyxis rollout pause deploy/feed-api
+kubectl -n pyxis set image deploy/feed-api api=nginx:1.29-alpine
+
+kubectl -n pyxis get rs -o name | wc -l | tr -d '[:space:]' \
+  > /opt/course/31/replicasets-while-paused
+
+kubectl -n pyxis rollout resume deploy/feed-api
+kubectl -n pyxis rollout status deploy/feed-api --timeout=180s

--- a/tests/solutions/ckad-mock-01/q32.sh
+++ b/tests/solutions/ckad-mock-01/q32.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl -n sagitta rollout restart deploy/session-store
+kubectl -n sagitta rollout status deploy/session-store --timeout=180s

--- a/tests/solutions/ckad-mock-01/q33.sh
+++ b/tests/solutions/ckad-mock-01/q33.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl -n lupus apply -f - <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: search-canary
+  namespace: lupus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: search
+      track: canary
+  template:
+    metadata:
+      labels:
+        app: search
+        track: canary
+    spec:
+      containers:
+        - name: web
+          image: nginx:1.29-alpine
+          ports:
+            - containerPort: 80
+EOF
+
+kubectl -n lupus scale deploy/search-stable --replicas=4
+kubectl -n lupus rollout status deploy/search-canary --timeout=180s
+kubectl -n lupus rollout status deploy/search-stable --timeout=180s

--- a/tests/solutions/ckad-mock-01/q34.sh
+++ b/tests/solutions/ckad-mock-01/q34.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cat > /opt/course/34/cache-values.yaml <<'EOF'
+replicaCount: 3
+image:
+  tag: 1.27-alpine
+EOF
+
+helm -n caelum upgrade --install object-cache sim/sim-cache \
+  -f /opt/course/34/cache-values.yaml --wait --timeout 3m
+
+kubectl -n caelum rollout status deploy/object-cache --timeout=180s

--- a/tests/solutions/ckad-mock-01/q35.sh
+++ b/tests/solutions/ckad-mock-01/q35.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cat > /opt/course/35/overlays/prod/kustomization.yaml <<'EOF'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ledger-api
+      spec:
+        template:
+          spec:
+            containers:
+              - name: api
+                env:
+                  - name: LEDGER_MODE
+                    value: prod
+                readinessProbe:
+                  initialDelaySeconds: 5
+EOF
+
+kubectl kustomize /opt/course/35/overlays/prod >/dev/null
+kubectl -n norma apply -k /opt/course/35/overlays/prod
+kubectl -n norma rollout status deploy/ledger-api --timeout=180s

--- a/tests/solutions/ckad-mock-01/q36.sh
+++ b/tests/solutions/ckad-mock-01/q36.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl -n octans apply -f - <<'EOF'
+apiVersion: v1
+kind: Service
+metadata:
+  name: catalog
+  namespace: octans
+spec:
+  type: ExternalName
+  externalName: catalog.mensa.svc.cluster.local
+EOF
+
+out=""
+for _ in $(seq 1 20); do
+  out=$(kubectl -n octans exec deploy/shopfront -- \
+    curl -s -m 5 http://catalog/ 2>/dev/null) || true
+  printf '%s' "$out" | grep -q 'catalog-mensa' && break
+  sleep 3
+done
+printf '%s' "$out" | grep -o 'catalog-mensa' | head -1 > /opt/course/36/catalog-check

--- a/tests/solutions/ckad-mock-01/q37.sh
+++ b/tests/solutions/ckad-mock-01/q37.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+openssl req -x509 -nodes -newkey rsa:2048 -days 365 \
+  -keyout /opt/course/37/tls.key \
+  -out    /opt/course/37/tls.crt \
+  -subj   '/CN=sculptor.sim.local' \
+  -addext 'subjectAltName=DNS:sculptor.sim.local' >/dev/null 2>&1
+
+kubectl -n sculptor create secret tls portal-tls \
+  --cert=/opt/course/37/tls.crt --key=/opt/course/37/tls.key \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n sculptor apply -f - <<'EOF'
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: portal-https
+  namespace: sculptor
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - sculptor.sim.local
+      secretName: portal-tls
+  rules:
+    - host: sculptor.sim.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: portal
+                port:
+                  number: 80
+EOF
+
+ip=$(kubectl -n ingress-nginx get svc ingress-nginx-controller -o jsonpath='{.spec.clusterIP}')
+out=""
+for _ in $(seq 1 20); do
+  out=$(kubectl -n sculptor exec deploy/portal -- \
+    curl -sk -m 5 --resolve "sculptor.sim.local:443:${ip}" \
+    https://sculptor.sim.local/ 2>/dev/null) || true
+  printf '%s' "$out" | grep -q 'portal-ok' && break
+  sleep 3
+done
+printf '%s' "$out" | grep -q 'portal-ok'

--- a/tests/solutions/ckad-mock-01/q38.sh
+++ b/tests/solutions/ckad-mock-01/q38.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl -n reticulum apply -f - <<'EOF'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: reticulum
+spec:
+  podSelector: {}
+  policyTypes: [Ingress]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-teller
+  namespace: reticulum
+spec:
+  podSelector:
+    matchLabels: {role: ledger}
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels: {role: teller}
+      ports:
+        - {protocol: TCP, port: 80}
+EOF
+
+ip=$(kubectl -n reticulum get pod -l role=ledger \
+  -o jsonpath='{.items[?(@.status.phase=="Running")].status.podIP}' | awk '{print $1}')
+
+# Calico needs a moment to program the deny; wait for it rather than racing it.
+for _ in $(seq 1 15); do
+  if kubectl -n reticulum exec deploy/auditor -- curl -s -m 3 -o /dev/null "http://${ip}:80" 2>/dev/null; then
+    sleep 2
+  else
+    break
+  fi
+done
+
+kubectl -n reticulum exec deploy/teller -- curl -s -m 5 -o /dev/null "http://${ip}:80"

--- a/tests/solutions/ckad-mock-01/q39.sh
+++ b/tests/solutions/ckad-mock-01/q39.sh
@@ -23,8 +23,10 @@ for _ in $(seq 1 20); do
 done
 
 kubectl -n telescopium get endpointslice -l kubernetes.io/service-name=shard -o json \
-  | jq -r '[.items[].endpoints[]? | select(.conditions.ready == true) | .addresses[]?] | unique | .[]' \
-  > /opt/course/39/shard-addresses
+  | jq -r '[.items[].endpoints[]?
+            | select(.conditions.ready == true)
+            | .targetRef.name + ".shard.telescopium.svc.cluster.local"] | unique | .[]' \
+  > /opt/course/39/shard-names
 
 out=""
 for _ in $(seq 1 10); do

--- a/tests/solutions/ckad-mock-01/q39.sh
+++ b/tests/solutions/ckad-mock-01/q39.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl -n telescopium apply -f - <<'EOF'
+apiVersion: v1
+kind: Service
+metadata:
+  name: shard
+  namespace: telescopium
+spec:
+  clusterIP: None
+  selector:
+    app: shard
+  ports:
+    - port: 80
+      targetPort: 80
+EOF
+
+for _ in $(seq 1 20); do
+  n=$(kubectl -n telescopium get endpointslice -l kubernetes.io/service-name=shard -o json \
+    | jq '[.items[].endpoints[]? | select(.conditions.ready == true)] | length')
+  [ "$n" = "3" ] && break
+  sleep 3
+done
+
+kubectl -n telescopium get endpointslice -l kubernetes.io/service-name=shard -o json \
+  | jq -r '[.items[].endpoints[]? | select(.conditions.ready == true) | .addresses[]?] | unique | .[]' \
+  > /opt/course/39/shard-addresses
+
+out=""
+for _ in $(seq 1 10); do
+  out=$(kubectl -n telescopium exec shard-0 -- \
+    curl -s -m 5 http://shard-2.shard.telescopium.svc.cluster.local/ 2>/dev/null) || true
+  printf '%s' "$out" | grep -q 'shard-2' && break
+  sleep 3
+done
+printf '%s' "$out" | grep -q 'shard-2'

--- a/tests/solutions/ckad-mock-01/q40.sh
+++ b/tests/solutions/ckad-mock-01/q40.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl apply -f - <<'EOF'
+apiVersion: v1
+kind: Service
+metadata:
+  name: ledger
+  namespace: cepheus
+spec:
+  clusterIP: None
+  selector:
+    app: ledger
+  ports:
+    - port: 80
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ledger
+  namespace: cepheus
+spec:
+  serviceName: ledger
+  replicas: 2
+  selector:
+    matchLabels: {app: ledger}
+  template:
+    metadata:
+      labels: {app: ledger}
+    spec:
+      containers:
+        - name: ledger
+          image: busybox:1.37
+          command: ["sh", "-c", "sleep 86400"]
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 128Mi
+EOF
+kubectl -n cepheus rollout status statefulset ledger --timeout=300s
+
+for p in ledger-0 ledger-1; do
+  kubectl -n cepheus exec "$p" -- sh -c "echo $p > /data/owner"
+done
+
+kubectl -n cepheus get pvc -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+  > /opt/course/40/claims

--- a/tests/solutions/ckad-mock-01/q41.sh
+++ b/tests/solutions/ckad-mock-01/q41.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pending=$(kubectl -n columba get pod \
+  -o jsonpath='{range .items[?(@.status.phase=="Pending")]}{.metadata.name}{"\n"}{end}' | head -1)
+printf '%s\n' "$pending" > /opt/course/41/pod-name
+
+{
+  kubectl -n columba get events --field-selector "involvedObject.name=${pending}" \
+    -o jsonpath='{range .items[*]}{.reason}{": "}{.message}{"\n"}{end}' 2>/dev/null || true
+  kubectl -n columba describe pod "$pending" 2>/dev/null || true
+} > /opt/course/41/reason
+
+kubectl -n columba delete pod "$pending" --wait=true --timeout=120s
+kubectl -n columba apply -f - <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: archive-indexer
+  namespace: columba
+  labels: {app: archive-indexer}
+spec:
+  containers:
+    - name: indexer
+      image: busybox:1.37
+      command: ["sh", "-c", "sleep 86400"]
+      resources:
+        requests:
+          memory: 64Mi
+EOF
+kubectl -n columba wait --for=condition=Ready pod/archive-indexer --timeout=120s

--- a/tests/solutions/ckad-mock-01/q42.sh
+++ b/tests/solutions/ckad-mock-01/q42.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+kubectl -n antlia get deploy \
+  --sort-by=.spec.replicas \
+  -o custom-columns='NAME:.metadata.name,REPLICAS:.spec.replicas,IMAGE:.spec.template.spec.containers[0].image' \
+  > /opt/course/42/report
+cat /opt/course/42/report

--- a/tests/solutions/ckad-mock-01/q43.sh
+++ b/tests/solutions/ckad-mock-01/q43.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Capture the evidence before the repair: fixing the probe rolls the Pods that
+# carry these events out of existence.
+{
+  kubectl -n horologium describe pod -l app=session-store 2>/dev/null || true
+  kubectl -n horologium get events --field-selector reason=Unhealthy \
+    -o jsonpath='{range .items[*]}{.reason}{": "}{.message}{"\n"}{end}' 2>/dev/null || true
+} > /opt/course/43/evidence
+
+kubectl -n horologium patch deploy session-store -p '{
+  "spec": {"template": {"spec": {"containers": [
+    {"name": "store", "livenessProbe": {"httpGet": {"path": "/", "port": 80}}}
+  ]}}}
+}'
+kubectl -n horologium rollout status deploy/session-store --timeout=180s

--- a/tests/solutions/ckad-mock-01/q44.sh
+++ b/tests/solutions/ckad-mock-01/q44.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The seeded Job normally reaches its terminal condition inside setup.sh; wait
+# again here so the reference run does not race a slow cluster.
+for _ in $(seq 1 20); do
+  state=$(kubectl -n eridanus get job ledger-reconcile \
+    -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null || true)
+  if [ "${state:-}" = "True" ]; then break; fi
+  sleep 3
+done
+
+kubectl -n eridanus get job ledger-reconcile \
+  -o jsonpath='{.status.conditions[?(@.type=="Failed")].reason}' > /opt/course/44/reason
+echo >> /opt/course/44/reason
+
+{
+  kubectl -n eridanus logs -l batch.kubernetes.io/job-name=ledger-reconcile --tail=-1 2>/dev/null || true
+  kubectl -n eridanus logs -l job-name=ledger-reconcile --tail=-1 2>/dev/null || true
+} > /opt/course/44/failure.log
+
+kubectl -n eridanus delete job ledger-reconcile --wait=true --timeout=120s
+kubectl -n eridanus apply -f - <<'EOF'
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ledger-reconcile
+  namespace: eridanus
+spec:
+  completions: 4
+  parallelism: 2
+  backoffLimit: 4
+  activeDeadlineSeconds: 120
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: reconcile
+          image: busybox:1.37
+          command: ["sh", "-c", "echo reconciled"]
+          resources:
+            requests: {memory: 16Mi, cpu: 10m}
+EOF
+kubectl -n eridanus wait --for=condition=Complete job/ledger-reconcile --timeout=180s

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -99,6 +99,7 @@ export interface ExamInfo {
   environment?: ExamEnvironment;
 
   hasTips?: boolean;
+  levelMixed?: boolean;
 }
 
 export interface ExamEnvironment {

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -175,6 +175,13 @@ export interface DomainResult {
   questionCount: number;
 }
 
+export interface LevelResult {
+  level: string;
+  earned: number;
+  total: number;
+  questionCount: number;
+}
+
 export interface QuestionResult {
   id: string;
 
@@ -215,6 +222,7 @@ export interface Results {
   questions: QuestionResult[];
 
   domains?: DomainResult[];
+  levels?: LevelResult[];
 
   mode?: SessionMode;
   seed?: string;

--- a/ui/src/components/LevelBreakdown.test.tsx
+++ b/ui/src/components/LevelBreakdown.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { LevelBreakdown } from "./LevelBreakdown";
+import type { LevelResult } from "../api";
+
+const level = (l: string, earned: number, total: number, n = 1): LevelResult => ({
+  level: l,
+  earned,
+  total,
+  questionCount: n,
+});
+
+describe("level breakdown", () => {
+  test("renders nothing for a bank that declares no levels", () => {
+    const { container } = render(<LevelBreakdown levels={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test("renders nothing when only one level was drawn — there is no shape to read", () => {
+    const { container } = render(<LevelBreakdown levels={[level("core", 4, 8, 2)]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test("keeps the rows in tier order even when the shortest tasks scored worst", () => {
+    render(
+      <LevelBreakdown
+        levels={[level("quick", 0, 10, 2), level("core", 5, 10, 2), level("deep", 10, 10, 2)]}
+      />,
+    );
+    const names = screen.getAllByRole("listitem").map((li) => li.textContent ?? "");
+    expect(names[0]).toMatch(/Quick/);
+    expect(names[1]).toMatch(/Core/);
+    expect(names[2]).toMatch(/Deep/);
+  });
+
+  test("names pacing when the score falls away as the tasks get longer", () => {
+    render(<LevelBreakdown levels={[level("quick", 10, 10, 2), level("deep", 3, 10, 2)]} />);
+    expect(screen.getByText(/falls away as the tasks get longer/)).toBeInTheDocument();
+    expect(screen.queryByText(/holds up across short and long tasks/)).not.toBeInTheDocument();
+  });
+
+  test("says length is not the problem when the score holds across levels", () => {
+    render(<LevelBreakdown levels={[level("quick", 5, 10, 2), level("deep", 5, 10, 2)]} />);
+    expect(screen.getByText(/holds up across short and long tasks/)).toBeInTheDocument();
+    expect(screen.queryByText(/falls away as the tasks get longer/)).not.toBeInTheDocument();
+  });
+
+  test("shows each level's percent and its task and point counts", () => {
+    render(<LevelBreakdown levels={[level("quick", 9, 10, 3), level("deep", 2, 10, 2)]} />);
+    expect(screen.getByText("90%")).toBeInTheDocument();
+    expect(screen.getByText("20%")).toBeInTheDocument();
+    expect(screen.getByText(/3 tasks · 9\/10 pts/)).toBeInTheDocument();
+    expect(screen.getByText(/2 tasks · 2\/10 pts/)).toBeInTheDocument();
+  });
+
+  test("ignores a level that carries no points rather than dividing by zero", () => {
+    render(<LevelBreakdown levels={[level("quick", 5, 10, 2), level("core", 0, 0, 0), level("deep", 5, 10, 2)]} />);
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+  });
+});

--- a/ui/src/components/LevelBreakdown.tsx
+++ b/ui/src/components/LevelBreakdown.tsx
@@ -1,0 +1,49 @@
+import type { LevelResult } from "../api";
+import { strings } from "../strings";
+
+interface LevelBreakdownProps {
+  levels?: LevelResult[];
+}
+
+function percentOf(earned: number, total: number): number {
+  return total > 0 ? Math.round((earned / total) * 100) : 0;
+}
+
+// Reads the shape rather than the ranking, so the rows stay in tier order: the
+// useful signal is whether the score falls away as the tasks get longer.
+export function LevelBreakdown({ levels }: LevelBreakdownProps) {
+  const rows = (levels ?? []).filter((l) => l.total > 0);
+  if (rows.length < 2) return null;
+
+  const scored = rows.map((l) => ({ ...l, percent: percentOf(l.earned, l.total) }));
+  const slumped = scored[0].percent - scored[scored.length - 1].percent >= 20;
+
+  return (
+    <section className="domain-breakdown level-breakdown">
+      <h2>{strings.score.levelTitle}</h2>
+      <p className="domain-hint">{strings.score.levelHint}</p>
+      <ul className="domain-rows">
+        {scored.map((l) => (
+          <li key={l.level} className="domain-row">
+            <div className="domain-row-head">
+              <span className="domain-name">
+                {strings.score.levelNames[l.level] ?? l.level}
+              </span>
+              <span className="domain-figure">{strings.score.percentValue(l.percent)}</span>
+            </div>
+
+            <span className="domain-bar" aria-hidden="true">
+              <span className="domain-bar-fill" style={{ width: `${l.percent}%` }} />
+            </span>
+            <span className="domain-meta">
+              {strings.score.levelMeta(l.questionCount, l.earned, l.total)}
+            </span>
+          </li>
+        ))}
+      </ul>
+      <p className="domain-hint level-verdict">
+        {slumped ? strings.score.levelSlump : strings.score.levelFlat}
+      </p>
+    </section>
+  );
+}

--- a/ui/src/screens/Mode.test.tsx
+++ b/ui/src/screens/Mode.test.tsx
@@ -242,6 +242,18 @@ describe("what the exam will ask", () => {
     expect(await screen.findByText(/2 drawn at random from 3/)).toBeInTheDocument();
   });
 
+  test("a level-mixed bank says so, and one without a mix does not claim it", async () => {
+    exam = { ...ckad, questionCount: 2, levelMixed: true };
+    const { unmount } = renderMode();
+    expect(await screen.findByText(/mixed across three levels/)).toBeInTheDocument();
+    unmount();
+
+    exam = { ...ckad, questionCount: 2 };
+    renderMode();
+    expect(await screen.findByText(/2 drawn at random from 3/)).toBeInTheDocument();
+    expect(screen.queryByText(/mixed across three levels/)).not.toBeInTheDocument();
+  });
+
   test("the chips come from the declared curriculum, not from the drawn questions", async () => {
     renderMode();
     const chip = await screen.findByRole("button", { name: /Application Design and Build/ });

--- a/ui/src/screens/Mode.tsx
+++ b/ui/src/screens/Mode.tsx
@@ -180,7 +180,9 @@ function DrawPanel({ exam, selected, onSelect }: DrawPanelProps) {
           {selected.length > 0
             ? strings.mode.drawNarrowed(drawn, pool, selected.length)
             : pooled
-              ? strings.mode.drawPooled(drawn, pool)
+              ? exam.levelMixed
+                ? strings.mode.drawPooledMixed(drawn, pool)
+                : strings.mode.drawPooled(drawn, pool)
               : strings.mode.drawAll(drawn)}
         </p>
       </div>

--- a/ui/src/screens/Score.tsx
+++ b/ui/src/screens/Score.tsx
@@ -8,6 +8,7 @@ import {
   type SessionMode,
 } from "../api";
 import { DomainBreakdown } from "../components/DomainBreakdown";
+import { LevelBreakdown } from "../components/LevelBreakdown";
 import { ExamTips } from "../components/ExamTips";
 import { PendingBar } from "../components/Pending";
 import { ResultsBanner } from "../components/ResultsBanner";
@@ -139,6 +140,7 @@ export function Score({ onNewAttempt, endReason, mode }: ScoreProps) {
               domains={results.domains}
               passingScore={results.passingScore}
             />
+            <LevelBreakdown levels={results.levels} />
             <NextSession
               results={results}
               starting={starting}

--- a/ui/src/strings.ts
+++ b/ui/src/strings.ts
@@ -758,6 +758,22 @@ export const strings = {
       points: number,
     ) => `${weight}% of exam · ${count} of ${total} tasks · ${earned}/${points} pts`,
 
+    levelTitle: "By task length",
+    levelHint:
+      "The same attempt cut by how long each task was meant to take. Levels are time bands, not a judgement of how clever a task is.",
+    levelNames: {
+      quick: "Quick — up to 4 min",
+      core: "Core — 4 to 9 min",
+      deep: "Deep — 9 to 14 min",
+    } as Record<string, string>,
+    levelMeta: (count: number, earned: number, points: number) =>
+      `${count} ${count === 1 ? "task" : "tasks"} · ${earned}/${points} pts`,
+
+    levelSlump:
+      "Your score falls away as the tasks get longer. That is usually pacing rather than missing knowledge — the fix is to plan a long task into steps before you start typing, not to read more.",
+    levelFlat:
+      "Your score holds up across short and long tasks, so length is not what is costing you.",
+
     domainBelow: "below threshold",
     domainUnknown: "Unclassified",
 

--- a/ui/src/strings.ts
+++ b/ui/src/strings.ts
@@ -116,6 +116,8 @@ export const strings = {
     drawTitle: "What you'll be asked",
     drawPooled: (drawn: number, pool: number) =>
       `${drawn} drawn at random from ${pool}, weighted to the published domain split. A different set every attempt.`,
+    drawPooledMixed: (drawn: number, pool: number) =>
+      `${drawn} drawn at random from ${pool}, weighted to the published domain split and mixed across three levels, so a sitting is not a wall of long tasks. A different set every attempt.`,
     drawAll: (n: number) =>
       `All ${n}, every attempt. This bank has no larger pool behind it yet, so the set does not change between sessions.`,
 

--- a/ui/src/theme.css
+++ b/ui/src/theme.css
@@ -2689,6 +2689,10 @@ button.nav-menu-item:hover {
   color: var(--text-muted);
 }
 
+.level-verdict {
+  margin-top: var(--space-4);
+}
+
 .domain-rows {
   list-style: none;
   margin: var(--space-4) 0 0;


### PR DESCRIPTION
Grows the CKAD bank from 26 questions to 44, draws 17 of them per attempt
instead of 22, and adds a second axis to the draw so a sitting holds a
deliberate mix of levels rather than whatever the shuffle produced.

Verifying it against a live cluster then turned up a set of grading bugs, most
of which predate this branch. Those are the second half of the diff.

## Why the pool, not a second bank

The bank was pooled only nominally. `bank-weights.sh` on `main` prints it:

```
ckad-mock-01: 26 questions, 217 points (pooled — every attempt draws 22)
  [ok ] pool   6  draw   6  Application Environment, Configuration and Security
  [ok ] pool   5  draw   5  Application Deployment
  [ok ] pool   4  draw   4  Services and Networking
  [ok ] pool   7  draw   4  Application Design and Build
  [ok ] pool   4  draw   3  Application Observability and Maintenance
```

Three of the five domains were asked in full every attempt, and 15 of the 22
questions were identical every sitting. A second CKAD bank would have halved
what each attempt drew from and refrozen the same domains; it would also have
rendered two identical cards, since `Exams.tsx` builds the heading from
`certification`, and left `trackCount` at 5 against 6 exams.

Dropping to 17 alone ends the frozen domains — no domain is drawn in full any
more — and 17 is the midpoint of the real exam's 15–20 tasks.

## The level axis

`spec.difficultyMix` opts a pooled bank into a second stratification, and each
question declares `quick`, `core` or `deep`.

**A tier is a time band, not an opinion**: `quick` is at most 240s, `core`
241–540, `deep` 541–840, and `exam.Load` refuses a bank whose label and
`targetSeconds` disagree. A subjective label rots; a budget does not.

The domain split stays a hard constraint and the mix a soft one. Each domain
spends its exact allocation on whichever tier is furthest behind, and any
shortfall carries to the next domain rather than bending the split —
`spec.domainWeights` is the promise `Results.Finalize` weights a real score by.

One consequence is worth knowing: **the tier composition of a draw does not
depend on the seed.** Only the deficit and what each domain holds decide which
tier is spent next, so the mix is guaranteed rather than likely, and one
simulation covers every possible draw. That is why `bank-weights.sh` can gate
it exactly instead of sampling.

```
ckad-mock-01: 44 questions, 360 points (pooled — every attempt draws 17)
  levels — 17 drawn as 5 quick, 8 core, 4 deep (mix 30/45/25)
          quick   core   deep   pool  draw  domain
              2      5      3     10     4  App Environment, Configuration and Security
              3      5      2     10     4  Application Deployment
              2      4      2      8     3  Services and Networking
              3      2      3      8     3  Application Design and Build
              2      4      2      8     3  App Observability and Maintenance
  [ok ] sitting 115.2 min of a 120 min clock (96% — band 85%-105%)
```

200 consecutive draws produced 200 distinct question sets. The 26-question bank
had about 140 possible in total.

## Reading the result back

Mixing the draw fixed the *input*. On its own it did nothing for the
*feedback*, and that is where the fatigue argument actually pays off: a
candidate could already see which domains they were weak in, but not whether
they lost points to gaps in knowledge or to running out of road on the long
tasks — and those two want completely different practice.

`GET /api/results` now carries the same score rolled up by tier, and the score
screen renders it under the domain breakdown:

```
By task length
  Quick — up to 4 min    100%    2 tasks · 18/18 pts
  Core — 4 to 9 min      100%    5 tasks · 45/45 pts
  Deep — 9 to 14 min       0%    3 tasks · 0/27 pts

  Your score falls away as the tasks get longer. That is usually pacing
  rather than missing knowledge — the fix is to plan a long task into
  steps before you start typing, not to read more.
```

The rows stay in **tier order rather than sorted by score**, because the shape
is the whole signal. That output is from a real attempt that solved every quick
and core question and left the deep ones alone.

Still nothing mid-attempt: a question labelled `deep` on screen would only tell
someone to brace. A bank that declares no tiers gets no breakdown at all rather
than one bucket labelled with the empty string, so `kcna-mock` is untouched.

## The 18 new questions

Written from the curriculum to close what the bank lacked: CRD discovery, RBAC
graded on what a ServiceAccount may *not* do, LimitRange defaults, a
dockerconfigjson pull secret, rollout pause/resume, rollout restart, a
proportional canary, a Helm values-file install, a Kustomize patch rather than a
transformer, ExternalName, Ingress TLS termination, default-deny NetworkPolicy
composition, a headless Service, a StatefulSet with `volumeClaimTemplates`,
`FailedScheduling` events, custom-column reporting, liveness-probe diagnosis,
and a Job that exhausts its `backoffLimit`.

Every question's points were re-derived for the bigger pool, flat per domain, so
every domain lands within 0.6pp of its curriculum weight.

## Grading bugs found by running it

None of this is reachable from CI, which never boots a cluster.

**A three-point check had been awarding full marks unconditionally.**
`q11/10_uninstalled.sh` ended with an `echo` after `report()`. `evaluate.go`
awards a check its full points whenever it exits 0 and only reads the criterion
tally when it does not, so the `echo` — not `report()` — set the exit status,
and both criteria had been failing and printing their failure messages while the
check scored 3/3 ever since scored criteria were retrofitted in `53432fe`.
`check-lint` grows an `after-report` rule so nothing can end that way again.

**25 of 360 points were scored by doing nothing**, against a rule
`CONTRIBUTING.md` states and `smoke.sh` asserts. Four shapes:

- an **absence** nothing was there to have — `negate` around an `exec` into a
  Pod that does not exist
- a **state the seed already provided** — "3 replicas ready", "the release is
  deployed"
- a **universal over an empty set** — `[ "$live" = "$ready" ]` is `0 = 0`
- a **negative nothing granted** — "may NOT delete" on a cluster where nothing
  is bound

A *"leave X alone"* criterion is a gate now, above the criteria: it costs the
whole check when violated and earns nothing when respected. Everything else is
conjoined with the work it accompanies.

**Two checks graded what a restart changes.** `smoke.sh` takes the stack down
and up and asserts the score survives; that gives every Pod a new IP and every
container one restart. `q39` recorded endpoint addresses and compared them at
grade time — it now records the per-Pod DNS names, which is the better question
as well as the robust one, since stable identity is the whole reason a headless
Service sits in front of a StatefulSet. `q43` required `restartCount == 0` — it
now measures how long each run lasted, against the seeded probe's ~11s kill
cycle.

**`smoke.sh` named `q01`** in its hints, solution and reseed assertions. That
domain used to draw 6 of 6 so `q01` was always present; at 4 of 10 it often is
not, and the facilitator correctly 404s a question outside the draw. Those
assertions now bind to a question the open attempt actually drew.

## Verification

```
SMOKE PASS (139/139 solved, 0/139 fresh, 139/139 resumed, 0 after reset)
```

All twelve smoke phases, plus every offline gate, four Go modules, tsc, eslint
and 770 UI tests.

Beyond smoke, which only ever exercises a drawn 17, all 44 questions were
verified individually by filtering the draw to one domain at a time — `Draw`
returns every in-scope question when the filter narrows the pool below
`examLength` — and each domain was graded twice, once untouched and once solved:

| Domain | Fresh | Solved |
|---|---|---|
| Environment, Config & Security | 0/90 | 90/90 |
| Application Deployment | 0/70 | 70/70 |
| Services and Networking | 0/72 | 72/72 |
| Application Design and Build | 0/72 | 72/72 |
| Observability and Maintenance | 0/56 | 56/56 |

Grading all 44 with nothing seeded scores 0 of 360. The hub was built and run
standalone against the banks index and reports `CKAD Mock Exam 17/44 nodes=2`.

## Notes

- `spec.environment.nodes` stays 2. No question needs the second node — CKAD has
  no node-management competency — and none did before this branch either.
- The bank id stays `ckad-mock-01`: attempt history is keyed by it
  (`ProgressByBank`), so a rename would orphan every saved attempt. Only
  `metadata.title` drops its trailing `01`.
- Per-question difficulty is deliberately **not** sent to the client during an
  attempt. It shapes the draw; labelling a live question `deep` would only tell
  someone to brace.
- No third-party dump is committed. The questions are original works, per
  `banks/LICENSE`.
