### PR TITLE
Add a NOTICE file and author attribution to the app, site and chart

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,52 @@
+kubestronaut-sim
+Copyright 2026 Camilo Joga
+
+Created and maintained by Camilo Joga <https://cjoga.cloud>.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License. You may obtain
+a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+--------------------------------------------------------------------------
+
+The question banks under banks/ are licensed separately, under the
+Creative Commons Attribution-ShareAlike 4.0 International License.
+See banks/LICENSE.
+
+--------------------------------------------------------------------------
+
+Third-party components distributed with this product:
+
+  noVNC — Mozilla Public License 2.0
+  https://github.com/novnc/noVNC
+
+  highlight.js — BSD 3-Clause License
+  https://github.com/highlightjs/highlight.js
+
+  React and react-dom — MIT License
+  https://github.com/facebook/react
+
+  react-markdown and remark-gfm — MIT License
+  https://github.com/remarkjs/react-markdown
+
+  IBM Plex Sans and IBM Plex Mono — SIL Open Font License 1.1
+  https://github.com/IBM/plex
+
+  JetBrains Mono — SIL Open Font License 1.1
+  https://github.com/JetBrains/JetBrainsMono
+
+--------------------------------------------------------------------------
+
+kubestronaut-sim is an independent open-source study tool. It is not
+affiliated with, endorsed by, or associated with the Cloud Native
+Computing Foundation, The Linux Foundation, or PSI. Kubernetes and the
+certification names (CKA, CKAD, CKS, KCNA, KCSA) are trademarks of The
+Linux Foundation.

--- a/README.md
+++ b/README.md
@@ -179,8 +179,10 @@ training.
 
 ## License
 
-- **Code:** Apache-2.0.
+- **Code:** Apache-2.0 — see [LICENSE](LICENSE) and [NOTICE](NOTICE).
 - **Question banks:** CC BY-SA 4.0 — see [banks/LICENSE](banks/LICENSE).
+
+Created and maintained by [Camilo Joga](https://cjoga.cloud).
 
 Not affiliated with CNCF, The Linux Foundation, or PSI. Kubernetes and
 the certification names are trademarks of The Linux Foundation.

--- a/deploy/helm/kubestronaut-sim/Chart.yaml
+++ b/deploy/helm/kubestronaut-sim/Chart.yaml
@@ -18,5 +18,5 @@ keywords:
   - kcna
   - exam
 maintainers:
-  - name: Camilool8
-    url: https://github.com/Camilool8
+  - name: Camilo Joga
+    url: https://cjoga.cloud

--- a/site/index.html
+++ b/site/index.html
@@ -880,6 +880,9 @@
               Open source, run locally, and honest about the difference between
               this and a real sitting.
             </p>
+            <p class="footer-byline">
+              Built by <a href="https://cjoga.cloud">Camilo Joga</a>.
+            </p>
           </div>
 
           <div class="footer-col">

--- a/site/styles.css
+++ b/site/styles.css
@@ -989,6 +989,12 @@ img {
   max-width: 40ch;
 }
 
+.footer-byline {
+  margin-top: var(--space-3);
+  font-size: var(--text-s);
+  color: var(--text-muted);
+}
+
 .footer-links {
   display: flex;
   flex-direction: column;

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,6 +3,13 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "license": "Apache-2.0",
+  "author": "Camilo Joga (https://cjoga.cloud)",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Camilool8/kubestronaut-sim.git",
+    "directory": "ui"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/ui/src/components/InfoDrawer.tsx
+++ b/ui/src/components/InfoDrawer.tsx
@@ -68,6 +68,13 @@ export function InfoDrawer({ onClose, onShowIntro }: InfoDrawerProps) {
 
         <section>
           <h3>{s.licensesTitle}</h3>
+          <p className="drawer-credit">
+            {s.authorCredit}{" "}
+            <a href={s.authorUrl} target="_blank" rel="noopener noreferrer">
+              {s.authorName}
+            </a>
+            .
+          </p>
           <ul className="license-list">
             {s.licenses.map((line) => (
               <li key={line}>{line}</li>

--- a/ui/src/screens/Exams.tsx
+++ b/ui/src/screens/Exams.tsx
@@ -347,7 +347,20 @@ export function Exams({
                 </ul>
               )}
 
-              <p className="page-footer">{strings.info.footerLine}</p>
+              <div className="page-footer">
+                <p className="page-footer-by">
+                  {strings.info.authorFooter}{" "}
+                  <a
+                    className="page-footer-link"
+                    href={strings.info.authorUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {strings.info.authorName}
+                  </a>
+                </p>
+                <p>{strings.info.footerLine}</p>
+              </div>
             </>
           );
         }}

--- a/ui/src/strings.ts
+++ b/ui/src/strings.ts
@@ -380,6 +380,10 @@ export const strings = {
     disclaimerBody:
       "Kubestronaut Sim is an independent open-source study tool. It is not affiliated with, endorsed by, or associated with the Cloud Native Computing Foundation, The Linux Foundation, or PSI. Kubernetes and the certification names (CKA, CKAD, CKS, KCNA, KCSA) are trademarks of The Linux Foundation.",
     licensesTitle: "Licenses and credits",
+    authorName: "Camilo Joga",
+    authorUrl: "https://cjoga.cloud",
+    authorFooter: "Built by",
+    authorCredit: "Created and maintained by",
     licenses: [
       "Simulator code: Apache License 2.0",
       "Question banks: Creative Commons BY-SA 4.0",

--- a/ui/src/theme.css
+++ b/ui/src/theme.css
@@ -587,6 +587,24 @@ button.nav-menu-item:hover {
   text-align: center;
 }
 
+.page-footer p {
+  margin: 0 0 var(--space-1);
+}
+
+.page-footer p:last-child {
+  margin-bottom: 0;
+}
+
+.page-footer-link {
+  color: var(--text-secondary);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.page-footer-link:hover {
+  color: var(--accent-strong);
+}
+
 .coverage {
   display: flex;
   align-items: center;
@@ -3529,6 +3547,22 @@ button.nav-menu-item:hover {
   color: var(--text-muted);
   font-size: var(--text-s);
   margin-top: var(--space-3);
+}
+
+.drawer-credit {
+  margin: 0 0 var(--space-3);
+  color: var(--text-muted);
+  font-size: var(--text-s);
+}
+
+.drawer-credit a {
+  color: var(--text-secondary);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.drawer-credit a:hover {
+  color: var(--accent-strong);
 }
 
 .license-list {


### PR DESCRIPTION
## What this changes

Puts the author's name on the project where a reader looks for it, and adds
the `NOTICE` file Apache-2.0 expects. The existing independence disclaimer
stays primary: the byline sits alongside it rather than above it, and stays
off the timed exam surfaces.

### Changes
- New `NOTICE`: copyright, the `banks/LICENSE` split for the question banks,
  the third-party components actually shipped, and the non-affiliation statement
- Byline in the exam-catalog footer and in the "Licenses and credits" drawer,
  driven by new `authorName`, `authorUrl`, `authorFooter` and `authorCredit` strings
- Byline in the landing-page footer
- `README.md` credit line, and a link to `NOTICE` from the License section
- `license`, `author` and `repository` fields on `ui/package.json`
- Chart maintainer recorded as the person rather than the GitHub handle

## Verification

CI runs the five bank gates, the Go tests, the UI suite, the image
builds and a shell syntax pass. It cannot run `tests/smoke.sh`, which is
the only thing that checks a fresh environment scores 0 and the
reference solutions score 100%.

- [ ] I ran `tests/smoke.sh` locally
- [x] Not needed — this change cannot affect grading or the environment

See [CONTRIBUTING.md](https://github.com/Camilool8/kubestronaut-sim/blob/main/CONTRIBUTING.md).
