### PR TITLE
fix(hub): don't refuse an in-progress MCQ attempt on mobile

### DIFF
--- a/hub/internal/api/device_test.go
+++ b/hub/internal/api/device_test.go
@@ -92,6 +92,26 @@ func TestAFinePointerIsAdmitted(t *testing.T) {
 	}
 }
 
+// The facilitator's own "begin an attempt" call, made from inside an
+// already-admitted MCQ session to choose training/speed/exam, carries no
+// bank — the exam is already fixed. It must not fall through to
+// DefaultKind (practical) and refuse a touch-only device that was never
+// running a desktop to begin with.
+func TestAPhoneMayBeginAnAttemptInAnExistingMcqSession(t *testing.T) {
+	s, c := hostedWithExams(t, okHandler())
+	if w := ready(t, s, c, `{"bank":"kcna-mock"}`); w.Code != http.StatusOK {
+		t.Fatalf("start: %d %s", w.Code, body(t, w))
+	}
+
+	r := coarse(httptest.NewRequest(http.MethodPost, "/api/session/start", strings.NewReader(`{"mode":"exam"}`)))
+	r.AddCookie(c)
+	w := do(s, r)
+
+	if w.Code == http.StatusConflict && codeOf(t, w) == codeDesktopRequired {
+		t.Fatalf("beginning an attempt in an existing mcq session was refused as needing a desktop: %s", w.Body)
+	}
+}
+
 func TestASwitchToAHandsOnExamIsRefusedOnAPhone(t *testing.T) {
 	s, c := hostedWithExams(t, okHandler())
 	if w := ready(t, s, c, `{"bank":"ckad-mock-01"}`); w.Code != http.StatusOK {

--- a/hub/internal/api/session.go
+++ b/hub/internal/api/session.go
@@ -62,7 +62,18 @@ func (s *Server) handleSessionStart(w http.ResponseWriter, r *http.Request) {
 		kind = session.KindOf(entry.ExamType)
 	}
 
-	if refuseTouchOnlyPractical(w, r, kind) {
+	// A user who already has a live session is resuming it, not starting a
+	// new one — Start() below returns that session untouched regardless of
+	// kind or bank. Gate on what it actually is: the in-session "begin an
+	// attempt" call (choosing training/speed/exam) carries no bank, since
+	// the exam is already fixed, and would otherwise fall through to
+	// DefaultKind (practical) here and refuse a touch-only device sitting
+	// an MCQ exam that never needed a desktop.
+	if existing, err := s.Sessions.Get(user.UserID); err == nil {
+		if refuseTouchOnlyPractical(w, r, existing.Kind) {
+			return
+		}
+	} else if refuseTouchOnlyPractical(w, r, kind) {
 		return
 	}
 


### PR DESCRIPTION
## Summary
- On mobile, KCNA (MCQ) reached the mode screen fine but tapping any "Start" (training/speed/exam) was refused with the desktop-required message — the same message hands-on exams correctly show.
- Root cause: `handleSessionStart` derives `kind` from the request body (`bank`, falling back to `DefaultKind`) *before* checking whether the caller already has a live session. The in-session "begin an attempt" call carries no `bank` — the exam is already fixed — so it fell through to `DefaultKind` (`practical`) and got refused on a touch-only device, regardless of the user's actual (MCQ) session.
- Reproduced live against the real deployment (`cjoga-prox-host`) with the exact `X-Sim-Pointer: coarse` header and body the client sends; got the exact refusal text reported.

## Changes
- `hub/internal/api/session.go`: when the user already has a live session, gate the touch-only check on *that session's* kind instead of the request-derived one. `Sessions.Start` already returns an existing session untouched regardless of `kind`/`bank`, so this only changes what the gate checks, not what session gets created/resumed.
- `hub/internal/api/device_test.go`: added `TestAPhoneMayBeginAnAttemptInAnExistingMcqSession`, which fails against the old code with the exact reported error and passes with the fix.

## Test plan
- [x] `go build ./... && go vet ./...` (hub module)
- [x] `go test ./...` (hub module) — all packages pass
- [x] New test confirmed to fail pre-fix (verified via temporary revert) and pass post-fix