### PR TITLE
Install editors on cluster nodes and widen the question panel

### DIFF
--- a/images/k8s-env/Dockerfile
+++ b/images/k8s-env/Dockerfile
@@ -107,7 +107,9 @@ RUN ARCH=$(uname -m); case "$ARCH" in x86_64) ARCH=amd64 ;; aarch64) ARCH=arm64 
 
 # The node image the clusters actually run: the pinned kind image plus root
 # sshd (the candidate has root ssh to every node — see the CKA plan's freedom
-# model) and the assets the aux questions need staged on the node. The stage
+# model) and the assets the aux questions need staged on the node. vim and nano
+# ride along in both node stages: kindest/node ships no editor, the real exam's
+# nodes do, and the aux questions are on-node edits of static pod manifests. The stage
 # ends by tarring its own rootfs; the preload stage ships that tar and start.sh
 # / banks/_lib/aux-cluster.sh `docker import` it under the pristine tag inside the
 # inner dockerd, reapplying the image config recorded in the .changes file.
@@ -122,7 +124,7 @@ FROM ${NODE_IMAGE} AS node-ssh
 COPY --from=fetch /pkg/etcdctl /pkg/etcdutl /usr/local/bin/
 COPY --from=sim /opt/sim/calico.yaml /opt/packages/calico.yaml
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends openssh-server \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends openssh-server vim nano \
     && rm -rf /var/lib/apt/lists/* \
     && (systemctl disable ssh.socket 2>/dev/null || true) \
     && systemctl enable ssh \
@@ -143,7 +145,7 @@ COPY --from=fetch /pkg/etcdctl /pkg/etcdutl /usr/local/bin/
 COPY --from=fetch /pkg/kubeadm /pkg/kubelet /pkg/kubectl /opt/packages/
 COPY --from=sim /opt/sim/calico.yaml /opt/packages/calico.yaml
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends openssh-server \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends openssh-server vim nano \
     && rm -rf /var/lib/apt/lists/* \
     && (systemctl disable ssh.socket 2>/dev/null || true) \
     && systemctl enable ssh \

--- a/ui/src/components/PanelResizer.test.tsx
+++ b/ui/src/components/PanelResizer.test.tsx
@@ -64,7 +64,7 @@ describe("PanelResizer accessibility contract", () => {
     expect(sep).toHaveAttribute("aria-controls", "question-panel");
     expect(sep).toHaveAttribute("aria-valuenow", "420");
     expect(sep).toHaveAttribute("aria-valuemin", "280");
-    expect(sep).toHaveAttribute("aria-valuemax", "600");
+    expect(sep).toHaveAttribute("aria-valuemax", "900");
     expect(sep).toHaveAccessibleName(/resize/i);
     expect(sep).toHaveAttribute("tabindex", "0");
   });
@@ -92,9 +92,9 @@ describe("PanelResizer keyboard", () => {
     sep.focus();
 
     await userEvent.keyboard("{End}");
-    expect(sep).toHaveAttribute("aria-valuenow", "600");
+    expect(sep).toHaveAttribute("aria-valuenow", "900");
     await userEvent.keyboard("{ArrowRight}");
-    expect(sep).toHaveAttribute("aria-valuenow", "600");
+    expect(sep).toHaveAttribute("aria-valuenow", "900");
 
     await userEvent.keyboard("{Home}");
     expect(sep).toHaveAttribute("aria-valuenow", "280");

--- a/ui/src/components/PanelResizer.tsx
+++ b/ui/src/components/PanelResizer.tsx
@@ -7,7 +7,7 @@ const STORAGE_KEY = "sim.panelWidth";
 
 const DEFAULT_WIDTH = 420;
 const MIN_WIDTH = 280;
-const MAX_WIDTH = 600;
+const MAX_WIDTH = 900;
 const STEP = 16;
 const COARSE_STEP = 64;
 

--- a/ui/src/theme.css
+++ b/ui/src/theme.css
@@ -1264,7 +1264,7 @@ button.nav-menu-item:hover {
   background: var(--surface);
   border-right: 1px solid var(--border);
 
-  width: clamp(280px, var(--panel-width, var(--task-pane-width)), min(600px, 50vw));
+  width: clamp(280px, var(--panel-width, var(--task-pane-width)), min(900px, 60vw));
   flex-shrink: 0;
   position: relative;
 


### PR DESCRIPTION
## What this changes

Candidates ssh-ing into cluster nodes — above all the CKA aux nodes, whose questions are on-node edits of static pod manifests — had no editor, because `kindest/node` ships none and the node stages only added `openssh-server`. Both node stages now install `vim` and `nano`, keeping main and aux nodes identical, matching the real exam nodes. Separately, the practical question panel width cap rises 1.5x from `min(600px, 50vw)` to `min(900px, 60vw)` (CSS clamp, JS clamp, ARIA bounds and tests moved together); default and minimum widths are unchanged.

## Verification

CI runs the offline gates, the Go tests, the UI suite, the image builds
and a shell syntax pass. It cannot run `tests/smoke.sh` — see [what CI
cannot run](https://github.com/Camilool8/kubestronaut-sim/blob/main/CONTRIBUTING.md#what-ci-cannot-run).

- [ ] I ran `tests/smoke.sh` locally
- [x] Not needed — this change cannot affect grading or the environment

Not run yet: the k8s-env change rebakes the node rootfs tars, so it does affect the environment — the full UI suite (840 tests) and `tests/check-k8s-pins.sh` pass locally, but a local `tests/smoke.sh` run should confirm the node image rebuild before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
