### PR TITLE
fix(k8s-env): raise inotify limits before creating nested kind nodes

### DIFF
--- a/images/k8s-env/start.sh
+++ b/images/k8s-env/start.sh
@@ -6,6 +6,23 @@ NODE_IMAGE="${NODE_IMAGE:-$(cat /opt/sim/node-image)}"
 . /opt/sim/phase.sh
 rm -f /shared/ready
 
+# A kind node's kubelet calls inotify_init for cAdvisor and its cert
+# watcher; a nested node container gets its own copy of these limits at
+# the moment `docker run` creates it, frozen from then on — raising them
+# on an ALREADY-RUNNING node does nothing. This must happen before `kind
+# create cluster` creates any node, not after. Measured live: cka-mock-01
+# building five nodes at once (up to nine with aux clusters) exhausted
+# the kernel default of 128 instances, and every one of the five crashed
+# forever on "Failed to start cAdvisor: inotify_init: too many open
+# files" — never once became healthy, so kubeadm's kubelet-check always
+# hit its own 4-minute deadline. Recreating a node after raising these
+# fixed it on the spot. 8192/524288 is what was verified live to let a
+# fresh node's kubelet start clean; kind's own docs recommend 512/524288
+# for multi-node setups, but this bank can stack aux clusters on top of
+# the main five, so the instance ceiling is padded well past that.
+echo 8192 > /proc/sys/fs/inotify/max_user_instances
+echo 524288 > /proc/sys/fs/inotify/max_user_watches
+
 phase dockerd "Starting the container runtime" 1
 dockerd-entrypoint.sh &
 dockerd_pid=$!


### PR DESCRIPTION
## Summary
- CKA (`cka-mock-01`) sessions were still failing to boot after the v0.9.2 CPU-limit bump. Live debugging on `cjoga-prox-host` found the real cause: every nested kind node's kubelet crash-loops forever on `Failed to start cAdvisor: inotify_init: too many open files`, hitting kubeadm's kubelet-check deadline every time — reproduced twice, on two different nodes (one VM, one bare metal), with **zero CPU throttling** on the second run, ruling out CPU as the cause.
- `cka-mock-01` builds five nested kind nodes at once (more when aux clusters stack on top), and the kernel default of 128 inotify instances per UID is shared across all of them — easily exhausted, since cAdvisor alone needs one per node.
- A nested node container's inotify limits are frozen at the moment `docker run` creates it. Verified live: raising the host value after a node was already crash-looping did nothing for that node, but recreating the node afterward let its kubelet start clean immediately. So the fix has to run before `kind create cluster`, not inside a retry or after a failure.

## Changes
- `images/k8s-env/start.sh`: raise `fs.inotify.max_user_instances` (8192, the value verified live) and `fs.inotify.max_user_watches` (524288, kind's own documented recommendation) at the very top of the script, before `dockerd` or any `kind create cluster` call.

## Test plan
- [x] `bash -n images/k8s-env/start.sh` and `tests/check-shell.sh` — clean
- [x] Live-verified the underlying mechanism against the real deployment: raised the limits on a running `k8s-env` container mid-crash-loop (no effect on the already-created node), then recreated the node — its kubelet started cleanly with no inotify errors
- [ ] Full end-to-end verification after this ships: a fresh `cka-mock-01` boot on `cjoga-prox-host` reaching ready with no manual intervention