### PR TITLE
Act on the repository audit's first-priority findings

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ## Verification
 
-CI runs the five bank gates, the Go tests, the UI suite, the image
+CI runs the seven offline gates, the Go tests, the UI suite, the image
 builds and a shell syntax pass. It cannot run `tests/smoke.sh`, which is
 the only thing that checks a fresh environment scores 0 and the
 reference solutions score 100%.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,83 @@
 version: 2
 updates:
+  # ----------------------------------------------------------------- ui (npm)
   - package-ecosystem: npm
     directory: /ui
     schedule:
       interval: monthly
     open-pull-requests-limit: 5
     groups:
+      # vite and vitest are one unit, not two dependencies: vitest declares a
+      # vite range (vitest 3 -> vite ^5 || ^6 || ^7) and a vite major moves the
+      # plugin API with it. Naming them as their own group is what
+      # CONTRIBUTING.md's "do not bump it alone" actually asks for -- both
+      # halves of the pair arrive in one reviewable pull request, and they do
+      # not arrive buried in a bulk eslint/typescript/jsdom bump.
+      vite-toolchain:
+        patterns:
+          - vite
+          - vitest
+          - "@vitejs/*"
       dev-dependencies:
         dependency-type: development
-    ignore:
-      - dependency-name: vitest
-        update-types: [version-update:semver-major]
+    # There is deliberately no `ignore` entry for vitest here any more.
+    #
+    # This block used to carry:
+    #     ignore:
+    #       - dependency-name: vitest
+    #         update-types: [version-update:semver-major]
+    #
+    # `ignore` suppresses Dependabot *security* pull requests as well as
+    # version bumps, so that rule held the repo on vitest 2.1.9 straight
+    # through CVE-2026-47429 (CVSS 9.8), fixed in 3.2.6 with no 2.x backport.
+    # It also blocked vite 5 -> 6 as a side effect, because vitest 2 requires
+    # vite ^5. The pairing constraint now lives in the vite-toolchain group
+    # above, which proposes the pair rather than hiding one half of it.
+    #
+    # Condition for adding an ignore rule back: only when a specific published
+    # version is known-broken for this repo, pinned by `versions:` to that
+    # exact range, and deleted as soon as the range is superseded. A standing
+    # `update-types: [version-update:semver-major]` ignore on any dependency is
+    # precisely the failure this comment exists to prevent -- it cannot tell a
+    # breaking change from a security fix, and silently withholds both.
 
+  # --------------------------------------------------- container base images
+  # Scoped to the directories whose Dockerfiles hold a Go build stage. Those
+  # FROM lines are the only place the Go toolchain version is written down, and
+  # nothing was watching them when Go 1.24 reached end of life. The runtime and
+  # ui-build bases in the same files (alpine, debian, node) ship in, or build,
+  # the released images, so they come along and are worth the same attention.
+  #
+  # Deliberately not watched, to keep the pull request volume honest:
+  #   images/k8s-env       docker:27-dind. The dind major is a pin the cluster
+  #                        bootstrap is written against, and evaluating a bump
+  #                        means booting a full cluster -- a human decision.
+  #   images/instance      debian:13-slim only; the same base is already
+  #                        watched through images/desktop.
+  #   images/banks         alpine:3.21 only; the same base is already watched
+  #                        through proxy and conductor.
+  #   banks/*/*/files/image  exam fixture content. That base image is part of
+  #                        what a candidate is graded against, not part of the
+  #                        product's supply chain.
+  - package-ecosystem: docker
+    directories:
+      - /proxy
+      - /conductor
+      - /facilitator
+      - /hub
+      - /images/desktop
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    groups:
+      base-images:
+        patterns:
+          - "*"
+        # golang:1.26-alpine appears in all five directories. group-by keeps
+        # one toolchain bump to one pull request instead of five.
+        group-by: dependency-name
+
+  # ------------------------------------------------------------ CI workflows
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,14 @@ jobs:
         run: bash tests/bank-hints.sh
       - name: MCQ banks
         run: bash tests/bank-mcq.sh
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+      - name: Vendor IBM Plex, so the font mirrors are actually compared
+        working-directory: ui
+        run: npm ci --omit=dev
       - name: Landing page in sync
         run: bash site/build.sh --check
 
@@ -43,7 +51,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.24"
+          go-version: "1.26"
           cache-dependency-path: ${{ matrix.module }}/go.mod
       - name: Test
         working-directory: ${{ matrix.module }}
@@ -87,7 +95,7 @@ jobs:
           version: v3.16.3
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.24"
+          go-version: "1.26"
           cache-dependency-path: hub/go.mod
 
       - name: Lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 **You need:** Docker Desktop (or docker + compose v2), python3 — not
 needed on Windows, where `sim.ps1` parses JSON natively — and ~9GB of
-free RAM. For the code itself: Go 1.24 and Node 22 — or Docker alone. On
+free RAM. For the code itself: Go 1.26 and Node 22 — or Docker alone. On
 Windows, run `sim.ps1` instead of `sim` — see
 [docs/install.md](docs/install.md) for the PowerShell steps.
 
@@ -37,12 +37,16 @@ Run these. They need no Docker and take seconds:
 
 ```bash
 tests/bank-weights.sh && tests/check-lint.sh && tests/check-lib.sh \
+  && tests/check-evidence.sh && tests/next-version.sh \
   && tests/bank-hints.sh && tests/bank-mcq.sh
 for m in conductor facilitator proxy hub images/desktop/opener; do (cd $m && go test ./... && go vet ./...); done
 (cd ui && npm ci && npx tsc --noEmit && npm run lint && npm test)
 ```
 
-If you touched `site/`, also run `bash site/build.sh --check`.
+If you touched `site/`, also run `bash site/build.sh --check`. It diffs
+`site/fonts/*.woff2` against `ui/node_modules/@fontsource`, so `npm ci` in
+`ui/` has to have run first — with the sources missing the check now fails
+instead of quietly skipping that comparison.
 
 If you touched `sim` or `sim.ps1`, also run `bash tests/check-sim-parity.sh`
 — the Windows launcher must offer the same nine subcommands, and CI fails
@@ -55,6 +59,8 @@ when the two drift.
 | `bank-weights.sh` | Each question's `weight:` equals the sum of its `# points:` headers, `exam.yaml` and the `q*/` directories agree, and the domain balance matches the curriculum. For a bank declaring `spec.difficultyMix`, also that every question's level matches its `targetSeconds` band, that the pool is deep enough per domain and level to hold the mix, and that a drawn sitting fits the clock |
 | `check-lint.sh` | No validator grades spelling instead of behaviour, and every check carries an exact `# points: N` header |
 | `check-lib.sh` | The `banks/_lib/checks.sh` helpers still treat `0.1` and `100m`, or `1Gi` and `1024Mi`, as the same answer |
+| `check-evidence.sh` | Drives real `validate.d` scripts against a stubbed `kubectl` to prove what a **failing** check reports: a failure never arrives without an `actual` pane, and a name the candidate did not use is named, not shown as an empty field. `tests/solutions/` only ever walks the happy path, which is how a check came to report `runAsUser='', want 10001` for a whole release |
+| `next-version.sh` | `.github/scripts/next-version.py` computes the release tag from the commit log, so this pins the arithmetic: which prefixes are a patch, that the largest bump wins, and that a breaking change on 0.x is a minor rather than v1.0.0 |
 | `bank-hints.sh` | Every hinted question has both tiers, and no hint shares 120 consecutive characters with its solution |
 | `bank-mcq.sh` | Six invariants over every `examType: mcq` bank, including a non-degenerate answer key |
 | `site/build.sh --check` | The generated mirrors are current, the page's figures match `banks/*/exam.yaml`, and its cert marks match `CertMark.tsx` |
@@ -95,8 +101,10 @@ docker run --rm -v "$PWD/ui":/w -w /w node:22-alpine npm install
 proxies `/api` and the `/desktop` websocket to port 8080, so run
 `./sim up` first.
 
-**vitest is pinned to v2** for vite 5 compatibility. Do not bump it
-alone.
+**vite and vitest are one pin, not two** — `vite ^6.4.3` with
+`vitest ^3.2.7`. Vitest runs the tests through Vite's own transform
+pipeline, so a major on one needs the matching major on the other.
+Bumping either alone breaks the suite.
 
 **`npm run lint` is clean at zero warnings.** Keep it that way.
 
@@ -108,7 +116,7 @@ build from their own directories.
 a bind-mounted `.git` has the wrong ownership:
 
 ```bash
-docker run --rm -e GOFLAGS=-buildvcs=false -v "$PWD/facilitator":/w -w /w golang:1.24 go test ./...
+docker run --rm -e GOFLAGS=-buildvcs=false -v "$PWD/facilitator":/w -w /w golang:1.26 go test ./...
 ```
 
 **`facilitator/internal/web/dist/index.html` and
@@ -203,7 +211,8 @@ YAML, Markdown and shell, so a `.txt` there is foreign by definition.
 **Two image tags must stay absent from `images/k8s-env/preload.txt`:**
 
 - `nginx:1.99` — question 02's broken image.
-- `nginx:0.0.0-corvus-nonexistent` — question 11's failing Helm install.
+- `nginx:0.0.0-corvus-nonexistent` — question 17's unpullable image, the
+  one the candidate has to read off the Deployment and correct.
 
 Both questions are built on those tags *not* resolving. Preloading them
 breaks two questions silently, and only a smoke run on a cold cache

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ what creates its cluster, and the page shows each phase as it completes.
 
 | Bank | Engine | Questions | Per attempt | Time | Pass |
 |---|---|---|---|---|---|
-| CKAD Mock Exam | Hands-on | 26 | 17 drawn | 120 min | 66% |
+| CKAD Mock Exam | Hands-on | 44 | 17 drawn | 120 min | 66% |
 | KCNA Mock Exam | Multiple choice | 97 | 65 drawn | 90 min | 75% |
 
 - Every draw is stratified to the published curriculum weights.
@@ -107,7 +107,8 @@ routes.
           alt="The score screen: a pass against the threshold, a domain breakdown ordered weakest first with two domains flagged below threshold, and a table of per-task verdicts with the points each one earned." />
    </picture>
 
-Press `?` in the app for the full shortcut list.
+Press `?` in the exam view for the full shortcut list. The key is bound
+on that screen only.
 
 ### Clipboard
 
@@ -136,7 +137,12 @@ A kind cluster sized by the exam you picked
 
 - **Calico** rather than kindnet, so NetworkPolicies are genuinely
   enforced and policy questions can be graded on behaviour.
-- ingress-nginx.
+- ingress-nginx, pinned to `controller-v1.15.1`. That is its last
+  release: the project was retired upstream in March 2026 and will get
+  no further patches. The Ingress **API** is not deprecated, and one
+  retired controller is not an exam change — see
+  [SECURITY.md](SECURITY.md#ingress-nginx-is-retired-upstream) for why
+  that is acceptable here and what would force a migration.
 - A local Helm repository.
 - A plain-HTTP registry for the image-building questions.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,17 +18,39 @@ Anyone who can reach port `8080` can:
 - Open the exam desktop — a real shell with cluster-admin.
 - Read, export or erase your attempt history.
 
-The only control is which interface it listens on.
+Two controls stand between that and a stranger, and neither is
+authentication:
 
-```bash
-SIM_BIND=127.0.0.1 ./sim up     # loopback only
-```
+- **Which interface it listens on.** This is the whole defence against
+  someone else on the network.
 
-```powershell
-.\sim.ps1 up -Bind 127.0.0.1    # loopback only
-```
+  ```bash
+  SIM_BIND=127.0.0.1 ./sim up     # loopback only
+  ```
 
-Use that on any network you do not control.
+  ```powershell
+  .\sim.ps1 up -Bind 127.0.0.1    # loopback only
+  ```
+
+  Use that on any network you do not control.
+
+- **An origin check on every state-changing route.** The facilitator
+  refuses a state-changing request that carries a cross-site `Origin` or
+  `Sec-Fetch-Site`. The check wraps the whole mux, so the
+  `/api/control/*` proxy to the conductor is behind it too. A request
+  sending neither header is allowed — that is `curl`, `./sim` and
+  `tests/smoke.sh`, none of which a browser can impersonate.
+
+The second exists because the first does not address the attacker who
+matters here. A page in another tab can send a `POST` to `:8080` from
+the candidate's own browser: the request originates on the machine
+running the stack, so `SIM_BIND=127.0.0.1` does not touch it. Without
+the origin check, any site the candidate visits could end a live attempt
+or trigger a reset. The response is opaque to the caller either way, so
+the risk was always destruction, never disclosure.
+
+Neither control identifies anybody. Anyone who can genuinely reach
+`:8080` still can do everything in the list above.
 
 ## Scope
 
@@ -65,6 +87,67 @@ the cluster's ingress on `8081`/`8443`, and NodePorts `30080-30082`.
 The instances hold `SYS_ADMIN`, `SYS_CHROOT`, `MKNOD`, `SETFCAP` and
 `SYS_RESOURCE`. Read that set as *meaningfully less than root on the
 host, but not a strong boundary*.
+
+## ingress-nginx is retired upstream
+
+The cluster's ingress controller is pinned to `controller-v1.15.1`
+(`INGRESS_NGINX_VERSION` in
+[images/k8s-env/Dockerfile](images/k8s-env/Dockerfile)). That is the last
+release the project will ever have. Retirement was announced 2025-11-11,
+the Steering Committee and the Security Response Committee restated it
+2026-01-29, the final releases shipped 2026-03-19 and the repository was
+archived read-only 2026-03-24. There will be no more bugfixes and **no
+more security patches**. InGate, the intended successor, is archived too
+— `kubernetes-sigs/ingate` is now `kubernetes-retired/ingate`, marked
+`[EOL]`.
+
+We are not migrating, and the reason is what this cluster is:
+
+- It is a throwaway kind cluster inside the privileged `k8s-env`
+  container, rebuilt from scratch on every reset. It holds nothing worth
+  taking.
+- No untrusted traffic reaches it. Its clients are the candidate's own
+  shells, their own desktop browser, and their own host on `:8081` and
+  `:8443` — and under a loopback `SIM_BIND`, not even that.
+- The CKAD competency is *"use Ingress rules to expose applications"*.
+  The Ingress **API** is not deprecated and is fully supported. One
+  controller implementation retired; nothing a candidate learns here
+  changed.
+- `q08` and `q37` are graded on routing behaviour, so swapping the
+  controller risks two working questions and buys a candidate nothing.
+
+**What would force a migration.** Either of these, and only these:
+
+- A real CVE against `controller-v1.15.1`. There will be no patched
+  release to move to, so the fix is a different controller.
+- The published controller images becoming unavailable. The prebaked
+  tarballs delay that for an existing image; they do nothing for a
+  rebuild, and nothing at all under `PRELOAD=none`.
+
+**The migration, when one of those fires.** Target [Gateway
+API](https://gateway-api.sigs.k8s.io/), which is the project's own
+recommendation; a maintained Ingress controller is the stopgap if the
+questions have to keep grading `networking.k8s.io/v1` Ingress objects.
+Three things have to hold:
+
+1. `banks/ckad-mock-01/q08` and `q37` must grade identically. Both check
+   what the controller *routes*, not what the manifest says, so their
+   `validate.d` scripts are the acceptance test for the swap — and both
+   address the controller by name, `q08` through
+   `ingress-nginx-controller.ingress-nginx.svc` and `q37` through that
+   Service's cluster IP. A rename breaks the check before the answer.
+   `q37` terminates TLS, which is where controllers differ most.
+2. `images/k8s-env/bootstrap.sh` installs the controller and waits on
+   `deployment/ingress-nginx-controller` by name. Both change together.
+3. The prebake list is derived, not written down: the `preload` stage in
+   [images/k8s-env/Dockerfile](images/k8s-env/Dockerfile) reads every
+   `image:` out of `/opt/sim/ingress-nginx.yaml` alongside
+   [images/k8s-env/preload.txt](images/k8s-env/preload.txt). Replacing
+   the manifest replaces the tarballs, so `PRELOAD=full` must be rebuilt
+   and an offline reset re-checked.
+
+The pinned version does not move until then. Bumping it is not an option
+— there is nothing to bump to.
 
 ## The conductor is the one real boundary
 

--- a/banks/ckad-mock-01/tips.md
+++ b/banks/ckad-mock-01/tips.md
@@ -1,6 +1,6 @@
 Two hours is not long. Most people who fail this exam knew the answers —
 they ran out of time getting to them. What follows is technique, not
-Kubernetes: the habits that decide how many of the twenty-two you reach.
+Kubernetes: the habits that decide how many of the seventeen you reach.
 
 ## Set the terminal up before you start
 

--- a/conductor/Dockerfile
+++ b/conductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY go.mod ./
 COPY cmd ./cmd

--- a/conductor/go.mod
+++ b/conductor/go.mod
@@ -1,3 +1,3 @@
 module kubestronaut-sim/conductor
 
-go 1.24
+go 1.26

--- a/docs/api.md
+++ b/docs/api.md
@@ -180,10 +180,10 @@ and the three selectable modes. Always 200.
   "hasTips": true,
   "levelMixed": true,
   "questions": [
-    {"id": "q01", "instance": "instance-1", "domain": "Application Environment, Configuration and Security", "weight": 9, "totalPoints": 9, "hintCount": 2, "targetSeconds": 360, "targetDerived": true}
+    {"id": "q01", "instance": "instance-1", "domain": "Application Environment, Configuration and Security", "weight": 9, "totalPoints": 9, "hintCount": 2, "targetSeconds": 300}
   ],
   "domains": [
-    {"name": "Application Environment, Configuration and Security", "weightPct": 25, "questionCount": 6}
+    {"name": "Application Environment, Configuration and Security", "weightPct": 25, "questionCount": 10}
   ],
   "modes": [
     {"id": "training", "durationSeconds": 0, "untimed": true, "helpAllowed": true, "gradesPerTask": true, "recorded": false, "recommended": false},
@@ -238,9 +238,13 @@ never `null`.
 
 `targetDerived` says that figure was **computed**, not authored — the
 question's weight's share of the bank's clock, which is what a bank
-setting no `spec.questions[].targetSeconds` gets.
+setting no `spec.questions[].targetSeconds` gets. It is omitted rather
+than sent as `false`, so it appears only on a derived figure.
 
-- Neither shipped bank sets one, so both are derived today.
+- The two shipped banks differ. `ckad-mock-01` authors one on every
+  question, because `spec.difficultyMix` makes the tier a time band and
+  a band cannot be derived; `kcna-mock` sets none, so all 97 of its
+  figures are derived.
 - The flag exists because the two are different claims: an author's
   judgement of the work, versus arithmetic about weights. A display that
   cannot tell them apart states the second with the first's confidence.
@@ -1084,6 +1088,11 @@ exactly what it is asked.
 Just the `summary` object above, for a caller that wants the four
 numbers without every record. Always 200 (or 503).
 
+**Nothing in this repository calls it** — not `sim`, not `sim.ps1`, not
+the UI, not `tests/`. The app reads the same rollup off
+`GET /api/history`, which it needs anyway. This route exists for a
+script of your own.
+
 ### GET /api/history/export
 
 The record as a downloadable document, with
@@ -1202,8 +1211,14 @@ service that owns that answer is the one that did not reply
 
 ### /desktop and /desktop/
 
-Reverse proxy to the noVNC desktop container, same-origin so the exam
-UI can iframe it.
+Reverse proxy to the noVNC desktop container. There is no iframe: the UI
+mounts noVNC's `RFB` on a plain `div` and points it at
+`ws(s)://<this host>/desktop/websockify`
+(`ui/src/components/DesktopViewport.tsx`). Proxying it here is what makes
+that URL same-origin — one host, one port, one scheme derived from the
+page's own — so the WebSocket needs no CORS, no second published port
+and no separate TLS certificate, and it works unchanged behind whatever
+fronts `:8080`.
 
 | Code | When |
 |---|---|
@@ -1221,10 +1236,16 @@ mux registers the same paths. See [Conductor](#conductor).
 ### Everything else
 
 Any path that is not `/api/*` or `/desktop*` serves the embedded UI:
-the real file when one exists, otherwise `index.html`, so client-side
-routes such as `/score` load. An unmatched path under `/api/` is a JSON
-404, never `index.html`
+the real file when one exists, otherwise `index.html`. An unmatched path
+under `/api/` is a JSON 404, never `index.html`
 (`facilitator/internal/api/api.go`).
+
+The UI routes on the fragment (`ui/src/lib/useHashRoute.ts`), so its own
+routes never reach here — `#/results/q01` is a plain `GET /`. The
+fallback is for the paths that do arrive and are not built assets: a
+bookmark from an older build, a hand-typed `/score`, a link someone
+shortened. Each gets the app rather than a 404, and the app opens at its
+default screen because the fragment is empty.
 
 ## Conductor
 
@@ -1533,7 +1554,7 @@ about to be destroyed.
 | `GET /api/history/export` | The interchange document (`{"version":1,"attempts":[...]}`, oldest first). Importable by a local `./sim`. |
 | `DELETE /api/history` | Erases the user's directory: every attempt and every results blob. |
 | `POST /api/history/import` | 501, with the reason. |
-| `GET /api/history/summary` | 501 — the CLI's route, and answering it wrongly would be worse than not answering. |
+| `GET /api/history/summary` | 501, with the reason. `GET /api/history` already returns every attempt with the rollup beside it, so a second projection of the same data would only be another thing to keep in step. |
 
 ### POST /hub/ingest/history
 

--- a/docs/bank-spec.md
+++ b/docs/bank-spec.md
@@ -6,14 +6,16 @@ The conductor scans every `banks/*/exam.yaml` into the catalog
 the exam selector renders; [banks/catalog.yaml](../banks/catalog.yaml) adds
 coming-soon entries whose exam engine does not exist yet.
 
-Five gates decide whether a bank ships —
+Six gates decide whether a bank ships —
 [bank-weights.sh](../tests/bank-weights.sh),
 [check-lint.sh](../tests/check-lint.sh),
-[check-lib.sh](../tests/check-lib.sh) and
+[check-lib.sh](../tests/check-lib.sh),
+[check-evidence.sh](../tests/check-evidence.sh) and
 [bank-hints.sh](../tests/bank-hints.sh) for hands-on banks, and
 [bank-mcq.sh](../tests/bank-mcq.sh) for multiple-choice ones. All are
-offline and run at the top of [tests/smoke.sh](../tests/smoke.sh), so a
-bank mistake fails in seconds rather than forty minutes into a cold boot.
+offline and CI runs all six. Every one but `check-evidence.sh` also runs
+at the top of [tests/smoke.sh](../tests/smoke.sh), so a bank mistake
+fails in seconds rather than forty minutes into a cold boot.
 
 There are two exam engines. Everything down to
 [Multiple-choice banks](#multiple-choice-banks-examtype-mcq) describes
@@ -208,7 +210,7 @@ For an author:
   moved four minutes of seeding from the boot screen to the moment the
   candidate presses Start, and gained almost no variety for it.
 
-`ckad-mock-01` pools 26 down to 17 for both reasons. **Holding the sitting
+`ckad-mock-01` pools 44 down to 17 for both reasons. **Holding the sitting
 to the right length** comes first: the real CKAD is 15-20 tasks in two
 hours, and 17 is its midpoint.
 
@@ -217,11 +219,11 @@ the pool is pooling in name only:
 
 | Domain | Pool | Rotation |
 |---|---|---|
-| Application Environment, Configuration and Security | 6 | 4 of 6 |
-| Application Deployment | 5 | 4 of 5 |
-| Services and Networking | 4 | 3 of 4 |
-| Application Design and Build | 7 | 3 of 7 |
-| Application Observability and Maintenance | 4 | 3 of 4 |
+| Application Environment, Configuration and Security | 10 | 4 of 10 |
+| Application Deployment | 10 | 4 of 10 |
+| Services and Networking | 8 | 3 of 8 |
+| Application Design and Build | 8 | 3 of 8 |
+| Application Observability and Maintenance | 8 | 3 of 8 |
 
 Deepening a domain widens its rotation. The gate prints this table, so the
 thinnest domain is always the one to write into next.
@@ -289,7 +291,7 @@ the bank when a tier lands more than one question from its share, prints
 a domain-by-tier depth table, and checks the drawn sitting against the
 clock: 0.85 to 1.05 of `spec.duration`, because a bank that wastes the
 clock and one nobody finishes are both miscalibrated. `ckad-mock-01`
-currently draws 4 quick, 9 core and 4 deep for 115 minutes of task time
+currently draws 5 quick, 8 core and 4 deep for 115 minutes of task time
 against 120.
 
 The tier never reaches the candidate **mid-attempt**: a question labelled
@@ -310,7 +312,7 @@ percentage point of its curriculum weight.
 
 What that does *not* give you is a drawn attempt whose raw points divide
 in the curriculum's ratios, and it cannot: a domain that contributes 4 of
-its 7 questions to the draw contributes 4/7 of its pool points with it.
+its 10 questions to the draw contributes 4/10 of its pool points with it.
 Two other things keep the promise instead, which is why
 [bank-weights.sh](../tests/bank-weights.sh) checks pool DEPTH here rather
 than point share:
@@ -347,13 +349,13 @@ structural ones that set it up.
 
 | # | Assertion | Line |
 |---|---|---|
-| 1 | The questions in `exam.yaml` and the `q*/` directories on disk are the same set | `:87` |
-| 2 | Every question has at least one `validate.d/*.sh` | `:106` |
-| 3 | Every check carries a `# points: N` header matching the grader's pattern exactly | `:110` |
-| 4 | A question's `weight:` equals the sum of its checks' points | `:114` |
-| 5 | Every question's domain has a `spec.domainWeights` entry | `:133` |
-| 6 | Every `spec.domainWeights` entry is used by at least one question | `:135` |
-| 7 | Each domain's share is within 2 percentage points of its target | `:146` |
+| 1 | The questions in `exam.yaml` and the `q*/` directories on disk are the same set | `:229` |
+| 2 | Every question has at least one `validate.d/*.sh` | `:237` |
+| 3 | Every check carries a `# points: N` header matching the grader's pattern exactly | `:241` |
+| 4 | A question's `weight:` equals the sum of its checks' points | `:246` |
+| 5 | Every question's domain has a `spec.domainWeights` entry | `:275` |
+| 6 | Every `spec.domainWeights` entry is used by at least one question | `:277` |
+| 7 | Each domain's share is within 2 percentage points of its target | `:341` |
 
 A bank with no `spec.domainWeights` skips 5 through 7 and is still subject to
 1 through 4. That is how `smoke-01`, the hidden switch-test fixture mapped to

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -157,7 +157,7 @@ Per practical session, across its eight containers:
 | | Requested | Limit |
 |---|---|---|
 | Memory | 3.9Gi | 11.8Gi |
-| CPU | 540m | 4400m |
+| CPU | 540m | 5900m |
 
 - Per-container numbers are measured and live in
   `deploy/helm/kubestronaut-sim/files/session-pod.yaml`. Override
@@ -231,5 +231,7 @@ disposable unit:
   hosted reset costs a full boot and reports different phases.
 - Every container except the two candidate shells reports the Pod's
   hostname, because a Pod shares one UTS namespace.
-- History import and the CLI's summary route are refused with an
-  explanation rather than proxied.
+- History import and `GET /api/history/summary` are refused with an
+  explanation rather than proxied. Import would let a durable record hold
+  attempts that were never graded; the summary is a projection of
+  `GET /api/history`, which the hub already serves in full.

--- a/facilitator/Dockerfile
+++ b/facilitator/Dockerfile
@@ -5,7 +5,7 @@ RUN npm ci
 COPY ui/ ./
 RUN npm run build
 
-FROM golang:1.24-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY facilitator/go.mod ./
 COPY facilitator/cmd ./cmd

--- a/facilitator/go.mod
+++ b/facilitator/go.mod
@@ -1,3 +1,3 @@
 module kubestronaut-sim/facilitator
 
-go 1.24
+go 1.26

--- a/facilitator/internal/api/api.go
+++ b/facilitator/internal/api/api.go
@@ -98,7 +98,35 @@ func New(ex *exam.Exam, bankDir string, mgr *session.Manager, grade Grader, desk
 
 	mux.HandleFunc("/", s.handleSPA)
 
-	return mux
+	return crossOriginGate(mux)
+}
+
+// crossOriginGate refuses state-changing requests that a page on another
+// origin made. It wraps the whole mux rather than individual handlers, so the
+// /api/control/ proxy is covered by the same check as everything routed here,
+// and a route added later cannot forget it.
+//
+// The gate is needed because nothing else stops it. No handler requires a JSON
+// content type, so a text/plain POST is a CORS simple request that needs no
+// preflight, and POST /api/session/end reads no body at all — so any tab could
+// end a live attempt and start grading. Binding to 127.0.0.1 is no defence:
+// the request originates in the candidate's own browser.
+//
+// http.CrossOriginProtection allows GET, HEAD and OPTIONS unconditionally, and
+// for every other method allows the request only when Sec-Fetch-Site says
+// same-origin or none, or when neither Sec-Fetch-Site nor Origin is present.
+// That last case is what keeps ./sim, tests/smoke.sh and every other curl
+// working: they send neither header. A page cannot suppress either header, so
+// it cannot reach POST /api/session/end or POST /api/control/reset. Rejected
+// requests get 403.
+//
+// No trusted origins and no bypass patterns are configured. Hosted mode puts
+// the hub in front, and the hub rewrites Host to the session Pod's address, so
+// the Origin-against-Host fallback could not match there — but the browser's
+// Sec-Fetch-Site: same-origin is forwarded verbatim through the hub's reverse
+// proxy and settles the request before that fallback is reached.
+func crossOriginGate(h http.Handler) http.Handler {
+	return http.NewCrossOriginProtection().Handler(h)
 }
 
 func handleHealthz(w http.ResponseWriter, r *http.Request) {

--- a/facilitator/internal/api/api_origin_test.go
+++ b/facilitator/internal/api/api_origin_test.go
@@ -1,0 +1,209 @@
+package api_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"kubestronaut-sim/facilitator/internal/session"
+)
+
+// httptest.NewRequest gives every request this Host, so it is what an
+// same-origin Origin header has to name.
+const (
+	sameOrigin  = "http://example.com"
+	otherOrigin = "https://attacker.example"
+)
+
+func (ts *testServer) doWithHeaders(t *testing.T, method, path string, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	ts.handler.ServeHTTP(rec, req)
+	return rec
+}
+
+// The allowed direction. The bare case matters most: ./sim, tests/smoke.sh and
+// every curl send neither Sec-Fetch-Site nor Origin, and must keep working.
+func TestSessionEndAllowedSameOrigin(t *testing.T) {
+	cases := []struct {
+		name    string
+		headers map[string]string
+	}{
+		{"no headers at all (curl, ./sim, smoke)", nil},
+		{"Sec-Fetch-Site same-origin", map[string]string{"Sec-Fetch-Site": "same-origin", "Origin": sameOrigin}},
+		{"Sec-Fetch-Site none (address bar)", map[string]string{"Sec-Fetch-Site": "none"}},
+		{"Origin matching Host, no Sec-Fetch-Site", map[string]string{"Origin": sameOrigin}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newTestServer(t)
+			if _, err := ts.mgr.Start(session.ModeExam, time.Hour); err != nil {
+				t.Fatalf("Start: %v", err)
+			}
+
+			rec := ts.doWithHeaders(t, http.MethodPost, "/api/session/end", tc.headers)
+			if rec.Code != http.StatusAccepted {
+				t.Fatalf("status = %d, want 202, body=%s", rec.Code, rec.Body.String())
+			}
+			if ts.grader.calls != 1 {
+				t.Errorf("grader.calls = %d, want 1", ts.grader.calls)
+			}
+			if state := ts.mgr.Snapshot().State; state != "ended" {
+				t.Errorf("state = %q, want ended", state)
+			}
+		})
+	}
+}
+
+// The refused direction. A page in another tab can suppress neither header, so
+// it cannot end a live attempt.
+func TestSessionEndRefusedCrossOrigin(t *testing.T) {
+	cases := []struct {
+		name    string
+		headers map[string]string
+	}{
+		{"Sec-Fetch-Site cross-site", map[string]string{"Sec-Fetch-Site": "cross-site", "Origin": otherOrigin}},
+		{"Sec-Fetch-Site cross-site, Origin suppressed", map[string]string{"Sec-Fetch-Site": "cross-site"}},
+		{"Sec-Fetch-Site same-site", map[string]string{"Sec-Fetch-Site": "same-site", "Origin": otherOrigin}},
+		{"Origin not matching Host, no Sec-Fetch-Site", map[string]string{"Origin": otherOrigin}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newTestServer(t)
+			if _, err := ts.mgr.Start(session.ModeExam, time.Hour); err != nil {
+				t.Fatalf("Start: %v", err)
+			}
+
+			rec := ts.doWithHeaders(t, http.MethodPost, "/api/session/end", tc.headers)
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want 403, body=%s", rec.Code, rec.Body.String())
+			}
+			if ts.grader.calls != 0 {
+				t.Errorf("grader.calls = %d, want 0 — the refusal must land before the handler", ts.grader.calls)
+			}
+			if state := ts.mgr.Snapshot().State; state != "running" {
+				t.Errorf("state = %q, want running — the attempt must survive the refused request", state)
+			}
+		})
+	}
+}
+
+// The /api/control/ proxy is mounted on the same mux, so the gate covers the
+// conductor routes too — POST /api/control/reset rebuilds the cluster.
+func TestControlProxyCrossOrigin(t *testing.T) {
+	const proxied = "control:/api/control/reset"
+
+	t.Run("same-origin reaches the conductor", func(t *testing.T) {
+		ts := newTestServer(t)
+		rec := ts.doWithHeaders(t, http.MethodPost, "/api/control/reset", map[string]string{
+			"Sec-Fetch-Site": "same-origin",
+			"Origin":         sameOrigin,
+		})
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("status = %d, want 202, body=%s", rec.Code, rec.Body.String())
+		}
+		if got := rec.Body.String(); got != proxied {
+			t.Errorf("body = %q, want %q", got, proxied)
+		}
+	})
+
+	t.Run("cross-origin never reaches the conductor", func(t *testing.T) {
+		ts := newTestServer(t)
+		rec := ts.doWithHeaders(t, http.MethodPost, "/api/control/reset", map[string]string{
+			"Sec-Fetch-Site": "cross-site",
+			"Origin":         otherOrigin,
+		})
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403, body=%s", rec.Code, rec.Body.String())
+		}
+		if got := rec.Body.String(); got == proxied {
+			t.Errorf("body = %q — the request was proxied to the conductor anyway", got)
+		}
+	})
+
+	t.Run("bare request still reaches the conductor", func(t *testing.T) {
+		ts := newTestServer(t)
+		rec := ts.do(t, http.MethodPost, "/api/control/reset")
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("status = %d, want 202, body=%s", rec.Code, rec.Body.String())
+		}
+	})
+}
+
+// Safe methods are exempt by design; nothing they reach changes state. The
+// codes are pinned rather than merely "not 403", so the test still means
+// something if a route starts answering differently.
+func TestSafeMethodsSurviveCrossOrigin(t *testing.T) {
+	paths := map[string]int{
+		"/healthz":             http.StatusOK,
+		"/api/exam":            http.StatusOK,
+		"/api/session":         http.StatusOK,
+		"/api/control/status":  http.StatusAccepted, // fakeControl's answer
+		"/api/history/summary": http.StatusServiceUnavailable,
+	}
+
+	ts := newTestServer(t)
+	for path, want := range paths {
+		rec := ts.doWithHeaders(t, http.MethodGet, path, map[string]string{
+			"Sec-Fetch-Site": "cross-site",
+			"Origin":         otherOrigin,
+		})
+		if rec.Code != want {
+			t.Errorf("GET %s = %d, want %d — safe methods must stay reachable, body=%s",
+				path, rec.Code, want, rec.Body.String())
+		}
+	}
+}
+
+// The other mutating routes the mux carries, pinned so the gate is not quietly
+// scoped to one handler.
+//
+// Two of these routes answer 403 on their own (docs and mid-attempt scoring
+// are Training-mode only), so a bare "is it 403" assertion would pass with no
+// gate at all. Each route is therefore also driven same-origin, and the two
+// bodies have to differ: the gate answers in plain text, every handler here
+// answers in JSON.
+func TestMutatingRoutesRefusedCrossOrigin(t *testing.T) {
+	routes := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/api/session/start"},
+		{http.MethodPost, "/api/session/grade"},
+		{http.MethodDelete, "/api/session"},
+		{http.MethodPut, "/api/session/focus"},
+		{http.MethodPut, "/api/questions/q01/answer"},
+		{http.MethodPost, "/api/history/import"},
+		{http.MethodDelete, "/api/history"},
+		{http.MethodPost, "/api/control/switch"},
+		{http.MethodPost, "/api/questions/q01/docs/open"},
+	}
+
+	for _, rt := range routes {
+		crossed := newTestServer(t).doWithHeaders(t, rt.method, rt.path, map[string]string{
+			"Sec-Fetch-Site": "cross-site",
+			"Origin":         otherOrigin,
+		})
+		if crossed.Code != http.StatusForbidden {
+			t.Errorf("cross-origin %s %s = %d, want 403, body=%s",
+				rt.method, rt.path, crossed.Code, crossed.Body.String())
+			continue
+		}
+
+		allowed := newTestServer(t).doWithHeaders(t, rt.method, rt.path, map[string]string{
+			"Sec-Fetch-Site": "same-origin",
+			"Origin":         sameOrigin,
+		})
+		if allowed.Body.String() == crossed.Body.String() {
+			t.Errorf("%s %s answers %q either way — the 403 is the handler's, not the gate's",
+				rt.method, rt.path, crossed.Body.String())
+		}
+	}
+}

--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -5,7 +5,7 @@ RUN npm ci
 COPY ui/ ./
 RUN npm run build
 
-FROM golang:1.24-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY hub/go.mod ./
 COPY hub/cmd ./cmd

--- a/hub/go.mod
+++ b/hub/go.mod
@@ -1,3 +1,3 @@
 module kubestronaut-sim/hub
 
-go 1.24
+go 1.26

--- a/images/desktop/Dockerfile
+++ b/images/desktop/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24 AS opener
+FROM golang:1.26-alpine AS opener
 WORKDIR /src
 COPY opener/ ./
 ENV CGO_ENABLED=0 GOFLAGS=-buildvcs=false

--- a/images/desktop/opener/go.mod
+++ b/images/desktop/opener/go.mod
@@ -1,3 +1,3 @@
 module kubestronaut-sim/desktop-opener
 
-go 1.24
+go 1.26

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY go.mod ./
 COPY cmd ./cmd

--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -1,3 +1,3 @@
 module kubestronaut-sim/proxy
 
-go 1.24
+go 1.26

--- a/sim.ps1
+++ b/sim.ps1
@@ -270,7 +270,13 @@ function Invoke-Up([string]$Bank) {
 }
 
 function Invoke-Purge([string]$Mode) {
-  if ($Mode -eq '--all') {
+  # -ceq, not -eq: PowerShell's -eq on strings is case-INSENSITIVE, so
+  # `--ALL`/`--All`/`--aLL` all reached `docker compose down -v` and deleted
+  # every volume including `state` (every attempt ever graded, no backup, no
+  # undo). sim:166 dispatches this through a shell `case` arm `--all)`, which
+  # is byte-exact, so `./sim purge --ALL` falls through to `*)` and refuses.
+  # Only the exact lowercase flag may be destructive, on both launchers.
+  if ($Mode -ceq '--all') {
     Write-Host 'Removing EVERY volume, including attempt history: every attempt graded on'
     Write-Host 'this machine is deleted, there is no backup, and there is no undo.'
     Write-Host '(Export it first from the app if you want to keep it.)'
@@ -322,6 +328,13 @@ function Invoke-Purge([string]$Mode) {
     }
     $labels = ($labelsRaw -join '') | ConvertFrom-Json
     $key = Get-Field $labels 'com.docker.compose.volume'
+    # Deliberately -eq and NOT -ceq, unlike the user-facing `--all` and
+    # $COMMANDS tests: this is a docker label, not something anybody typed,
+    # and the two operators fail in opposite directions here. A hypothetical
+    # 'State' misses a case-sensitive test, leaves $kept false, and the
+    # attempt-history volume is DELETED; it matches the case-insensitive one
+    # and the volume is kept. Same fail-closed rule as the label-read guard
+    # above -- when in doubt, keep the volume.
     if ($key -eq 'state') { $kept = $true; continue }
     # An in-use volume ALWAYS makes "docker volume rm" write to stderr --
     # exactly the case Invoke-DockerSafe exists to survive on 5.1, and
@@ -485,7 +498,12 @@ function Invoke-Doctor {
   }
 }
 
-if ($COMMANDS -notcontains $Command) {
+# -cnotcontains, not -notcontains: -contains/-notcontains compare
+# case-INSENSITIVELY, so `.\sim.ps1 DOCTOR` (or PURGE, or UP) used to run
+# where `./sim DOCTOR` prints usage and exits 1 -- sim dispatches on a shell
+# `case` whose arms are byte-exact. The command names are the nine lowercase
+# strings in $COMMANDS and nothing else, on both launchers.
+if ($COMMANDS -cnotcontains $Command) {
   Write-Host $USAGE
   exit 1
 }
@@ -498,7 +516,15 @@ if ($COMMANDS -notcontains $Command) {
 # out of `ssh` (exit 130) would look like a launcher crash instead of an
 # interrupted session. up and purge keep throwing: they have follow-on logic
 # (the boot-poll loop, volume cleanup) that must not run after a failure.
-switch ($Command) {
+#
+# -casesensitive: a bare `switch` matches its arms case-INSENSITIVELY. The
+# guard above already rejects anything that is not one of the nine exact
+# lowercase names, so nothing reaches here in the wrong case today -- this
+# keeps the two guards independent, so a future edit to either one cannot
+# quietly re-open dispatch on `PURGE`/`DOWN`/`RESET` on its own. Every arm
+# below is a lowercase literal drawn from $COMMANDS, so case-sensitive
+# matching can never fall through to no arm at all.
+switch -casesensitive ($Command) {
   'up'     { Invoke-Up $Argument }
   'down'   { & docker compose down --remove-orphans; exit $LASTEXITCODE }
   'purge'  { Invoke-Purge $Argument }

--- a/site/build.sh
+++ b/site/build.sh
@@ -9,6 +9,11 @@ TOKENS_SRC="$repo/ui/src/styles/tokens.css"
 FAVICON_SRC="$repo/ui/public/favicon.svg"
 FONT_SRC="$repo/ui/node_modules/@fontsource"
 
+mode=build
+if [ "${1:-}" = "--check" ]; then
+  mode=check
+fi
+
 FONT_FILES="ibm-plex-sans/files/ibm-plex-sans-latin-400-normal.woff2
 ibm-plex-sans/files/ibm-plex-sans-latin-600-normal.woff2
 ibm-plex-mono/files/ibm-plex-mono-latin-400-normal.woff2
@@ -37,13 +42,16 @@ generate() {
 
   if [ -d "$FONT_SRC" ]; then
     for f in $FONT_FILES; do
+      [ -f "$FONT_SRC/$f" ] || { echo "build.sh: missing $FONT_SRC/$f" >&2; exit 1; }
       cp "$FONT_SRC/$f" "$out/fonts/$(basename "$f")"
     done
-  else
+  elif [ "$mode" != check ]; then
     echo "build.sh: $FONT_SRC not found - skipping fonts." >&2
     echo "          Run 'npm ci' in ui/ to vendor IBM Plex; until then the" >&2
     echo "          page renders in the token stacks' system fallbacks." >&2
   fi
+  # Under --check a missing $FONT_SRC is a failure, not a skip, and the
+  # --check block below reports it alongside the other findings.
 }
 
 check_figures() {
@@ -85,11 +93,60 @@ else:
         if str(pool) not in block:
             fail.append(f"{name} has {pool} questions, absent from the stat note")
 
+# A bank's draw is published in exactly one place: its exam card's
+# "Drawn / pool" stat, `<dd>17 <span class="exam-stat-of">/ 44</span></dd>`,
+# with the pool repeated in the card's prose as "44-task pool". Searching the
+# whole document with re.S instead paired a `17` inside the Tux logo's path
+# data with a `44` 10,550 characters later while the visible card said 26. So
+# the search is scoped to the card that carries the stat, and the match has to
+# be short enough to be that one stat rather than a span of unrelated markup.
+SPAN_LIMIT = 40  # a real "17 <span class="exam-stat-of">/ 44" match is 34
+
+# Split on the card opener: a card holds nested <li> and <ul>, so it cannot be
+# matched by a non-greedy close. Each slice ends at the first </ul> after it,
+# which is its own domain list, or at the grid's for a card without one.
+cards = [c.split("</ul>")[0] for c in page.split('<li class="exam-card')[1:]]
+stats = []
+for card in cards:
+    for dd in re.findall(r"<dd\b[^>]*>.*?</dd>", card, re.S):
+        if 'class="exam-stat-of"' in dd:
+            stats.append((card, dd))
+
+if not cards:
+    fail.append('no <li class="exam-card"> on the page -- the parse is wrong')
+elif not stats:
+    fail.append('no exam card carries a "exam-stat-of" stat -- the parse is wrong')
+
 for name, pool, drawn in banks:
     if drawn is None:
         continue
-    if not re.search(rf"\b{drawn}\b.*?\b{pool}\b", page, re.S):
-        fail.append(f"{name} draws {drawn} of {pool}, not advertised as such")
+    if not any(
+        len(m.group(0)) <= SPAN_LIMIT
+        for m in (re.search(rf"\b{drawn}\b.*?\b{pool}\b", dd, re.S) for _, dd in stats)
+        if m is not None
+    ):
+        shown = "; ".join(
+            " ".join(re.findall(r"\d+", re.sub(r"<[^>]*>", " ", dd))) or "no figures"
+            for _, dd in stats
+        )
+        fail.append(
+            f"{name} draws {drawn} of {pool}, advertised by no exam card's "
+            f'"Drawn / pool" stat (the page shows: {shown or "nothing"})'
+        )
+
+# The card's prose repeats the pool. It is the same figure, so it goes stale
+# the same way -- and it is the sentence a reader believes.
+for card, dd in stats:
+    of = re.search(r'<span class="exam-stat-of">\s*/\s*(\d+)', dd)
+    if of is None:
+        fail.append("an exam-stat-of span carries no pool figure")
+        continue
+    for said in re.findall(r"(\d+)[-\s](?:task|question)s? pool", card):
+        if said != of.group(1):
+            fail.append(
+                f"an exam card's stat says a pool of {of.group(1)} while its "
+                f"description says {said}"
+            )
 
 for line in fail:
     print(f"build.sh: {line}", file=sys.stderr)
@@ -338,6 +395,13 @@ if [ "${1:-}" = "--check" ]; then
         status=1
       fi
     done
+  else
+    # Skipping here is how the mirror went unchecked: the CI job that runs
+    # --check has no ui/node_modules, so all four woff2 passed untested.
+    echo "build.sh: $FONT_SRC not found - the four site/fonts/*.woff2 cannot be" >&2
+    echo "          compared against their sources, so --check would prove less" >&2
+    echo "          than it claims. Run 'npm ci' in ui/ before checking." >&2
+    status=1
   fi
 
   [ "$status" -eq 0 ] && echo "build.sh: site/ is in sync with its sources."

--- a/site/index.html
+++ b/site/index.html
@@ -346,14 +346,14 @@
               <div><dt>Duration</dt><dd>2h</dd></div>
               <div>
                 <dt>Drawn / pool</dt>
-                <dd>17 <span class="exam-stat-of">/ 26</span></dd>
+                <dd>17 <span class="exam-stat-of">/ 44</span></dd>
               </div>
               <div><dt>To pass</dt><dd>66%</dd></div>
               <div><dt>Engine</dt><dd class="exam-stat-engine">Practical</dd></div>
             </dl>
 
             <p class="exam-desc">
-              17 tasks drawn each attempt from a 26-task pool, across the
+              17 tasks drawn each attempt from a 44-task pool, across the
               full CKAD curriculum: workloads and multi-container design,
               deployments and configuration, security contexts,
               observability, and services, ingress and network policy. The

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "kubestronaut-sim-ui",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@fontsource/ibm-plex-mono": "^5.3.0",
         "@fontsource/ibm-plex-sans": "^5.3.0",
@@ -31,8 +32,8 @@
         "jsdom": "^29.1.1",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.65.0",
-        "vite": "^5.4.0",
-        "vitest": "^2.1.9",
+        "vite": "^6.4.3",
+        "vitest": "^3.2.7",
         "vitest-axe": "^0.1.0"
       }
     },
@@ -540,9 +541,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
       "cpu": [
         "ppc64"
       ],
@@ -553,13 +554,13 @@
         "aix"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
       "cpu": [
         "arm"
       ],
@@ -570,13 +571,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
       "cpu": [
         "arm64"
       ],
@@ -587,13 +588,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
       "cpu": [
         "x64"
       ],
@@ -604,13 +605,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
       "cpu": [
         "arm64"
       ],
@@ -621,13 +622,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
       "cpu": [
         "x64"
       ],
@@ -638,13 +639,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
       "cpu": [
         "arm64"
       ],
@@ -655,13 +656,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
       "cpu": [
         "x64"
       ],
@@ -672,13 +673,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
       "cpu": [
         "arm"
       ],
@@ -689,13 +690,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
       "cpu": [
         "arm64"
       ],
@@ -706,13 +707,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
       "cpu": [
         "ia32"
       ],
@@ -723,13 +724,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
       "cpu": [
         "loong64"
       ],
@@ -740,13 +741,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
       "cpu": [
         "mips64el"
       ],
@@ -757,13 +758,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
       "cpu": [
         "ppc64"
       ],
@@ -774,13 +775,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
       "cpu": [
         "riscv64"
       ],
@@ -791,13 +792,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
       "cpu": [
         "s390x"
       ],
@@ -808,13 +809,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
       "cpu": [
         "x64"
       ],
@@ -825,13 +826,30 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
       "cpu": [
         "x64"
       ],
@@ -842,13 +860,30 @@
         "netbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
       "cpu": [
         "x64"
       ],
@@ -859,13 +894,30 @@
         "openbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
       "cpu": [
         "x64"
       ],
@@ -876,13 +928,13 @@
         "sunos"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
       "cpu": [
         "arm64"
       ],
@@ -893,13 +945,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
       "cpu": [
         "ia32"
       ],
@@ -910,13 +962,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
       "cpu": [
         "x64"
       ],
@@ -927,7 +979,7 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1719,6 +1771,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1727,6 +1790,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -2084,38 +2154,39 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
-      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
-        "chai": "^5.1.2",
-        "tinyrainbow": "^1.2.0"
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
-      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.9",
+        "@vitest/spy": "3.2.7",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.12"
+        "magic-string": "^0.30.17"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -2127,70 +2198,71 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
-      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^1.2.0"
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
-      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "2.1.9",
-        "pathe": "^1.1.2"
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
-      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "magic-string": "^0.30.12",
-        "pathe": "^1.1.2"
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
-      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyspy": "^3.0.2"
+        "tinyspy": "^4.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
-      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "loupe": "^3.1.2",
-        "tinyrainbow": "^1.2.0"
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -2335,9 +2407,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2686,9 +2758,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2696,32 +2768,35 @@
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/escalade": {
@@ -4410,9 +4485,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -4554,9 +4629,9 @@
       }
     },
     "node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -4993,6 +5068,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -5060,9 +5155,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
-      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5070,9 +5165,9 @@
       }
     },
     "node_modules/tinyspy": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
-      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5376,21 +5471,24 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.21",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.21.3",
-        "postcss": "^8.4.43",
-        "rollup": "^4.20.0"
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -5399,17 +5497,23 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
         "less": "*",
         "lightningcss": "^1.21.0",
         "sass": "*",
         "sass-embedded": "*",
         "stylus": "*",
         "sugarss": "*",
-        "terser": "^5.4.0"
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
       },
       "peerDependenciesMeta": {
         "@types/node": {
+          "optional": true
+        },
+        "jiti": {
           "optional": true
         },
         "less": {
@@ -5432,79 +5536,92 @@
         },
         "terser": {
           "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
         }
       }
     },
     "node_modules/vite-node": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
-      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
-        "debug": "^4.3.7",
-        "es-module-lexer": "^1.5.4",
-        "pathe": "^1.1.2",
-        "vite": "^5.0.0"
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "bin": {
         "vite-node": "vite-node.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vitest": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
-      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "2.1.9",
-        "@vitest/mocker": "2.1.9",
-        "@vitest/pretty-format": "^2.1.9",
-        "@vitest/runner": "2.1.9",
-        "@vitest/snapshot": "2.1.9",
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
-        "chai": "^5.1.2",
-        "debug": "^4.3.7",
-        "expect-type": "^1.1.0",
-        "magic-string": "^0.30.12",
-        "pathe": "^1.1.2",
-        "std-env": "^3.8.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.1",
-        "tinypool": "^1.0.1",
-        "tinyrainbow": "^1.2.0",
-        "vite": "^5.0.0",
-        "vite-node": "2.1.9",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.9",
-        "@vitest/ui": "2.1.9",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
         "happy-dom": "*",
         "jsdom": "*"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
           "optional": true
         },
         "@types/node": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -42,8 +42,8 @@
     "jsdom": "^29.1.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.65.0",
-    "vite": "^5.4.0",
-    "vitest": "^2.1.9",
+    "vite": "^6.4.3",
+    "vitest": "^3.2.7",
     "vitest-axe": "^0.1.0"
   }
 }


### PR DESCRIPTION
Clears the nine issues in the **Act on these first** block of #106.

Three themes, as the audit found them: one number went stale and the gate that should have caught it could not fail; two dependency lines reached end of life because nothing was watching them; and the threat model had a hole its own documented mitigation did not cover.

## Changes

**The stale number, and the gate that let it ship.** `site/build.sh`'s figure check was an unanchored regex under `re.S`, so it searched the whole document — for `ckad-mock-01` it matched a `17` inside the Tux logo's SVG path data and a `44` some 10,550 characters later, while the visible exam card said 26. It is now scoped to each card's own `exam-stat-of` block with a bounded span, plus a second assertion that a card's prose figure equals its own stat. The font-mirror check was guarded by `if [ -d "$FONT_SRC" ]` and the `banks` job never installed `ui/node_modules`, so the four `woff2` were never compared; a missing source tree is now a failure, and the job installs what it needs. With the gate honest, the figures it passed over are corrected across the landing page, README, bank spec and `tips.md` — which is served by `GET /api/exam/tips` and read mid-attempt.

**The EOL dependency lines.** Go 1.24 died 2026-02-10 with five security rounds missed; the toolchain moves to 1.26 across CI, five Dockerfiles and five `go.mod`. vite 5 carried three advisories unfixed for the entire 5.x line and vitest 2 carried CVE-2026-47429 at CVSS 9.8; both move together, since vitest runs tests through Vite's transform pipeline. Neither line went stale independently — Dependabot watched npm and github-actions only, so the Go version, written down solely in `FROM` lines and a CI string, was invisible. Docker is now watched across the five Go build-stage directories.

**The threat-model hole.** Nothing in the facilitator, conductor or proxy checked request origin, no handler required a JSON content type, and `POST /api/session/end` reads no body — so any page in any tab could end a live attempt and start grading, or reset the environment through the conductor proxy. `SIM_BIND=127.0.0.1` was never a mitigation: the request originates in the candidate's own browser. The gate wraps the whole mux, so the `/api/control/` proxy is covered and a later route cannot forget it.

**Windows destruction parity.** `.\sim.ps1 purge --ALL` reached `docker compose down -v` and deleted every volume including `state` — every attempt ever graded, no undo — where `./sim purge --ALL` refuses.

**Reference docs.** Factual drift in `api.md`, `hosting.md` and `CONTRIBUTING.md`, and an honest statement of the ingress-nginx retirement.

## Positions taken

Three of the audit's decisions were to *not* change something, and this PR holds them:

- **ingress-nginx is not migrated.** The Ingress API is not deprecated; one controller implementation retired. This is a throwaway kind cluster rebuilt on every reset with no untrusted traffic, and swapping controllers risks `q08` and `q37` for no pedagogical gain. The retirement, the trigger and the migration sketch are documented instead. Verification added to the sketch: those two questions address the controller *by name* (`ingress-nginx-controller.ingress-nginx.svc`), so a swap breaks the checks before it breaks the answers.
- **The `--all` volume-label test deliberately stays case-insensitive.** Making it `-ceq` alongside the user-facing fixes would invert a fail-closed guard — a case-sensitive miss there leaves `$kept` false and *deletes* the attempt-history volume.
- **The vitest `ignore` rule is dropped, not annotated.** #86 asked for a comment naming what retires the rule. `ignore` suppresses Dependabot *security* PRs as well as version bumps, so it did not merely delay vitest 3 — it withheld the 9.8 fix, and blocked vite 5→6 as a side effect since vitest 2 requires vite ^5. One rule stalled both lines, and a comment cannot make a standing suppression safe. The pairing constraint moves to a `vite-toolchain` group that proposes the pair rather than hiding half of it; the removal site records the condition for ever adding one back.

## Verification

- All five Go modules: `go test ./...` and `go vet ./...` on `golang:1.26-alpine`.
- All eight images build. `hub` still refuses to start misconfigured; `NODE_IMAGE` still resolves with no environment; `docker compose config` valid.
- UI: 49 files / 807 tests, `tsc --noEmit` and `lint` clean at zero warnings, `npm audit` 0 vulnerabilities (from 7). Lockfile regenerated in `node:22-alpine`.
- The origin gate is pinned in both directions — same-origin, `Sec-Fetch-Site: none`, and bare `curl` allowed; `cross-site`, `same-site`, and suppressed-`Origin` refused — across 9 mutating routes and the control proxy. Two routes already answered 403 on their own, so those assertions passed with no gate at all; they now require the gate's body to differ from the handler's, and the deny suite was confirmed failing against an ungated build.
- The landing-page gate was proved failing on a wrong figure, on a divergent `woff2`, and on absent sources — not merely passing on the corrected page.
- `sim.ps1` verified under PowerShell 7 for `purge --ALL`/`--All`/`--aLL`, `DOCTOR`, `help` and `nonsense`; the `--all` destroy path proved reachable by AST extraction against a neutralised `docker` rather than by running it. All nine volumes intact.
- All seven bank gates, shell syntax, CRLF and `/shared` atomicity gates pass.

Closes #81
Closes #82
Closes #83
Closes #84
Closes #85
Closes #86
Closes #87
Closes #88
Closes #89
