### PR TITLE
fix(cka): raise k8s-env cpu limit for cka-mock-01

### DIFF
--- a/deploy/helm/kubestronaut-sim/values.yaml
+++ b/deploy/helm/kubestronaut-sim/values.yaml
@@ -177,16 +177,26 @@ sessions:
     #
     # cka-mock-01 builds a five-node main cluster and up to four
     # single-node aux clusters inside one k8s-env, so its ceiling is
-    # double the manifest's 6Gi. Only the limit is raised: the
-    # scheduler-visible request stays at the manifest's measured 2Gi,
-    # the same deliberate overcommitment the base sizing makes (see
-    # docs/hosting.md#sizing). To reserve the peak instead, add
-    # `requests: {memory: 6Gi}` in your own values.
+    # double the manifest's 6Gi and 2000m. Only the limits are raised:
+    # the scheduler-visible requests stay at the manifest's measured
+    # 2Gi/300m, the same deliberate overcommitment the base sizing makes
+    # (see docs/hosting.md#sizing). To reserve the peak instead, add
+    # `requests: {memory: 6Gi, cpu: "1"}` in your own values.
+    #
+    # The cpu limit was memory-only until it was caught starving a real
+    # session: kubeadm join has its own internal 4-minute kubelet-health
+    # deadline, and the manifest's 2 cores — sized for a two-node cluster
+    # — throttled the second worker's join of a five-node one past it.
+    # Measured on the cgroup mid-failure: 16 of 2493 periods throttled,
+    # all inside that one join's ~4-minute busy window. Worse on a VM
+    # session node (fewer real cycles per vCPU than bare metal) than on
+    # one with headroom to spare, but the manifest's limit was the
+    # ceiling everywhere; raising it is not a workaround for one node.
     banks:
       cka-mock-01:
         resources:
           k8s-env:
-            limits: {memory: 12Gi}
+            limits: {memory: 12Gi, cpu: "4"}
 
   mcq:
     # An MCQ session is a facilitator and 128Mi. It needs no cluster, no

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -167,13 +167,16 @@ Per practical session, across its eight containers:
   `sessions.practical.banks.<id>.resources`. Seats are unaffected: one
   pool, one queue, a differently sized Pod in it.
 - The chart ships one such entry: `cka-mock-01` raises the k8s-env
-  memory limit to **12Gi**, because that exam builds a five-node main
-  cluster and its questions can add up to four single-node `aux-*`
-  clusters inside the same container. Only the limit is raised — the
-  request stays at the manifest's 2Gi, the same overcommitment bet the
-  base sizing makes. If your CKA seats share nodes with anything you
-  care about, reserve the peak instead:
-  `sessions.practical.banks.cka-mock-01.resources.k8s-env.requests.memory: 6Gi`.
+  memory limit to **12Gi** and the cpu limit to **4**, because that exam
+  builds a five-node main cluster and its questions can add up to four
+  single-node `aux-*` clusters inside the same container. The cpu limit
+  matters as much as the memory one here: `kubeadm join` has its own
+  4-minute kubelet-health deadline, and the manifest's 2 cores — sized
+  for a two-node cluster — can throttle a five-node join past it. Only
+  the limits are raised — requests stay at the manifest's 2Gi/300m, the
+  same overcommitment bet the base sizing makes. If your CKA seats share
+  nodes with anything you care about, reserve the peak instead:
+  `sessions.practical.banks.cka-mock-01.resources.k8s-env.requests: {memory: 6Gi, cpu: "1"}`.
 
 **Overcommitment is deliberate.** Three sessions request 11.8Gi and
 could demand 35Gi — 53.4Gi if all three sit `cka-mock-01`. If several


### PR DESCRIPTION
## Summary
- `cka-mock-01` boots a five-node main cluster plus up to four single-node aux clusters inside one `k8s-env` container, but only the memory limit was ever scaled up for that topology — CPU stayed at the base 2-core value sized for a two-node cluster.
- Caught live on `cjoga-prox-host`: a session's `kubeadm join` failed because the worker's kubelet didn't pass health inside kubeadm's own 4-minute deadline. The container's cgroup `cpu.stat` showed real CFS throttling concentrated in that exact window.

## Changes
- `deploy/helm/kubestronaut-sim/values.yaml`: add `cpu: "4"` to the `cka-mock-01` → `k8s-env` limits override, alongside the existing `memory: 12Gi`.
- `docs/hosting.md`: update the Sizing section to document the cpu limit and why it matters here.

## Test plan
- [x] `helm lint deploy/helm/kubestronaut-sim`
- [x] `helm template` with dummy required values — confirmed `cka-mock-01`'s rendered `k8s-env` container carries `"limits":{"cpu":"4","memory":"12Gi"}`
- [x] Bump `kp-k8s-dev` and `helm upgrade` after merge, then confirm a live `cka-mock-01` session boots clean on `lab.vmworker1.cjoga.cloud-51cc33eb`